### PR TITLE
Address some linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  skip-dirs:
+    - autoprofile/internal/pprof # vendored code
+    - example # clean up first
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    # enable once the error handling in fsm.go is improved
+    #- errcheck

--- a/autoprofile/internal/allocation_sampler.go
+++ b/autoprofile/internal/allocation_sampler.go
@@ -45,7 +45,7 @@ func (as *AllocationSampler) Profile(duration int64, timespan int64) (*Profile, 
 		roots = append(roots, child)
 	}
 
-	return NewProfile(categoryMemory, typeMemoryAllocation, unitByte, roots, duration, timespan), nil
+	return NewProfile(CategoryMemory, TypeMemoryAllocation, UnitByte, roots, duration, timespan), nil
 }
 
 func (as *AllocationSampler) createAllocationCallGraph(p *profile.Profile) (*CallSite, error) {

--- a/autoprofile/internal/block_sampler.go
+++ b/autoprofile/internal/block_sampler.go
@@ -66,7 +66,7 @@ func (bs *BlockSampler) Profile(duration, timespan int64) (*Profile, error) {
 	for _, child := range bs.top.children {
 		roots = append(roots, child)
 	}
-	p := NewProfile(categoryTime, typeBlockingCalls, unitMillisecond, roots, duration, timespan)
+	p := NewProfile(CategoryTime, TypeBlockingCalls, UnitMillisecond, roots, duration, timespan)
 	return p, nil
 }
 

--- a/autoprofile/internal/cpu_sampler.go
+++ b/autoprofile/internal/cpu_sampler.go
@@ -62,7 +62,7 @@ func (cs *CPUSampler) Profile(duration int64, timespan int64) (*Profile, error) 
 	for _, child := range cs.top.children {
 		roots = append(roots, child)
 	}
-	p := NewProfile(categoryCPU, typeCPUUsage, unitMillisecond, roots, duration, timespan)
+	p := NewProfile(CategoryCPU, TypeCPUUsage, UnitMillisecond, roots, duration, timespan)
 	return p, nil
 }
 

--- a/autoprofile/internal/cpu_sampler_test.go
+++ b/autoprofile/internal/cpu_sampler_test.go
@@ -34,7 +34,7 @@ func simulateCPULoad(d time.Duration) {
 		select {
 		case <-done:
 			return
-		default:
+		default: //nolint:staticcheck
 		}
 	}
 }

--- a/autoprofile/internal/profile.go
+++ b/autoprofile/internal/profile.go
@@ -9,23 +9,23 @@ import (
 )
 
 const (
-	runtimeGolang string = "golang"
+	RuntimeGolang = "golang"
 
-	categoryCPU    string = "cpu"
-	categoryMemory string = "memory"
-	categoryTime   string = "time"
+	CategoryCPU    = "cpu"
+	CategoryMemory = "memory"
+	CategoryTime   = "time"
 
-	typeCPUUsage         string = "cpu-usage"
-	typeMemoryAllocation string = "memory-allocations"
-	typeBlockingCalls    string = "blocking-calls"
+	TypeCPUUsage         = "cpu-usage"
+	TypeMemoryAllocation = "memory-allocations"
+	TypeBlockingCalls    = "blocking-calls"
 
-	unitSample      string = "sample"
-	unitMillisecond string = "millisecond"
-	unitMicrosecond string = "microsecond"
-	unitNanosecond  string = "nanosecond"
-	unitByte        string = "byte"
-	unitKilobyte    string = "kilobyte"
-	unitPercent     string = "percent"
+	UnitSample      = "sample"
+	UnitMillisecond = "millisecond"
+	UnitMicrosecond = "microsecond"
+	UnitNanosecond  = "nanosecond"
+	UnitByte        = "byte"
+	UnitKilobyte    = "kilobyte"
+	UnitPercent     = "percent"
 )
 
 type CallSite struct {
@@ -56,7 +56,7 @@ func NewProfile(category string, typ string, unit string, roots []*CallSite, dur
 	p := &Profile{
 		ProcessID: strconv.Itoa(os.Getpid()),
 		ID:        GenerateUUID(),
-		Runtime:   runtimeGolang,
+		Runtime:   RuntimeGolang,
 		Category:  category,
 		Type:      typ,
 		Unit:      unit,

--- a/autoprofile/internal/sampler_scheduler.go
+++ b/autoprofile/internal/sampler_scheduler.go
@@ -41,7 +41,6 @@ type SamplerScheduler struct {
 	profileRecorder  *Recorder
 	sampler          Sampler
 	config           SamplerConfig
-	active           Flag
 	started          Flag
 	samplerTimer     *Timer
 	reportTimer      *Timer

--- a/eum.go
+++ b/eum.go
@@ -3,6 +3,7 @@ package instana
 import (
 	"bytes"
 	"io/ioutil"
+	"sort"
 	"strings"
 )
 
@@ -16,19 +17,22 @@ func EumSnippet(apiKey string, traceID string, meta map[string]string) string {
 	}
 
 	b, err := ioutil.ReadFile(eumTemplate)
-
 	if err != nil {
 		return ""
 	}
 
-	var snippet = string(b)
-	var metaBuffer bytes.Buffer
-
-	snippet = strings.Replace(snippet, "$apiKey", apiKey, -1)
+	snippet := strings.Replace(string(b), "$apiKey", apiKey, -1)
 	snippet = strings.Replace(snippet, "$traceId", traceID, -1)
 
-	for key, value := range meta {
-		metaBuffer.WriteString("  ineum('meta', '" + key + "', '" + value + "');\n")
+	var keys []string
+	for k := range meta {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var metaBuffer bytes.Buffer
+	for _, k := range keys {
+		metaBuffer.WriteString("ineum('meta','" + k + "','" + meta[k] + "');")
 	}
 
 	snippet = strings.Replace(snippet, "$meta", metaBuffer.String(), -1)

--- a/eum.go
+++ b/eum.go
@@ -10,6 +10,10 @@ import (
 const eumTemplate string = "eum.js"
 
 // EumSnippet generates javascript code to initialize JavaScript agent
+//
+// Deprecated: this snippet is outdated and this method will be removed in
+// the next major version. To learn about the way to install Instana EUM snippet
+// please refer to https://docs.instana.io/products/website_monitoring/#installation
 func EumSnippet(apiKey string, traceID string, meta map[string]string) string {
 
 	if len(apiKey) == 0 || len(traceID) == 0 {

--- a/eum.js
+++ b/eum.js
@@ -1,11 +1,3 @@
 <script>
-(function(c,e,f,k,g,h,b,a,d){c[g]||(c[g]=h,b=c[h]=function(){
-  b.q.push(arguments)},b.q=[],b.l=1*new Date,a=e.createElement(f),a.async=1,
-    a.src=k,a.setAttribute("crossorigin", "anonymous"),d=e.getElementsByTagName(f)[0],
-    d.parentNode.insertBefore(a,d))})(window,document,"script",
-    "//eum.instana.io/eum.min.js","InstanaEumObject","ineum");
-  ineum('reportingUrl', 'https://eum-saas.instana.io');
-  ineum('key', '$apiKey');
-  ineum('traceId', '$traceId');
-  $meta
+(function(c,e,f,k,g,h,b,a,d){c[g]||(c[g]=h,b=c[h]=function(){b.q.push(arguments)},b.q=[],b.l=1*new Date,a=e.createElement(f),a.async=1,a.src=k,a.setAttribute("crossorigin","anonymous"),d=e.getElementsByTagName(f)[0],d.parentNode.insertBefore(a,d))})(window,document,"script","//eum.instana.io/eum.min.js","InstanaEumObject","ineum");ineum('reportingUrl','https://eum-saas.instana.io');ineum('key','$apiKey');ineum('traceId','$traceId');$meta
 </script>

--- a/eum_test.go
+++ b/eum_test.go
@@ -8,28 +8,13 @@ import (
 )
 
 const eumExpectedResult string = `<script>
-  (function(i,s,o,g,r,a,m){i['InstanaEumObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//eum.instana.io/eum.min.js','ineum');
-
-  ineum('apiKey', 'myApiKey');
-  ineum('traceId', 'myTraceId');
-  ineum('meta', 'key1', 'value1');
-  ineum('meta', 'key2', 'value2');
-
-</script>`
+(function(c,e,f,k,g,h,b,a,d){c[g]||(c[g]=h,b=c[h]=function(){b.q.push(arguments)},b.q=[],b.l=1*new Date,a=e.createElement(f),a.async=1,a.src=k,a.setAttribute("crossorigin","anonymous"),d=e.getElementsByTagName(f)[0],d.parentNode.insertBefore(a,d))})(window,document,"script","//eum.instana.io/eum.min.js","InstanaEumObject","ineum");ineum('reportingUrl','https://eum-saas.instana.io');ineum('key','myApiKey');ineum('traceId','myTraceId');ineum('meta','key1','value1');ineum('meta','key2','value2');
+</script>
+`
 
 func TestEum(t *testing.T) {
-
-	m := make(map[string]string, 2)
-	m["key1"] = "value1"
-	m["key2"] = "value2"
-
-	var result = instana.EumSnippet("myApiKey", "myTraceId", m)
-
-	assert.Contains(t, result, "ineum('key', 'myApiKey');")
-	assert.Contains(t, result, "ineum('traceId', 'myTraceId');")
-	assert.Contains(t, result, "ineum('meta', 'key1', 'value1');")
-	assert.Contains(t, result, "ineum('meta', 'key2', 'value2');")
+	assert.Equal(t, eumExpectedResult, instana.EumSnippet("myApiKey", "myTraceId", map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}))
 }

--- a/example/autoprofile/demo.go
+++ b/example/autoprofile/demo.go
@@ -18,8 +18,7 @@ func useCPU(duration int, usage int) {
 	for j := 0; j < duration; j++ {
 		go func() {
 			for i := 0; i < usage*80000; i++ {
-				str := "str" + strconv.Itoa(i)
-				str = str + "a"
+				_ = strconv.Itoa(i)
 			}
 		}()
 
@@ -31,12 +30,9 @@ func simulateCPUUsage() {
 	// sumulate CPU usage anomaly - every 45 minutes
 	cpuAnomalyTicker := time.NewTicker(45 * time.Minute)
 	go func() {
-		for {
-			select {
-			case <-cpuAnomalyTicker.C:
-				// for 60 seconds produce generate 50% CPU usage
-				useCPU(60, 50)
-			}
+		for range cpuAnomalyTicker.C {
+			// for 60 seconds produce generate 50% CPU usage
+			useCPU(60, 50)
 		}
 	}()
 
@@ -62,11 +58,8 @@ func simulateMemoryLeak() {
 	// simulate memory leak - constantly
 	constantTicker := time.NewTicker(2 * 3600 * time.Second)
 	go func() {
-		for {
-			select {
-			case <-constantTicker.C:
-				leakMemory(2*3600, 1000)
-			}
+		for range constantTicker.C {
+			leakMemory(2*3600, 1000)
 		}
 	}()
 
@@ -119,13 +112,10 @@ func simulateNetworkWait() {
 	}()
 
 	requestTicker := time.NewTicker(500 * time.Millisecond)
-	for {
-		select {
-		case <-requestTicker.C:
-			res, err := http.Get("http://localhost:5002/test")
-			if err == nil {
-				res.Body.Close()
-			}
+	for range requestTicker.C {
+		res, err := http.Get("http://localhost:5002/test")
+		if err == nil {
+			res.Body.Close()
 		}
 	}
 }
@@ -158,7 +148,7 @@ func simulateLockWait() {
 
 		go func() {
 			lock.RLock()
-			lock.RUnlock()
+			defer lock.RUnlock()
 
 			done <- true
 		}()

--- a/example/many.go
+++ b/example/many.go
@@ -15,7 +15,7 @@ const (
 )
 
 func simple(ctx context.Context) {
-	parentSpan, ctx := ot.StartSpanFromContext(ctx, "parent")
+	parentSpan, _ := ot.StartSpanFromContext(ctx, "parent")
 	parentSpan.SetTag(string(ext.Component), Service)
 	parentSpan.SetTag(string(ext.SpanKind), string(ext.SpanKindRPCServerEnum))
 	parentSpan.SetTag(string(ext.PeerHostname), "localhost")

--- a/example/rpc/rpc.go
+++ b/example/rpc/rpc.go
@@ -13,7 +13,7 @@ const (
 )
 
 func rpc(ctx context.Context) {
-	parentSpan, ctx := ot.StartSpanFromContext(ctx, "parentService.myCoolMethod")
+	parentSpan, _ := ot.StartSpanFromContext(ctx, "parentService.myCoolMethod")
 	childSpan := ot.StartSpan("childService.anotherCoolMethod", ot.ChildOf(parentSpan.Context()))
 
 	time.Sleep(450 * time.Millisecond)

--- a/fsm.go
+++ b/fsm.go
@@ -141,7 +141,8 @@ func (r *fsmS) announceSensor(e *f.Event) {
 		schedFile := fmt.Sprintf("/proc/%d/sched", os.Getpid())
 		if _, err := os.Stat(schedFile); err == nil {
 			sf, err := os.Open(schedFile)
-			defer sf.Close()
+			defer sf.Close() //nolint:staticcheck
+
 			if err == nil {
 				fscanner := bufio.NewScanner(sf)
 				fscanner.Scan()

--- a/fsm.go
+++ b/fsm.go
@@ -29,6 +29,8 @@ type fsmS struct {
 	retries int
 }
 
+var procSchedPIDRegex = regexp.MustCompile(`\((\d+),`)
+
 func (r *fsmS) init() {
 
 	log.warn("Stan is on the scene.  Starting Instana instrumentation.")
@@ -145,8 +147,7 @@ func (r *fsmS) announceSensor(e *f.Event) {
 				fscanner.Scan()
 				primaLinea := fscanner.Text()
 
-				r := regexp.MustCompile("\\((\\d+),")
-				match := r.FindStringSubmatch(primaLinea)
+				match := procSchedPIDRegex.FindStringSubmatch(primaLinea)
 				i, err := strconv.Atoi(match[1])
 				if err == nil {
 					pid = i

--- a/propagation.go
+++ b/propagation.go
@@ -21,8 +21,7 @@ const (
 	// FieldL Level header
 	FieldL = "x-instana-l"
 	// FieldB OT Baggage header
-	FieldB     = "x-instana-b-"
-	fieldCount = 2
+	FieldB = "x-instana-b-"
 )
 
 func (r *textMapPropagator) inject(spanContext ot.SpanContext, opaqueCarrier interface{}) error {

--- a/util.go
+++ b/util.go
@@ -95,11 +95,6 @@ func getCommandLine() (string, []string) {
 	return parts[0], parts[1:]
 }
 
-func abs(x int64) int64 {
-	y := x >> 63
-	return (x + y) ^ y
-}
-
 func getDefaultGateway(routeTableFile string) string {
 	routeTable, err := os.Open(routeTableFile)
 

--- a/util.go
+++ b/util.go
@@ -86,10 +86,7 @@ func getCommandLine() (string, []string) {
 	}
 
 	parts := strings.FieldsFunc(string(cmdline), func(c rune) bool {
-		if c == '\u0000' {
-			return true
-		}
-		return false
+		return c == '\u0000'
 	})
 	log.debug("cmdline says:", parts[0], parts[1:])
 	return parts[0], parts[1:]

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -10,23 +10,23 @@ import (
 )
 
 // Trace IDs (and Span IDs) are based on Java Signed Long datatype
-const MinUint64 = uint64(0)
-const MaxUint64 = uint64(18446744073709551615)
-const MinInt64 = int64(-9223372036854775808)
-const MaxInt64 = int64(9223372036854775807)
+const (
+	MinInt64 int64 = -9223372036854775808
+	MaxInt64 int64 = 9223372036854775807
+)
 
 func TestGeneratedIDRange(t *testing.T) {
 	var count = 10000
 	for index := 0; index < count; index++ {
 		id := randomID()
-		assert.True(t, id <= 9223372036854775807, "Generated ID is out of bounds (+)")
-		assert.True(t, id >= -9223372036854775808, "Generated ID is out of bounds (-)")
+		assert.True(t, id <= MaxInt64, "Generated ID is out of bounds (+)")
+		assert.True(t, id >= MinInt64, "Generated ID is out of bounds (-)")
 	}
 }
 
 func TestIDConversionBackForth(t *testing.T) {
-	maxID := int64(9223372036854775807)
-	minID := int64(-9223372036854775808)
+	maxID := int64(MaxInt64)
+	minID := int64(MinInt64)
 	maxHex := "7fffffffffffffff"
 	minHex := "8000000000000000"
 


### PR DESCRIPTION
I've ran `golangci-lint` against this code and addressed some of the issues it found. Here is what's left:

* The code in `example/` often ignores errors, since I plan to revisit it anyway, I've just excluded this folder in config
* `errcheck` raises quite a few complaints about errors being ignored. While most of them are related to `fsm.FSM` event transitions, there are some more important ones (JSON unmarshalling, HTTP requests) that require some refactoring. This is on my TODO as well
* Bundled version of `pprof` was also excluded. The issues there are minor and I'd rather not touch this code

Since most of the linters have already dropped the support for Go prior to 1.10, I did not include this step into CI build pipeline.

**Important**: `instana.EumSnippet()` is deprecated now and will be removed soon, please refer to the [documentation](https://docs.instana.io/products/website_monitoring/#installation) on how to install the JS snippet.