### PR TITLE
Run linter on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: go
 
-go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
-  - 1.13.x
-  - 1.14.x
-  - tip
+matrix:
+  include:
+    - go: tip
+    - go: 1.8.x
+    - go: 1.9.x
+    - go: 1.10.x
+    - go: 1.11.x
+    - go: 1.12.x
+    - go: 1.13.x
+    - go: 1.14.x
+      env: RUN_LINTER=yes
+
+script:
+  - make test
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: go
 
 go:
-  - 1.7.5
-  - 1.8.7
-  - 1.9.5
-  - 1.10.1
-  - 1.11.13
-  - 1.12.6
-  - 1.13.7
-  - 1.14
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
   - tip
-
-jobs:
-  allow_failures:
-  - go: 1.7.5 # fails since github.com/looplab/fsm@master has dropped 1.7 support
 
 notifications:
   slack:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 MODULES = $(shell find . -name go.mod -exec dirname {} \;)
 LINTER ?= $(shell go env GOPATH)/bin/golangci-lint
 
-test: $(LINTER) $(MODULES)
+ifdef RUN_LINTER
+test: $(LINTER)
+endif
+
+test: $(MODULES)
 
 $(MODULES):
 	cd $@ && go get -d -t ./... && go test $(GOFLAGS) ./...
+ifdef RUN_LINTER
 	cd $@ && $(LINTER) run
+endif
 
 $(LINTER):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/a2bc9b7a99e3280805309d71036e8c2106853250/install.sh \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+MODULES = $(shell find . -name go.mod -exec dirname {} \;)
+
+test: $(MODULES)
+
+$(MODULES):
+	cd $@ && go get -d -t ./... && go test $(GOFLAGS) ./...
+
+.PHONY: test $(MODULES)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 MODULES = $(shell find . -name go.mod -exec dirname {} \;)
+LINTER ?= $(shell go env GOPATH)/bin/golangci-lint
 
-test: $(MODULES)
+test: $(LINTER) $(MODULES)
 
 $(MODULES):
 	cd $@ && go get -d -t ./... && go test $(GOFLAGS) ./...
+	cd $@ && $(LINTER) run
+
+$(LINTER):
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/a2bc9b7a99e3280805309d71036e8c2106853250/install.sh \
+	| sh -s -- -b $(basename $(GOPATH))/bin v1.23.8
 
 .PHONY: test $(MODULES)


### PR DESCRIPTION
This PR removes go1.7 from test matrix and adds a Makefile to run tests and `golangci-lint` on Travis. The linter is only run for the latest version of Go, since it only supports the latest two releases following the [official support policy](https://golang.org/doc/devel/release.html#policy).