### PR TITLE
Add batched spans

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -91,6 +91,23 @@ type Span struct {
 	Data      typedSpanData `json:"data"`
 }
 
+func newSpan(span *spanS, from *fromS) Span {
+	data := RegisteredSpanType(span.Operation).ExtractData(span)
+
+	return Span{
+		TraceID:   span.context.TraceID,
+		ParentID:  span.context.ParentID,
+		SpanID:    span.context.SpanID,
+		Timestamp: uint64(span.Start.UnixNano()) / uint64(time.Millisecond),
+		Duration:  uint64(span.Duration) / uint64(time.Millisecond),
+		Name:      string(data.Type()),
+		Ec:        span.ErrorCount,
+		From:      from,
+		Kind:      int(data.Kind()),
+		Data:      data,
+	}
+}
+
 // SpanData contains fields to be sent in the `data` section of an OT span document. These fields are
 // common for all span types.
 type SpanData struct {

--- a/json_span.go
+++ b/json_span.go
@@ -94,8 +94,7 @@ type Span struct {
 
 func newSpan(span *spanS, from *fromS) Span {
 	data := RegisteredSpanType(span.Operation).ExtractData(span)
-
-	return Span{
+	sp := Span{
 		TraceID:   span.context.TraceID,
 		ParentID:  span.context.ParentID,
 		SpanID:    span.context.SpanID,
@@ -107,6 +106,15 @@ func newSpan(span *spanS, from *fromS) Span {
 		Kind:      int(data.Kind()),
 		Data:      data,
 	}
+
+	if bs, ok := span.Tags[batchSizeTag].(int); ok {
+		if bs > 1 {
+			sp.Batch = &batchInfo{Size: bs}
+		}
+		delete(span.Tags, batchSizeTag)
+	}
+
+	return sp
 }
 
 type batchInfo struct {

--- a/json_span.go
+++ b/json_span.go
@@ -86,6 +86,7 @@ type Span struct {
 	Duration  uint64        `json:"d"`
 	Name      string        `json:"n"`
 	From      *fromS        `json:"f"`
+	Batch     *batchInfo    `json:"b,omitempty"`
 	Kind      int           `json:"k"`
 	Ec        int           `json:"ec,omitempty"`
 	Data      typedSpanData `json:"data"`
@@ -106,6 +107,10 @@ func newSpan(span *spanS, from *fromS) Span {
 		Kind:      int(data.Kind()),
 		Data:      data,
 	}
+}
+
+type batchInfo struct {
+	Size int `json:"s"`
 }
 
 // SpanData contains fields to be sent in the `data` section of an OT span document. These fields are

--- a/recorder.go
+++ b/recorder.go
@@ -62,8 +62,6 @@ func (r *Recorder) RecordSpan(span *spanS) {
 		return
 	}
 
-	data := RegisteredSpanType(span.Operation).ExtractData(span)
-
 	r.Lock()
 	defer r.Unlock()
 
@@ -71,18 +69,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 		r.spans = r.spans[1:]
 	}
 
-	r.spans = append(r.spans, Span{
-		TraceID:   span.context.TraceID,
-		ParentID:  span.context.ParentID,
-		SpanID:    span.context.SpanID,
-		Timestamp: uint64(span.Start.UnixNano()) / uint64(time.Millisecond),
-		Duration:  uint64(span.Duration) / uint64(time.Millisecond),
-		Name:      string(data.Type()),
-		Ec:        span.ErrorCount,
-		From:      sensor.agent.from,
-		Kind:      int(data.Kind()),
-		Data:      data,
-	})
+	r.spans = append(r.spans, newSpan(span, sensor.agent.from))
 
 	if r.testMode || !sensor.agent.canSend() {
 		return

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -6,12 +6,12 @@ import (
 	instana "github.com/instana/go-sensor"
 	ext "github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecorderBasics(t *testing.T) {
-	opts := instana.Options{LogLevel: instana.Debug}
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&opts, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
 	span := tracer.StartSpan("http-client")
 	span.SetTag(string(ext.SpanKind), "exit")
@@ -22,6 +22,31 @@ func TestRecorderBasics(t *testing.T) {
 
 	// Validate GetQueuedSpans returns queued spans and clears the queue
 	spans := recorder.GetQueuedSpans()
-	assert.Equal(t, 1, len(spans))
+	assert.Len(t, spans, 1)
 	assert.Equal(t, 0, recorder.QueuedSpansCount())
+}
+
+func TestRecorder_BatchSpan(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	tracer.StartSpan("test-span", instana.BatchSize(2)).Finish()
+
+	spans := recorder.GetQueuedSpans()
+	require.Len(t, spans, 1)
+
+	require.NotNil(t, spans[0].Batch)
+	assert.Equal(t, 2, spans[0].Batch.Size)
+}
+
+func TestRecorder_BatchSpan_Single(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	tracer.StartSpan("test-span", instana.BatchSize(1)).Finish()
+
+	spans := recorder.GetQueuedSpans()
+	require.Len(t, spans, 1)
+
+	assert.Nil(t, spans[0].Batch)
 }

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,12 @@
+package instana
+
+import ot "github.com/opentracing/opentracing-go"
+
+const batchSizeTag = "batch_size"
+
+// BatchSize returns an opentracing.Tag to mark the span as a batched span representing
+// similar span categories. An example of such span would be batch writes to a queue,
+// a database, etc. If the batch size less than 2, then this option has no effect
+func BatchSize(n int) ot.Tag {
+	return ot.Tag{Key: batchSizeTag, Value: n}
+}


### PR DESCRIPTION
This PR adds support for batched spans. If the span represents a batch operation, e.g. inserting multiple records into a DB or publishing multiple messages to the queue, the size of this batch can now be provided as `instana.BatchSize()` tag. This value, if greater than 1, will be than sent to the agent in `b.s` field.