### PR TITLE
Expose instana.Sensor tracer

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -32,6 +32,11 @@ func NewSensorWithTracer(tracer ot.Tracer) *Sensor {
 	return &Sensor{tracer: tracer}
 }
 
+// Tracer returns the tracer instance for this sensor
+func (s *Sensor) Tracer() ot.Tracer {
+	return s.tracer
+}
+
 // TraceHandler is similar to TracingHandler in regards, that it wraps an existing http.HandlerFunc
 // into a named instance to support capturing tracing information and data. The returned values are
 // compatible with handler registration methods, e.g. http.Handle()


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/instana/go-sensor/pull/89. The idea is to use `instana.Sensor` in 3rd party instrumentations instead of a generic `ot.Tracer`. This would allow us to inject additional functionality along with basic tracing method (for example logging).