### PR TITLE
Increase the time between the timer ticks to make calls to Stop() in-between more reliable

### DIFF
--- a/autoprofile/internal/timer_test.go
+++ b/autoprofile/internal/timer_test.go
@@ -10,26 +10,26 @@ import (
 
 func TestTimer_Restart(t *testing.T) {
 	var fired int
-	timer := internal.NewTimer(0, 10*time.Millisecond, func() {
+	timer := internal.NewTimer(0, 20*time.Millisecond, func() {
 		fired++
 	})
 
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
 	timer.Stop()
 
 	assert.Equal(t, 1, fired)
 
-	time.Sleep(30 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 1, fired)
 }
 
 func TestTimer_Sleep(t *testing.T) {
 	var fired int
-	timer := internal.NewTimer(10*time.Millisecond, 0, func() {
+	timer := internal.NewTimer(20*time.Millisecond, 0, func() {
 		fired++
 	})
 
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
 	timer.Stop()
 
 	assert.Equal(t, 1, fired)
@@ -37,12 +37,12 @@ func TestTimer_Sleep(t *testing.T) {
 
 func TestTimer_Sleep_Stopped(t *testing.T) {
 	var fired int
-	timer := internal.NewTimer(10*time.Millisecond, 0, func() {
+	timer := internal.NewTimer(20*time.Millisecond, 0, func() {
 		fired++
 	})
 
 	timer.Stop()
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
 
 	assert.Equal(t, 0, fired)
 }


### PR DESCRIPTION
The test occasionally fails on slower CI builds, so adding more time in between calls should™ help.

Closes https://github.com/instana/go-sensor/issues/94