### PR TITLE
adapters: remove never taken branch

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -86,11 +86,7 @@ func (s *Sensor) TracingHttpRequest(name string, parent, req *http.Request, clie
 	span.SetTag(string(ext.HTTPStatusCode), res.StatusCode)
 
 	if err != nil {
-		if e, ok := err.(error); ok {
-			span.LogFields(otlog.Error(e))
-		} else {
-			span.LogFields(otlog.Object("error", err))
-		}
+		span.LogFields(otlog.Error(err))
 	}
 	return
 }


### PR DESCRIPTION
client.Do always returns an error so the type assertion check is unnecessary. See https://play.golang.org/p/GLYZZZXTxux