### PR TITLE
make intermediate spans possible

### DIFF
--- a/span.go
+++ b/span.go
@@ -234,7 +234,7 @@ func (r *spanS) getSpanKind() string {
 	case string(ext.SpanKindRPCClientEnum), "producer", "exit":
 		return "exit"
 	}
-	return ""
+	return "intermediate"
 }
 
 func (r *spanS) collectLogs() map[uint64]map[string]interface{} {


### PR DESCRIPTION
If a span is not entry nor exit it must be intermediate not ""

At the backend if the type is "" it default to entry, this messes up the flow map with span that should be intermediate.