### PR TITLE
Pluggable logger

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -13,17 +13,6 @@ import (
 type SpanSensitiveFunc func(span ot.Span)
 type ContextSensitiveFunc func(span ot.Span, ctx context.Context)
 
-// LeveledLogger is an interface of a generic logger that support different message levels.
-// By default instana.Sensor uses logger.Logger with log.Logger as an output, however this
-// interface is also compatible with such popular loggers as github.com/sirupsen/logrus.Logger
-// and go.uber.org/zap.SugaredLogger
-type LeveledLogger interface {
-	Debug(v ...interface{})
-	Info(v ...interface{})
-	Warn(v ...interface{})
-	Error(v ...interface{})
-}
-
 // Sensor is used to inject tracing information into requests
 type Sensor struct {
 	tracer ot.Tracer

--- a/adapters.go
+++ b/adapters.go
@@ -2,12 +2,9 @@ package instana
 
 import (
 	"context"
-	"log"
 	"net/http"
-	"os"
 	"runtime"
 
-	"github.com/instana/go-sensor/logger"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -46,7 +43,7 @@ func NewSensor(serviceName string) *Sensor {
 func NewSensorWithTracer(tracer ot.Tracer) *Sensor {
 	return &Sensor{
 		tracer: tracer,
-		logger: logger.New(log.New(os.Stderr, "", log.LstdFlags)),
+		logger: defaultLogger,
 	}
 }
 

--- a/adapters.go
+++ b/adapters.go
@@ -147,11 +147,11 @@ func (s *Sensor) WithTracingSpan(operationName string, w http.ResponseWriter, re
 	case nil:
 		opts = append(opts, ext.RPCServerOption(wireContext))
 	case ot.ErrSpanContextNotFound:
-		instanaLog.debug("no span context provided with %s %s", req.Method, req.URL.Path)
+		s.Logger().Debug("no span context provided with ", req.Method, " ", req.URL.Path)
 	case ot.ErrUnsupportedFormat:
-		instanaLog.info("unsupported span context format provided with %s %s", req.Method, req.URL.Path)
+		s.Logger().Info("unsupported span context format provided with ", req.Method, " ", req.URL.Path)
 	default:
-		instanaLog.warn("failed to extract span context from the request:", err)
+		s.Logger().Warn("failed to extract span context from the request:", err)
 	}
 
 	if ps, ok := SpanFromContext(req.Context()); ok {

--- a/adapters.go
+++ b/adapters.go
@@ -119,11 +119,11 @@ func (s *Sensor) WithTracingSpan(operationName string, w http.ResponseWriter, re
 	case nil:
 		opts = append(opts, ext.RPCServerOption(wireContext))
 	case ot.ErrSpanContextNotFound:
-		log.debug("no span context provided with %s %s", req.Method, req.URL.Path)
+		instanaLog.debug("no span context provided with %s %s", req.Method, req.URL.Path)
 	case ot.ErrUnsupportedFormat:
-		log.info("unsupported span context format provided with %s %s", req.Method, req.URL.Path)
+		instanaLog.info("unsupported span context format provided with %s %s", req.Method, req.URL.Path)
 	default:
-		log.warn("failed to extract span context from the request:", err)
+		instanaLog.warn("failed to extract span context from the request:", err)
 	}
 
 	if ps, ok := SpanFromContext(req.Context()); ok {

--- a/adapters.go
+++ b/adapters.go
@@ -2,9 +2,12 @@ package instana
 
 import (
 	"context"
+	"log"
 	"net/http"
+	"os"
 	"runtime"
 
+	"github.com/instana/go-sensor/logger"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -13,9 +16,21 @@ import (
 type SpanSensitiveFunc func(span ot.Span)
 type ContextSensitiveFunc func(span ot.Span, ctx context.Context)
 
+// LeveledLogger is an interface of a generic logger that support different message levels.
+// By default instana.Sensor uses logger.Logger with log.Logger as an output, however this
+// interface is also compatible with such popular loggers as github.com/sirupsen/logrus.Logger
+// and go.uber.org/zap.SugaredLogger
+type LeveledLogger interface {
+	Debug(v ...interface{})
+	Info(v ...interface{})
+	Warn(v ...interface{})
+	Error(v ...interface{})
+}
+
 // Sensor is used to inject tracing information into requests
 type Sensor struct {
 	tracer ot.Tracer
+	logger LeveledLogger
 }
 
 // NewSensor creates a new instana.Sensor
@@ -29,12 +44,25 @@ func NewSensor(serviceName string) *Sensor {
 
 // NewSensorWithTracer returns a new instana.Sensor that uses provided tracer to report spans
 func NewSensorWithTracer(tracer ot.Tracer) *Sensor {
-	return &Sensor{tracer: tracer}
+	return &Sensor{
+		tracer: tracer,
+		logger: logger.New(log.New(os.Stderr, "", log.LstdFlags)),
+	}
 }
 
 // Tracer returns the tracer instance for this sensor
 func (s *Sensor) Tracer() ot.Tracer {
 	return s.tracer
+}
+
+// Logger returns the logger instance for this sensor
+func (s *Sensor) Logger() LeveledLogger {
+	return s.logger
+}
+
+// SetLogger sets the logger for this sensor
+func (s *Sensor) SetLogger(l LeveledLogger) {
+	s.logger = l
 }
 
 // TraceHandler is similar to TracingHandler in regards, that it wraps an existing http.HandlerFunc

--- a/adapters_test.go
+++ b/adapters_test.go
@@ -233,12 +233,8 @@ func TestWithTracingSpan_WithWireContext(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
-
-	traceID, err := instana.ID2Header(1234567890)
-	require.NoError(t, err)
-
-	parentSpanID, err := instana.ID2Header(1)
-	require.NoError(t, err)
+	traceID := instana.FormatID(1234567890)
+	parentSpanID := instana.FormatID(1)
 
 	req.Header.Set(instana.FieldT, traceID)
 	req.Header.Set(instana.FieldS, parentSpanID)

--- a/agent.go
+++ b/agent.go
@@ -54,6 +54,13 @@ func (r *agentS) init() {
 	r.setFrom(&fromS{})
 }
 
+func (r *agentS) initFsm() *fsmS {
+	ret := &fsmS{agent: r}
+	ret.init()
+
+	return ret
+}
+
 func (r *agentS) makeURL(prefix string) string {
 	return r.makeHostURL(r.host, prefix)
 }
@@ -153,7 +160,7 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 		// this is the time where the entity is registering in the Instana
 		// backend and it will return 404 until it's done.
 		if !r.sensor.agent.fsm.fsm.Is("announced") {
-			instanaLog.info(err, url)
+			r.sensor.logger.Info(err, url)
 		}
 	}
 
@@ -170,15 +177,4 @@ func (r *agentS) setHost(host string) {
 
 func (r *agentS) reset() {
 	r.fsm.reset()
-}
-
-func (r *sensorS) initAgent() *agentS {
-
-	instanaLog.debug("initializing agent")
-
-	ret := new(agentS)
-	ret.sensor = r
-	ret.init()
-
-	return ret
 }

--- a/agent.go
+++ b/agent.go
@@ -153,7 +153,7 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 		// this is the time where the entity is registering in the Instana
 		// backend and it will return 404 until it's done.
 		if !r.sensor.agent.fsm.fsm.Is("announced") {
-			log.info(err, url)
+			instanaLog.info(err, url)
 		}
 	}
 
@@ -174,7 +174,7 @@ func (r *agentS) reset() {
 
 func (r *sensorS) initAgent() *agentS {
 
-	log.debug("initializing agent")
+	instanaLog.debug("initializing agent")
 
 	ret := new(agentS)
 	ret.sensor = r

--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -3,6 +3,7 @@ package autoprofile
 import (
 	"github.com/instana/go-sensor/autoprofile/internal"
 	"github.com/instana/go-sensor/autoprofile/internal/logger"
+	instalogger "github.com/instana/go-sensor/logger"
 )
 
 var (
@@ -34,7 +35,16 @@ var (
 
 // SetLogLevel sets the min log level for autoprofiler
 func SetLogLevel(level int) {
-	logger.SetLogLevel(logger.Level(level))
+	switch logger.Level(level) {
+	case logger.ErrorLevel:
+		logger.SetLogLevel(instalogger.ErrorLevel)
+	case logger.WarnLevel:
+		logger.SetLogLevel(instalogger.WarnLevel)
+	case logger.InfoLevel:
+		logger.SetLogLevel(instalogger.InfoLevel)
+	default:
+		logger.SetLogLevel(instalogger.DebugLevel)
+	}
 }
 
 // Enable enables the auto profiling (disabled by default)

--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -34,6 +34,8 @@ var (
 )
 
 // SetLogLevel sets the min log level for autoprofiler
+//
+// Deprecated: use autoprofile.SetLogger() to set the logger and configure the min log level directly
 func SetLogLevel(level int) {
 	switch logger.Level(level) {
 	case logger.ErrorLevel:

--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -47,6 +47,11 @@ func SetLogLevel(level int) {
 	}
 }
 
+// SetLogger sets the leveled logger to use to output the diagnostic messages and errors
+func SetLogger(l logger.LeveledLogger) {
+	logger.SetLogger(l)
+}
+
 // Enable enables the auto profiling (disabled by default)
 func Enable() {
 	if enabled {

--- a/autoprofile/internal/logger/logger.go
+++ b/autoprofile/internal/logger/logger.go
@@ -1,6 +1,8 @@
 package logger
 
-import l "log"
+import (
+	instalogger "github.com/instana/go-sensor/logger"
+)
 
 // Level is the log level
 type Level uint8
@@ -13,61 +15,45 @@ const (
 	DebugLevel
 )
 
-var defaultLogger *logWrapper = &logWrapper{DebugLevel}
+var defaultLogger LeveledLogger = instalogger.New(nil)
+
+// LeveledLogger is an interface of a generic logger that support different message levels.
+// By default instana.Sensor uses logger.Logger with log.Logger as an output, however this
+// interface is also compatible with such popular loggers as github.com/sirupsen/logrus.Logger
+// and go.uber.org/zap.SugaredLogger
+type LeveledLogger interface {
+	Debug(v ...interface{})
+	Info(v ...interface{})
+	Warn(v ...interface{})
+	Error(v ...interface{})
+}
 
 // SetLogLevel configures the min log level for autoprofile defaultLogger
-func SetLogLevel(level Level) {
-	defaultLogger.logLevel = level
+func SetLogLevel(level instalogger.Level) {
+	l, ok := defaultLogger.(*instalogger.Logger)
+	if !ok {
+		return
+	}
+
+	l.SetLevel(level)
 }
 
 // Debug writes log message with defaultLogger.Debug level
 func Debug(v ...interface{}) {
-	defaultLogger.debug(v...)
+	defaultLogger.Debug(v...)
 }
 
 // Info writes log message with defaultLogger.Info level
 func Info(v ...interface{}) {
-	defaultLogger.info(v...)
+	defaultLogger.Info(v...)
 }
 
 // Warn writes log message with defaultLogger.Warn level
 func Warn(v ...interface{}) {
-	defaultLogger.warn(v...)
+	defaultLogger.Warn(v...)
 }
 
 // Error writes log message with defaultLogger.Error level
 func Error(v ...interface{}) {
-	defaultLogger.error(v...)
-}
-
-type logWrapper struct {
-	logLevel Level
-}
-
-func (lw *logWrapper) makeV(prefix string, v ...interface{}) []interface{} {
-	return append([]interface{}{prefix}, v...)
-}
-
-func (lw *logWrapper) debug(v ...interface{}) {
-	if lw.logLevel >= DebugLevel {
-		l.Println(lw.makeV("DEBUG: instana:", v...)...)
-	}
-}
-
-func (lw *logWrapper) info(v ...interface{}) {
-	if lw.logLevel >= InfoLevel {
-		l.Println(lw.makeV("INFO: instana:", v...)...)
-	}
-}
-
-func (lw *logWrapper) warn(v ...interface{}) {
-	if lw.logLevel >= WarnLevel {
-		l.Println(lw.makeV("WARN: instana:", v...)...)
-	}
-}
-
-func (lw *logWrapper) error(v ...interface{}) {
-	if lw.logLevel >= ErrorLevel {
-		l.Println(lw.makeV("ERROR: instana:", v...)...)
-	}
+	defaultLogger.Error(v...)
 }

--- a/autoprofile/internal/logger/logger.go
+++ b/autoprofile/internal/logger/logger.go
@@ -38,6 +38,11 @@ func SetLogLevel(level instalogger.Level) {
 	l.SetLevel(level)
 }
 
+// SetLogger sets the leveled logger to use to output the diagnostic messages and errors
+func SetLogger(l LeveledLogger) {
+	defaultLogger = l
+}
+
 // Debug writes log message with defaultLogger.Debug level
 func Debug(v ...interface{}) {
 	defaultLogger.Debug(v...)

--- a/log.go
+++ b/log.go
@@ -1,7 +1,7 @@
 package instana
 
 import (
-	l "log"
+	"log"
 )
 
 // Valid log levels
@@ -16,7 +16,7 @@ type logS struct {
 	sensor *sensorS
 }
 
-var log *logS
+var instanaLog *logS
 
 func (r *logS) makeV(prefix string, v ...interface{}) []interface{} {
 	return append([]interface{}{prefix}, v...)
@@ -24,29 +24,29 @@ func (r *logS) makeV(prefix string, v ...interface{}) []interface{} {
 
 func (r *logS) debug(v ...interface{}) {
 	if r.sensor.options.LogLevel >= Debug {
-		l.Println(r.makeV("DEBUG: instana:", v...)...)
+		log.Println(r.makeV("DEBUG: instana:", v...)...)
 	}
 }
 
 func (r *logS) info(v ...interface{}) {
 	if r.sensor.options.LogLevel >= Info {
-		l.Println(r.makeV("INFO: instana:", v...)...)
+		log.Println(r.makeV("INFO: instana:", v...)...)
 	}
 }
 
 func (r *logS) warn(v ...interface{}) {
 	if r.sensor.options.LogLevel >= Warn {
-		l.Println(r.makeV("WARN: instana:", v...)...)
+		log.Println(r.makeV("WARN: instana:", v...)...)
 	}
 }
 
 func (r *logS) error(v ...interface{}) {
 	if r.sensor.options.LogLevel >= Error {
-		l.Println(r.makeV("ERROR: instana:", v...)...)
+		log.Println(r.makeV("ERROR: instana:", v...)...)
 	}
 }
 
 func (r *sensorS) initLog() {
-	log = new(logS)
-	log.sensor = r
+	instanaLog = new(logS)
+	instanaLog.sensor = r
 }

--- a/log.go
+++ b/log.go
@@ -56,3 +56,18 @@ func (r *sensorS) initLog() {
 	instanaLog = new(logS)
 	instanaLog.sensor = r
 }
+
+// setLogLevel translates legacy Instana log levels into logger.Logger levels.
+// Any level that is greater than instana.Debug is interpreted as logger.DebugLevel.
+func setLogLevel(l *logger.Logger, level int) {
+	switch level {
+	case Error:
+		l.SetLevel(logger.ErrorLevel)
+	case Warn:
+		l.SetLevel(logger.WarnLevel)
+	case Info:
+		l.SetLevel(logger.InfoLevel)
+	default:
+		l.SetLevel(logger.DebugLevel)
+	}
+}

--- a/log.go
+++ b/log.go
@@ -15,47 +15,7 @@ const (
 	Debug = 3
 )
 
-type logS struct {
-	sensor *sensorS
-}
-
-var (
-	instanaLog    *logS
-	defaultLogger = logger.New(log.New(os.Stderr, "", log.LstdFlags))
-)
-
-func (r *logS) makeV(prefix string, v ...interface{}) []interface{} {
-	return append([]interface{}{prefix}, v...)
-}
-
-func (r *logS) debug(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Debug {
-		log.Println(r.makeV("DEBUG: instana:", v...)...)
-	}
-}
-
-func (r *logS) info(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Info {
-		log.Println(r.makeV("INFO: instana:", v...)...)
-	}
-}
-
-func (r *logS) warn(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Warn {
-		log.Println(r.makeV("WARN: instana:", v...)...)
-	}
-}
-
-func (r *logS) error(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Error {
-		log.Println(r.makeV("ERROR: instana:", v...)...)
-	}
-}
-
-func (r *sensorS) initLog() {
-	instanaLog = new(logS)
-	instanaLog.sensor = r
-}
+var defaultLogger = logger.New(log.New(os.Stderr, "", log.LstdFlags))
 
 // setLogLevel translates legacy Instana log levels into logger.Logger levels.
 // Any level that is greater than instana.Debug is interpreted as logger.DebugLevel.

--- a/log.go
+++ b/log.go
@@ -1,9 +1,6 @@
 package instana
 
 import (
-	"log"
-	"os"
-
 	"github.com/instana/go-sensor/logger"
 )
 
@@ -26,7 +23,7 @@ type LeveledLogger interface {
 	Error(v ...interface{})
 }
 
-var defaultLogger LeveledLogger = logger.New(log.New(os.Stderr, "", log.LstdFlags))
+var defaultLogger LeveledLogger = logger.New(nil)
 
 // SetLogger configures the default logger to be used by Instana go-sensor. Note that changing the logger
 // will not affect already initialized instana.Sensor instances. To make them use the new logger please call

--- a/log.go
+++ b/log.go
@@ -2,6 +2,9 @@ package instana
 
 import (
 	"log"
+	"os"
+
+	"github.com/instana/go-sensor/logger"
 )
 
 // Valid log levels
@@ -16,7 +19,10 @@ type logS struct {
 	sensor *sensorS
 }
 
-var instanaLog *logS
+var (
+	instanaLog    *logS
+	defaultLogger = logger.New(log.New(os.Stderr, "", log.LstdFlags))
+)
 
 func (r *logS) makeV(prefix string, v ...interface{}) []interface{} {
 	return append([]interface{}{prefix}, v...)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,111 @@
+package logger
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Valid log levels to be used with (*logger.Logger).SetLevel()
+const (
+	ErrorLevel Level = iota
+	WarnLevel
+	InfoLevel
+	DebugLevel
+)
+
+// Level defines the minimum logging level for logger.Log
+type Level uint8
+
+// String returns the log line label for this level
+func (lvl Level) String() string {
+	switch lvl {
+	case DebugLevel:
+		return "DEBUG"
+	case InfoLevel:
+		return "INFO"
+	case WarnLevel:
+		return "WARN"
+	case ErrorLevel:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Printer is used by logger.Log instance to print out a log message
+type Printer interface {
+	Print(a ...interface{})
+}
+
+// Logger is a configurable leveled logger used by Instana's Go sensor. It follows the same interface
+// as github.com/sirupsen/logrus.Logger and go.uber.org/zap.SugaredLogger
+type Logger struct {
+	p Printer
+
+	mu  sync.Mutex
+	lvl Level
+}
+
+// New initializes a new instance of Logger that uses provided printer as a backend to
+// output the log messages. The stdlib log.Logger satisfies logger.Printer interface:
+//
+// 	logger := logger.New(logger.WarnLevel, log.New(os.Stderr, "instana:", log.LstdFlags))
+// 	logger.SetLevel(logger.WarnLevel)
+//
+// 	logger.Debug("this is a debug message") // won't be printed
+// 	logger.Error("this is an  message") // ... while this one will
+//
+// The default logging level for a new logger instance is logger.ErrorLevel
+func New(printer Printer) *Logger {
+	return &Logger{
+		p: printer,
+	}
+}
+
+// SetLevel changes the log level for this logger instance
+func (l *Logger) SetLevel(level Level) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.lvl = level
+}
+
+// Debug appends a debug message to the log
+func (l *Logger) Debug(v ...interface{}) {
+	if l.lvl < DebugLevel {
+		return
+	}
+
+	l.print(DebugLevel, v)
+}
+
+// Info appends an info message to the log
+func (l *Logger) Info(v ...interface{}) {
+	if l.lvl < InfoLevel {
+		return
+	}
+
+	l.print(InfoLevel, v)
+}
+
+// Warn appends a warning message to the log
+func (l *Logger) Warn(v ...interface{}) {
+	if l.lvl < WarnLevel {
+		return
+	}
+
+	l.print(WarnLevel, v)
+}
+
+// Error appends an error message to the log
+func (l *Logger) Error(v ...interface{}) {
+	if l.lvl < ErrorLevel {
+		return
+	}
+
+	l.print(ErrorLevel, v)
+}
+
+func (l *Logger) print(lvl Level, v []interface{}) {
+	l.p.Print(lvl.String(), ": ", fmt.Sprint(v...))
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -72,14 +72,30 @@ func New(printer Printer) *Logger {
 		printer = log.New(os.Stderr, "", log.LstdFlags)
 	}
 
-	return &Logger{
+	l := &Logger{
 		p:      printer,
 		prefix: DefaultPrefix,
 	}
+	l.SetLevel(ErrorLevel)
+
+	return l
 }
 
-// SetLevel changes the log level for this logger instance
+// SetLevel changes the log level for this logger instance. In case there is an INSTANA_DEBUG env variable set,
+// the provided log level will be overridden with DebugLevel.
 func (l *Logger) SetLevel(level Level) {
+	if _, ok := os.LookupEnv("INSTANA_DEBUG"); ok {
+		if level != DebugLevel {
+			defer l.Info(
+				"INSTANA_DEBUG env variable is set, the log level has been set to ",
+				DebugLevel,
+				" instead of requested ",
+				level,
+			)
+		}
+		level = DebugLevel
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,6 +2,8 @@ package logger
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"sync"
 )
 
@@ -59,8 +61,17 @@ type Logger struct {
 // 	logger.Debug("this is a debug message") // won't be printed
 // 	logger.Error("this is an  message") // ... while this one will
 //
-// The default logging level for a new logger instance is logger.ErrorLevel
+// In case  there is no printer provided, logger.Logger will use a new instance of log.Logger
+// initialized with log.Lstdflags that writes to os.Stderr:
+//
+// 	log.New(os.Stderr, "", log.Lstdflags)
+//
+// The default logging level for a new logger instance is logger.ErrorLevel.
 func New(printer Printer) *Logger {
+	if printer == nil {
+		printer = log.New(os.Stderr, "", log.LstdFlags)
+	}
+
 	return &Logger{
 		p:      printer,
 		prefix: DefaultPrefix,

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -5,27 +5,49 @@ import (
 
 	"github.com/instana/go-sensor/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestLogger_SetPrefix(t *testing.T) {
+	p := &printer{}
+
+	l := logger.New(p)
+	l.SetPrefix("test-logger>>")
+	l.Error("error level")
+
+	require.Len(t, p.Records, 1)
+	assert.Equal(t, []interface{}{"test-logger>>", "ERROR", ": ", "error level"}, p.Records[0])
+}
+
+func TestLogger_SetPrefix_DefaultValue(t *testing.T) {
+	p := &printer{}
+
+	l := logger.New(p)
+	l.Error("error level")
+
+	require.Len(t, p.Records, 1)
+	assert.Equal(t, []interface{}{"instana: ", "ERROR", ": ", "error level"}, p.Records[0])
+}
 
 func TestLogger_SetLevel(t *testing.T) {
 	examples := map[logger.Level][][]interface{}{
 		logger.DebugLevel: {
-			{"DEBUG", ": ", "debuglevel"},
+			{"instana: ", "DEBUG", ": ", "debuglevel"},
+			{"instana: ", "INFO", ": ", "infolevel"},
+			{"instana: ", "WARN", ": ", "warnlevel"},
+			{"instana: ", "ERROR", ": ", "errorlevel"},
 		},
 		logger.InfoLevel: {
-			{"DEBUG", ": ", "debuglevel"},
-			{"INFO", ": ", "infolevel"},
+			{"instana: ", "INFO", ": ", "infolevel"},
+			{"instana: ", "WARN", ": ", "warnlevel"},
+			{"instana: ", "ERROR", ": ", "errorlevel"},
 		},
 		logger.WarnLevel: {
-			{"DEBUG", ": ", "debuglevel"},
-			{"INFO", ": ", "infolevel"},
-			{"WARN", ": ", "warnlevel"},
+			{"instana: ", "WARN", ": ", "warnlevel"},
+			{"instana: ", "ERROR", ": ", "errorlevel"},
 		},
 		logger.ErrorLevel: {
-			{"DEBUG", ": ", "debuglevel"},
-			{"INFO", ": ", "infolevel"},
-			{"WARN", ": ", "warnlevel"},
-			{"ERROR", ": ", "errorlevel"},
+			{"instana: ", "ERROR", ": ", "errorlevel"},
 		},
 	}
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,55 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/instana/go-sensor/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger_SetLevel(t *testing.T) {
+	examples := map[logger.Level][][]interface{}{
+		logger.DebugLevel: {
+			{"DEBUG", ": ", "debuglevel"},
+		},
+		logger.InfoLevel: {
+			{"DEBUG", ": ", "debuglevel"},
+			{"INFO", ": ", "infolevel"},
+		},
+		logger.WarnLevel: {
+			{"DEBUG", ": ", "debuglevel"},
+			{"INFO", ": ", "infolevel"},
+			{"WARN", ": ", "warnlevel"},
+		},
+		logger.ErrorLevel: {
+			{"DEBUG", ": ", "debuglevel"},
+			{"INFO", ": ", "infolevel"},
+			{"WARN", ": ", "warnlevel"},
+			{"ERROR", ": ", "errorlevel"},
+		},
+	}
+
+	for lvl, expected := range examples {
+		t.Run(lvl.String(), func(t *testing.T) {
+			p := &printer{}
+
+			l := logger.New(p)
+			l.SetLevel(lvl)
+
+			l.Debug("debug", "level")
+			l.Info("info", "level")
+			l.Warn("warn", "level")
+			l.Error("error", "level")
+
+			assert.Equal(t, expected, p.Records)
+		})
+	}
+}
+
+type printer struct {
+	Records [][]interface{}
+}
+
+func (p *printer) Print(args ...interface{}) {
+	p.Records = append(p.Records, args)
+}

--- a/meter.go
+++ b/meter.go
@@ -73,7 +73,7 @@ func (r *meterS) init() {
 				if r.snapshotCountdown == 0 {
 					r.snapshotCountdown = SnapshotPeriod
 					s = r.collectSnapshot()
-					log.debug("collected snapshot")
+					instanaLog.debug("collected snapshot")
 				} else {
 					s = nil
 				}
@@ -147,7 +147,7 @@ func (r *meterS) collectSnapshot() *SnapshotS {
 
 func (r *sensorS) initMeter() *meterS {
 
-	log.debug("initializing meter")
+	instanaLog.debug("initializing meter")
 
 	ret := new(meterS)
 	ret.sensor = r

--- a/meter.go
+++ b/meter.go
@@ -73,16 +73,15 @@ func (r *meterS) init() {
 				if r.snapshotCountdown == 0 {
 					r.snapshotCountdown = SnapshotPeriod
 					s = r.collectSnapshot()
-					instanaLog.debug("collected snapshot")
-				} else {
-					s = nil
+					r.sensor.logger.Debug("collected snapshot")
 				}
 
 				pid, _ := strconv.Atoi(r.sensor.agent.from.PID)
 				d := &EntityData{
 					PID:      pid,
 					Snapshot: s,
-					Metrics:  r.collectMetrics()}
+					Metrics:  r.collectMetrics(),
+				}
 
 				go r.send(d)
 			}
@@ -143,15 +142,4 @@ func (r *meterS) collectSnapshot() *SnapshotS {
 		MaxProcs: runtime.GOMAXPROCS(0),
 		Compiler: runtime.Compiler,
 		NumCPU:   runtime.NumCPU()}
-}
-
-func (r *sensorS) initMeter() *meterS {
-
-	instanaLog.debug("initializing meter")
-
-	ret := new(meterS)
-	ret.sensor = r
-	ret.init()
-
-	return ret
 }

--- a/propagation.go
+++ b/propagation.go
@@ -85,12 +85,12 @@ func (r *textMapPropagator) inject(spanContext ot.SpanContext, opaqueCarrier int
 	if instanaTID, err := ID2Header(sc.TraceID); err == nil {
 		carrier.Set(exstfieldT, instanaTID)
 	} else {
-		log.debug(err)
+		instanaLog.debug(err)
 	}
 	if instanaSID, err := ID2Header(sc.SpanID); err == nil {
 		carrier.Set(exstfieldS, instanaSID)
 	} else {
-		log.debug(err)
+		instanaLog.debug(err)
 	}
 	carrier.Set(exstfieldL, strconv.Itoa(1))
 

--- a/propagation.go
+++ b/propagation.go
@@ -106,59 +106,49 @@ func (r *textMapPropagator) extract(opaqueCarrier interface{}) (ot.SpanContext, 
 		return nil, ot.ErrInvalidCarrier
 	}
 
-	fieldCount := 0
-	var traceID, spanID int64
-	var err error
-	baggage := make(map[string]string)
-	err = carrier.ForeachKey(func(k, v string) error {
+	spanContext := SpanContext{
+		Baggage: make(map[string]string),
+	}
+
+	var fieldCount int
+	err := carrier.ForeachKey(func(k, v string) error {
 		switch strings.ToLower(k) {
 		case FieldT:
 			fieldCount++
-			traceID, err = Header2ID(v)
+
+			traceID, err := Header2ID(v)
 			if err != nil {
 				return ot.ErrSpanContextCorrupted
 			}
+
+			spanContext.TraceID = traceID
 		case FieldS:
 			fieldCount++
-			spanID, err = Header2ID(v)
+
+			spanID, err := Header2ID(v)
 			if err != nil {
 				return ot.ErrSpanContextCorrupted
 			}
+
+			spanContext.SpanID = spanID
 		default:
 			lk := strings.ToLower(k)
-
 			if strings.HasPrefix(lk, FieldB) {
-				baggage[strings.TrimPrefix(lk, FieldB)] = v
+				spanContext.Baggage[strings.TrimPrefix(lk, FieldB)] = v
 			}
 		}
 
 		return nil
 	})
-
-	return r.finishExtract(err, fieldCount, traceID, spanID, baggage)
-}
-
-func (r *textMapPropagator) finishExtract(err error,
-	fieldCount int,
-	traceID int64,
-	spanID int64,
-	baggage map[string]string) (ot.SpanContext, error) {
 	if err != nil {
 		return nil, err
 	}
 
-	if fieldCount < 2 {
-		if fieldCount == 0 {
-			return nil, ot.ErrSpanContextNotFound
-		}
-
+	if fieldCount == 0 {
+		return nil, ot.ErrSpanContextNotFound
+	} else if fieldCount < 2 {
 		return nil, ot.ErrSpanContextCorrupted
 	}
 
-	return SpanContext{
-		TraceID: traceID,
-		SpanID:  spanID,
-		Sampled: false,
-		Baggage: baggage,
-	}, nil
+	return spanContext, nil
 }

--- a/propagation.go
+++ b/propagation.go
@@ -36,12 +36,10 @@ func (r *textMapPropagator) inject(spanContext ot.SpanContext, opaqueCarrier int
 	}
 
 	// Handle pre-existing case-sensitive keys
-	var (
-		exstfieldT = FieldT
-		exstfieldS = FieldS
-		exstfieldL = FieldL
-		exstfieldB = FieldB
-	)
+	exstfieldT := FieldT
+	exstfieldS := FieldS
+	exstfieldL := FieldL
+	exstfieldB := FieldB
 
 	roCarrier.ForeachKey(func(k, v string) error {
 		switch strings.ToLower(k) {
@@ -82,16 +80,8 @@ func (r *textMapPropagator) inject(spanContext ot.SpanContext, opaqueCarrier int
 		}
 	}
 
-	if instanaTID, err := ID2Header(sc.TraceID); err == nil {
-		carrier.Set(exstfieldT, instanaTID)
-	} else {
-		instanaLog.debug(err)
-	}
-	if instanaSID, err := ID2Header(sc.SpanID); err == nil {
-		carrier.Set(exstfieldS, instanaSID)
-	} else {
-		instanaLog.debug(err)
-	}
+	carrier.Set(exstfieldT, FormatID(sc.TraceID))
+	carrier.Set(exstfieldS, FormatID(sc.SpanID))
 	carrier.Set(exstfieldL, strconv.Itoa(1))
 
 	for k, v := range sc.Baggage {
@@ -116,7 +106,7 @@ func (r *textMapPropagator) extract(opaqueCarrier interface{}) (ot.SpanContext, 
 		case FieldT:
 			fieldCount++
 
-			traceID, err := Header2ID(v)
+			traceID, err := ParseID(v)
 			if err != nil {
 				return ot.ErrSpanContextCorrupted
 			}
@@ -125,7 +115,7 @@ func (r *textMapPropagator) extract(opaqueCarrier interface{}) (ot.SpanContext, 
 		case FieldS:
 			fieldCount++
 
-			spanID, err := Header2ID(v)
+			spanID, err := ParseID(v)
 			if err != nil {
 				return ot.ErrSpanContextCorrupted
 			}

--- a/recorder.go
+++ b/recorder.go
@@ -116,7 +116,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 	}
 
 	if len(r.spans) >= sensor.options.ForceTransmissionStartingAt {
-		instanaLog.debug("Forcing spans to agent.  Count:", len(r.spans))
+		sensor.logger.Debug("Forcing spans to agent. Count:", len(r.spans))
 		go r.send()
 	}
 }
@@ -168,7 +168,7 @@ func (r *Recorder) send() {
 		go func() {
 			_, err := sensor.agent.request(sensor.agent.makeURL(agentTracesURL), "POST", spansToSend)
 			if err != nil {
-				instanaLog.debug("Posting traces failed in send(): ", err)
+				sensor.logger.Debug("Posting traces failed in send(): ", err)
 				sensor.agent.reset()
 			}
 		}()

--- a/recorder.go
+++ b/recorder.go
@@ -116,7 +116,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 	}
 
 	if len(r.spans) >= sensor.options.ForceTransmissionStartingAt {
-		log.debug("Forcing spans to agent.  Count:", len(r.spans))
+		instanaLog.debug("Forcing spans to agent.  Count:", len(r.spans))
 		go r.send()
 	}
 }
@@ -168,7 +168,7 @@ func (r *Recorder) send() {
 		go func() {
 			_, err := sensor.agent.request(sensor.agent.makeURL(agentTracesURL), "POST", spansToSend)
 			if err != nil {
-				log.debug("Posting traces failed in send(): ", err)
+				instanaLog.debug("Posting traces failed in send(): ", err)
 				sensor.agent.reset()
 			}
 		}()

--- a/sensor.go
+++ b/sensor.go
@@ -30,7 +30,10 @@ func (r *sensorS) init(options *Options) {
 		return
 	}
 
-	r.logger = defaultLogger
+	if r.logger == nil {
+		r.setLogger(defaultLogger)
+	}
+
 	r.setOptions(options)
 	r.configureServiceName()
 	r.agent = r.initAgent()
@@ -73,6 +76,10 @@ func (r *sensorS) setOptions(options *Options) {
 	if l, ok := r.logger.(*logger.Logger); ok {
 		setLogLevel(l, r.options.LogLevel)
 	}
+}
+
+func (r *sensorS) setLogger(l LeveledLogger) {
+	r.logger = l
 }
 
 func (r *sensorS) configureServiceName() {

--- a/sensor.go
+++ b/sensor.go
@@ -97,12 +97,12 @@ func InitSensor(options *Options) {
 				return errors.New("sender not ready")
 			}
 
-			log.debug("sending profiles to agent")
+			instanaLog.debug("sending profiles to agent")
 
 			_, err := sensor.agent.request(sensor.agent.makeURL(agentProfilesURL), "POST", profiles)
 			if err != nil {
 				sensor.agent.reset()
-				log.error(err)
+				instanaLog.error(err)
 			}
 
 			return err
@@ -111,5 +111,5 @@ func InitSensor(options *Options) {
 		autoprofile.Enable()
 	}
 
-	log.debug("initialized sensor")
+	instanaLog.debug("initialized sensor")
 }

--- a/sensor.go
+++ b/sensor.go
@@ -30,11 +30,29 @@ func (r *sensorS) init(options *Options) {
 		return
 	}
 
+	r.logger = defaultLogger
 	r.setOptions(options)
 	r.configureServiceName()
 	r.agent = r.initAgent()
 	r.meter = r.initMeter()
-	r.logger = defaultLogger
+}
+
+func (r *sensorS) initAgent() *agentS {
+	r.logger.Debug("initializing agent")
+
+	ret := &agentS{sensor: r}
+	ret.init()
+
+	return ret
+}
+
+func (r *sensorS) initMeter() *meterS {
+	r.logger.Debug("initializing meter")
+
+	ret := &meterS{sensor: r}
+	ret.init()
+
+	return ret
 }
 
 func (r *sensorS) setOptions(options *Options) {
@@ -107,12 +125,12 @@ func InitSensor(options *Options) {
 				return errors.New("sender not ready")
 			}
 
-			instanaLog.debug("sending profiles to agent")
+			sensor.logger.Debug("sending profiles to agent")
 
 			_, err := sensor.agent.request(sensor.agent.makeURL(agentProfilesURL), "POST", profiles)
 			if err != nil {
 				sensor.agent.reset()
-				instanaLog.error(err)
+				sensor.logger.Error(err)
 			}
 
 			return err
@@ -121,5 +139,5 @@ func InitSensor(options *Options) {
 		autoprofile.Enable()
 	}
 
-	instanaLog.debug("initialized sensor")
+	sensor.logger.Debug("initialized sensor")
 }

--- a/sensor.go
+++ b/sensor.go
@@ -16,6 +16,7 @@ const (
 type sensorS struct {
 	meter       *meterS
 	agent       *agentS
+	logger      LeveledLogger
 	options     *Options
 	serviceName string
 }
@@ -24,12 +25,15 @@ var sensor *sensorS
 
 func (r *sensorS) init(options *Options) {
 	// sensor can be initialized explicitly or implicitly through OpenTracing global init
-	if r.meter == nil {
-		r.setOptions(options)
-		r.configureServiceName()
-		r.agent = r.initAgent()
-		r.meter = r.initMeter()
+	if r.meter != nil {
+		return
 	}
+
+	r.setOptions(options)
+	r.configureServiceName()
+	r.agent = r.initAgent()
+	r.meter = r.initMeter()
+	r.logger = defaultLogger
 }
 
 func (r *sensorS) setOptions(options *Options) {

--- a/sensor.go
+++ b/sensor.go
@@ -105,7 +105,6 @@ func InitSensor(options *Options) {
 		options.LogLevel = Debug
 	}
 
-	sensor.initLog()
 	sensor.init(options)
 
 	// enable auto-profiling

--- a/sensor.go
+++ b/sensor.go
@@ -116,7 +116,7 @@ func InitSensor(options *Options) {
 
 	// enable auto-profiling
 	if options.EnableAutoProfile {
-		autoprofile.SetLogLevel(options.LogLevel)
+		autoprofile.SetLogger(sensor.logger)
 		autoprofile.SetOptions(autoprofile.Options{
 			IncludeProfilerFrames: options.IncludeProfilerFrames,
 			MaxBufferedProfiles:   options.MaxBufferedProfiles,

--- a/sensor.go
+++ b/sensor.go
@@ -105,13 +105,6 @@ func InitSensor(options *Options) {
 	}
 
 	sensor = &sensorS{}
-
-	// If this environment variable is set, then override log level
-	_, ok := os.LookupEnv("INSTANA_DEBUG")
-	if ok {
-		options.LogLevel = Debug
-	}
-
 	sensor.init(options)
 
 	// enable auto-profiling

--- a/sensor.go
+++ b/sensor.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/instana/go-sensor/autoprofile"
+	"github.com/instana/go-sensor/logger"
 )
 
 const (
@@ -48,6 +49,11 @@ func (r *sensorS) setOptions(options *Options) {
 
 	if r.options.ForceTransmissionStartingAt == 0 {
 		r.options.ForceTransmissionStartingAt = DefaultForceSpanSendAt
+	}
+
+	// handle the legacy (instana.Options).LogLevel value if we use logger.Logger to log
+	if l, ok := r.logger.(*logger.Logger); ok {
+		setLogLevel(l, r.options.LogLevel)
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -41,9 +41,9 @@ func ID2Header(id int64) (string, error) {
 			// Convert uint64 to hex string equivalent and return that
 			return strconv.FormatUint(unsigned, 16), nil
 		}
-		log.debug(err)
+		instanaLog.debug(err)
 	} else {
-		log.debug(err)
+		instanaLog.debug(err)
 	}
 	return "", errors.New("context corrupted; could not convert value")
 }
@@ -65,12 +65,12 @@ func Header2ID(header string) (int64, error) {
 				// The success case
 				return signedID, nil
 			}
-			log.debug(err)
+			instanaLog.debug(err)
 		} else {
-			log.debug(err)
+			instanaLog.debug(err)
 		}
 	} else {
-		log.debug(err)
+		instanaLog.debug(err)
 	}
 	return int64(0), errors.New("context corrupted; could not convert value")
 }
@@ -81,14 +81,14 @@ func getCommandLine() (string, []string) {
 	cmdline, err := ioutil.ReadFile(cmdlinePath)
 
 	if err != nil {
-		log.debug("No /proc.  Returning OS reported cmdline")
+		instanaLog.debug("No /proc.  Returning OS reported cmdline")
 		return os.Args[0], os.Args[1:]
 	}
 
 	parts := strings.FieldsFunc(string(cmdline), func(c rune) bool {
 		return c == '\u0000'
 	})
-	log.debug("cmdline says:", parts[0], parts[1:])
+	instanaLog.debug("cmdline says:", parts[0], parts[1:])
 	return parts[0], parts[1:]
 }
 
@@ -96,7 +96,7 @@ func getDefaultGateway(routeTableFile string) string {
 	routeTable, err := os.Open(routeTableFile)
 
 	if err != nil {
-		log.error(err)
+		instanaLog.error(err)
 		return ""
 	}
 
@@ -115,7 +115,7 @@ func getDefaultGateway(routeTableFile string) string {
 			gateway, err := hexGatewayToAddr(gatewayHex)
 
 			if err != nil {
-				log.error(err)
+				instanaLog.error(err)
 				return ""
 			}
 
@@ -124,7 +124,7 @@ func getDefaultGateway(routeTableFile string) string {
 	}
 
 	if err := s.Err(); err != nil {
-		log.error(err)
+		instanaLog.error(err)
 	}
 
 	return ""

--- a/util.go
+++ b/util.go
@@ -73,53 +73,20 @@ func ParseID(header string) (int64, error) {
 	return signedID, nil
 }
 
-// ID2Header converts an Instana ID to a value that can be used in
-// context propagation (such as HTTP headers).  More specifically,
-// this converts a signed 64 bit integer into an unsigned hex string.
+// ID2Header calls instana.FormatID() and returns its result and a nil error.
+// This is kept here for backward compatibility with go-sensor@v1.x
+//
+// Deprecated: please use instana.FormatID() instead
 func ID2Header(id int64) (string, error) {
-	// FIXME: We're assuming LittleEndian here
-
-	// Write out _signed_ 64bit integer to byte buffer
-	buf := bytes.NewBuffer(nil)
-	if err := binary.Write(buf, binary.LittleEndian, id); err != nil {
-		return "", fmt.Errorf("context corrupted; could not convert value: %s", err)
-	}
-
-	// Read bytes back into _unsigned_ 64 bit integer
-	var unsigned uint64
-	if err := binary.Read(buf, binary.LittleEndian, &unsigned); err != nil {
-		return "", fmt.Errorf("context corrupted; could not convert value: %s", err)
-	}
-
-	// Convert uint64 to hex string equivalent and return that
-	return strconv.FormatUint(unsigned, 16), nil
+	return FormatID(id), nil
 }
 
-// Header2ID converts an header context value into an Instana ID.  More
-// specifically, this converts an unsigned 64 bit hex value into a signed
-// 64bit integer.
+// Header2ID calls instana.ParseID() and returns its result.
+// This is kept here for backward compatibility with go-sensor@v1.x
+//
+// Deprecated: please use instana.ParseID() instead
 func Header2ID(header string) (int64, error) {
-	// FIXME: We're assuming LittleEndian here
-
-	// Parse unsigned 64 bit hex string into unsigned 64 bit base 10 integer
-	unsignedID, err := strconv.ParseUint(header, 16, 64)
-	if err != nil {
-		return 0, fmt.Errorf("context corrupted; could not convert value: %s", err)
-	}
-
-	// Write out _unsigned_ 64bit integer to byte buffer
-	buf := bytes.NewBuffer(nil)
-	if err := binary.Write(buf, binary.LittleEndian, unsignedID); err != nil {
-		return 0, fmt.Errorf("context corrupted; could not convert value: %s", err)
-	}
-
-	// Read bytes back into _signed_ 64 bit integer
-	var signedID int64
-	if err := binary.Read(buf, binary.LittleEndian, &signedID); err != nil {
-		return 0, fmt.Errorf("context corrupted; could not convert value: %s", err)
-	}
-
-	return signedID, nil
+	return ParseID(header)
 }
 
 func getProcCommandLine() (string, []string, bool) {

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Trace IDs (and Span IDs) are based on Java Signed Long datatype
@@ -128,8 +129,9 @@ func TestHexGatewayToAddr(t *testing.T) {
 func TestGetDefaultGateway(t *testing.T) {
 
 	tests := []struct {
-		in       string
-		expected string
+		in          string
+		expected    string
+		expectError bool
 	}{
 		{
 			in: `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
@@ -168,8 +170,8 @@ eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0
 				t.Fatal(err)
 			}
 
-			gateway := getDefaultGateway(tmpFile.Name())
-
+			gateway, err := getDefaultGateway(tmpFile.Name())
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, gateway)
 		}()
 	}


### PR DESCRIPTION
This PR introduces the new `github.com/instana/go-sensor/logger` package that provides a leveled logger implementation used by Go sensor and autoprofiler to write diagnostic and error messages. This is **NOT** logging instrumentation.

An instance of `logger.Logger` is used as a default, has configurable prefix and respects `INSTANA_DEBUG` environment variable, overriding any log level set in the code with `logger.DebugLevel`.

I've also added two new methods: `instana.SetLogger()` and `autoprofile.SetLogger()` that allow to use any 3rd party logger that conforms the `instana.LeveledLogger` interface, e.g. `github.com/sirupsen/logrus.Logger` or `go.uber.org/zap.SugaredLogger`. In this case the `INSTANA_DEBUG` variable needs to be handled explicitly, as different loggers may have different ways to set the min logging level.

This PR deprecates `autoprofile.SetLogLevel()` in favor of `autoprofile.SetLogger()`.

Closes https://github.com/instana/go-sensor/issues/13