### PR TITLE
Fix error span handling

### DIFF
--- a/span.go
+++ b/span.go
@@ -114,7 +114,7 @@ func (r *spanS) LogFields(fields ...otlog.Field) {
 
 	for _, v := range fields {
 		// If this tag indicates an error, increase the error count
-		if v.Key() == "error" {
+		if v.Key() == "error" || v.Key() == "error.object" {
 			r.ErrorCount++
 		}
 	}


### PR DESCRIPTION
The `opentracing-go` library [has changed](https://github.com/opentracing/opentracing-go/pull/179) the log field key used for errors. We rely on this value to keep track of errors count and to mark these calls as erroneous later. After this update the errors logged using `otlog.Error()` don't affect the error count anymore, which may result in erroneous calls missing in Instana dashboard.

This PR changes the handling of error log fields by accepting both keys: `error` and `error.object`.