### PR TITLE
Always send HTTP status code

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -153,3 +153,11 @@ func (rec *statusCodeRecorder) WriteHeader(status int) {
 	rec.Status = status
 	rec.ResponseWriter.WriteHeader(status)
 }
+
+func (rec *statusCodeRecorder) Write(b []byte) (int, error) {
+	if rec.Status == 0 {
+		rec.Status = http.StatusOK
+	}
+
+	return rec.ResponseWriter.Write(b)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/instana/go-sensor
 go 1.8
 
 require (
-	github.com/felixge/httpsnoop v1.0.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/looplab/fsm v0.1.0
 	github.com/opentracing/basictracer-go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/felixge/httpsnoop v1.0.0 h1:gh8fMGz0rlOv/1WmRZm7OgncIOTsAj21iNJot48omJQ=
-github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -14,6 +12,7 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
The current implementation of `(*instana.Sensor).TracingHandler()` only sets the `http.status_code` tag when the underlying handler explicitly calls `(http.ResponseWriter).WriteHeader()`. However this method is also can be called implicitly if `(http.ResponseWriter).Write()` is called first.

This PR replaces `github.com/felixge/httpsnoop.Hooks` with a simple wrapper over `http.ResponesWriter` that preserves the status code whenever any of `Write` or `WriteHeader` is called.