### PR TITLE
Allow to configure service name via an env variable

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -61,16 +61,19 @@ func (r *sensorS) configureServiceName() {
 // InitSensor intializes the sensor (without tracing) to begin collecting
 // and reporting metrics.
 func InitSensor(options *Options) {
-	if sensor == nil {
-		sensor = new(sensorS)
-		// If this environment variable is set, then override log level
-		_, ok := os.LookupEnv("INSTANA_DEBUG")
-		if ok {
-			options.LogLevel = Debug
-		}
-
-		sensor.initLog()
-		sensor.init(options)
-		log.debug("initialized sensor")
+	if sensor != nil {
+		return
 	}
+
+	sensor = &sensorS{}
+
+	// If this environment variable is set, then override log level
+	_, ok := os.LookupEnv("INSTANA_DEBUG")
+	if ok {
+		options.LogLevel = Debug
+	}
+
+	sensor.initLog()
+	sensor.init(options)
+	log.debug("initialized sensor")
 }

--- a/sensor.go
+++ b/sensor.go
@@ -45,12 +45,13 @@ func (r *sensorS) setOptions(options *Options) {
 }
 
 func (r *sensorS) configureServiceName() {
-	if r.options != nil {
-		r.serviceName = r.options.Service
+	if name, ok := os.LookupEnv("INSTANA_SERVICE_NAME"); ok {
+		r.serviceName = name
+		return
 	}
 
-	if r.serviceName == "" {
-		r.serviceName = os.Getenv("INSTANA_SERVICE_NAME")
+	if r.options != nil {
+		r.serviceName = r.options.Service
 	}
 
 	if r.serviceName == "" {

--- a/sensor.go
+++ b/sensor.go
@@ -44,10 +44,6 @@ func (r *sensorS) setOptions(options *Options) {
 	}
 }
 
-func (r *sensorS) getOptions() *Options {
-	return r.options
-}
-
 func (r *sensorS) configureServiceName() {
 	if r.options != nil {
 		r.serviceName = r.options.Service

--- a/sensor.go
+++ b/sensor.go
@@ -20,7 +20,7 @@ type sensorS struct {
 var sensor *sensorS
 
 func (r *sensorS) init(options *Options) {
-	//sensor can be initialized explicit or implicit through OpenTracing global init
+	// sensor can be initialized explicitly or implicitly through OpenTracing global init
 	if r.meter == nil {
 		r.setOptions(options)
 		r.configureServiceName()
@@ -58,7 +58,7 @@ func (r *sensorS) configureServiceName() {
 	}
 }
 
-// InitSensor Intializes the sensor (without tracing) to begin collecting
+// InitSensor intializes the sensor (without tracing) to begin collecting
 // and reporting metrics.
 func InitSensor(options *Options) {
 	if sensor == nil {

--- a/sensor.go
+++ b/sensor.go
@@ -50,6 +50,10 @@ func (r *sensorS) configureServiceName() {
 	}
 
 	if r.serviceName == "" {
+		r.serviceName = os.Getenv("INSTANA_SERVICE_NAME")
+	}
+
+	if r.serviceName == "" {
 		r.serviceName = filepath.Base(os.Args[0])
 	}
 }


### PR DESCRIPTION
Current implementation of `instana.InitSensor()` immediately falls back to the name of the binary if there was service name provided explicitly via `instana.Options`. These changes allow to configure the service name via the `INSTANA_SERVICE_NAME` env variable, so the name lookup works as follows:

1. `INSTANA_SERVICE_NAME` env var
2. `(instana.Options).Service` value
3. Name of the binary

Closes #71 