### PR TITLE
Update min Go version in README to go1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![golang banner 2017-07-11](https://disznc.s3.amazonaws.com/Instana-Go-2017-07-11-at-16.01.45.png)
 
 # Instana Go Sensor
-go-sensor requires Go version 1.7 or greater.
+go-sensor requires Go version 1.8 or greater.
 
 The Instana Go sensor consists of two parts:
 


### PR DESCRIPTION
As of v1.6.0 the official support of go1.7 [has been dropped](https://github.com/instana/go-sensor/pull/84).