### PR TITLE
Log grpc instrumentation errors

### DIFF
--- a/instrumentation/instagrpc/client_test.go
+++ b/instrumentation/instagrpc/client_test.go
@@ -84,14 +84,14 @@ func TestUnaryClientInterceptor(t *testing.T) {
 	traceIDHeader := mdRec.MD.Get(instana.FieldT)
 	require.Len(t, traceIDHeader, 1)
 
-	traceID, err := instana.Header2ID(traceIDHeader[0])
+	traceID, err := instana.ParseID(traceIDHeader[0])
 	require.NoError(t, err)
 	assert.Equal(t, span.TraceID, traceID)
 
 	spanIDHeader := mdRec.MD.Get(instana.FieldS)
 	require.Len(t, spanIDHeader, 1)
 
-	spanID, err := instana.Header2ID(spanIDHeader[0])
+	spanID, err := instana.ParseID(spanIDHeader[0])
 	require.NoError(t, err)
 	assert.Equal(t, span.SpanID, spanID)
 
@@ -227,14 +227,14 @@ func TestStreamClientInterceptor(t *testing.T) {
 	traceIDHeader := mdRec.MD.Get(instana.FieldT)
 	require.Len(t, traceIDHeader, 1)
 
-	traceID, err := instana.Header2ID(traceIDHeader[0])
+	traceID, err := instana.ParseID(traceIDHeader[0])
 	require.NoError(t, err)
 	assert.Equal(t, span.TraceID, traceID)
 
 	spanIDHeader := mdRec.MD.Get(instana.FieldS)
 	require.Len(t, spanIDHeader, 1)
 
-	spanID, err := instana.Header2ID(spanIDHeader[0])
+	spanID, err := instana.ParseID(spanIDHeader[0])
 	require.NoError(t, err)
 	assert.Equal(t, span.SpanID, spanID)
 

--- a/instrumentation/instagrpc/go.mod
+++ b/instrumentation/instagrpc/go.mod
@@ -3,7 +3,7 @@ module github.com/instana/go-sensor/instrumentation/instagrpc
 go 1.9
 
 require (
-	github.com/instana/go-sensor v1.7.1
+	github.com/instana/go-sensor v1.8.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.4.0
 	google.golang.org/grpc v1.15.0

--- a/instrumentation/instagrpc/go.sum
+++ b/instrumentation/instagrpc/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/felixge/httpsnoop v1.0.0 h1:gh8fMGz0rlOv/1WmRZm7OgncIOTsAj21iNJot48omJQ=
-github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -12,12 +10,8 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/instana/go-sensor v1.6.0 h1:Xm9UIF8qpoYBkR6eC9Lno8yDlh7wK+/p7FQYxy31T3c=
-github.com/instana/go-sensor v1.6.0/go.mod h1:m9fEK83zLD2yZy/DYNEAejZRwpzuTw6Jem4liiHb+2E=
-github.com/instana/go-sensor v1.7.0 h1:s/03yWEQzjEfccY976eezWiuvCM+tqbuVDNEDpCMV+c=
-github.com/instana/go-sensor v1.7.0/go.mod h1:vTJIeJG+q1U7q3iF63I3U97K3QakTvPld3+kFGiFrEQ=
-github.com/instana/go-sensor v1.7.1 h1:HLjhvuJp9+gcDO29eGEmoJ4RmpNDRMLqL787y98wTGY=
-github.com/instana/go-sensor v1.7.1/go.mod h1:vTJIeJG+q1U7q3iF63I3U97K3QakTvPld3+kFGiFrEQ=
+github.com/instana/go-sensor v1.8.0 h1:S7TSv5t5IwgCE5TmNosPtpp9nUHHWGB7FSf5DbJyQt0=
+github.com/instana/go-sensor v1.8.0/go.mod h1:lDfZvfAyo5DWJ2AvOHINRTUTG5TMdZNnwXXcFRtfZBE=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=
@@ -29,7 +23,6 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/instrumentation/instagrpc/server.go
+++ b/instrumentation/instagrpc/server.go
@@ -25,7 +25,7 @@ import (
 // If the handler returns an error or panics, the error message is then attached to the span logs.
 func UnaryServerInterceptor(sensor *instana.Sensor) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		sp := startServerSpan(ctx, info.FullMethod, "unary", sensor.Tracer())
+		sp := startServerSpan(ctx, info.FullMethod, "unary", sensor)
 		defer sp.Finish()
 
 		// log request in case handler panics
@@ -58,7 +58,7 @@ func UnaryServerInterceptor(sensor *instana.Sensor) grpc.UnaryServerInterceptor 
 // If the handler returns an error or panics, the error message is then attached to the span logs.
 func StreamServerInterceptor(sensor *instana.Sensor) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		sp := startServerSpan(ss.Context(), info.FullMethod, "stream", sensor.Tracer())
+		sp := startServerSpan(ss.Context(), info.FullMethod, "stream", sensor)
 		defer sp.Finish()
 
 		// log request in case handler panics
@@ -80,7 +80,8 @@ func StreamServerInterceptor(sensor *instana.Sensor) grpc.StreamServerIntercepto
 	}
 }
 
-func startServerSpan(ctx context.Context, method, callType string, tracer ot.Tracer) ot.Span {
+func startServerSpan(ctx context.Context, method, callType string, sensor *instana.Sensor) ot.Span {
+	tracer := sensor.Tracer()
 	opts := []ot.StartSpanOption{
 		ext.SpanKindRPCServer,
 		ot.Tags{
@@ -107,14 +108,11 @@ func startServerSpan(ctx context.Context, method, callType string, tracer ot.Tra
 	case nil:
 		opts = append(opts, ext.RPCServerOption(wireContext))
 	case ot.ErrSpanContextNotFound:
-		// TODO: log this using the sensor logger
-		// the remote did not provide any OpenTracing headers, so we just start a new trace
+		sensor.Logger().Debug("no tracing context found in request to ", method, ", starting a new trace")
 	case ot.ErrUnsupportedFormat:
-		// TODO: log this using the sensor logger
-		// log.Printf("WARN: unsupported grpc request context format")
+		sensor.Logger().Warn("unsupported grpc request context format for ", method)
 	default:
-		// TODO: log this using the sensor logger
-		// log.Printf("ERROR: failed to extract context")
+		sensor.Logger().Error("failed to extract request context for ", method, ": ", err)
 	}
 
 	return tracer.StartSpan("rpc-server", opts...)

--- a/instrumentation/instagrpc/server_test.go
+++ b/instrumentation/instagrpc/server_test.go
@@ -84,15 +84,9 @@ func TestUnaryServerInterceptor_WithClientTraceID(t *testing.T) {
 	client, err := newTestServiceClient(addr, time.Second)
 	require.NoError(t, err)
 
-	traceID, err := instana.ID2Header(1234567890)
-	require.NoError(t, err)
-
-	parentSpanID, err := instana.ID2Header(1)
-	require.NoError(t, err)
-
 	md := metadata.New(map[string]string{
-		instana.FieldT:            traceID,
-		instana.FieldS:            parentSpanID,
+		instana.FieldT:            instana.FormatID(1234567890),
+		instana.FieldS:            instana.FormatID(1),
 		instana.FieldB + "custom": "banana",
 	})
 
@@ -273,15 +267,9 @@ func TestStreamServerInterceptor_WithClientTraceID(t *testing.T) {
 	client, err := newTestServiceClient(addr, time.Second)
 	require.NoError(t, err)
 
-	traceID, err := instana.ID2Header(1234567890)
-	require.NoError(t, err)
-
-	parentSpanID, err := instana.ID2Header(1)
-	require.NoError(t, err)
-
 	md := metadata.New(map[string]string{
-		instana.FieldT:            traceID,
-		instana.FieldS:            parentSpanID,
+		instana.FieldT:            instana.FormatID(1234567890),
+		instana.FieldS:            instana.FormatID(1),
 		instana.FieldB + "custom": "banana",
 	})
 


### PR DESCRIPTION
This PR adds error logging to the `instagrpc` instrumentation. The logs are written using `(*instana.Sensor).Logger()` introduced in `v1.8.0`, hence an update of `go-sensor` is required.