### PR TITLE
Add suppress tracing support

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -8,8 +8,6 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 )
 
-type textMapPropagator struct{}
-
 // Instana header constants
 const (
 	// FieldT Trace ID header
@@ -22,7 +20,7 @@ const (
 	FieldB = "x-instana-b-"
 )
 
-func (r *textMapPropagator) inject(spanContext ot.SpanContext, opaqueCarrier interface{}) error {
+func injectTraceContext(spanContext ot.SpanContext, opaqueCarrier interface{}) error {
 	sc, ok := spanContext.(SpanContext)
 	if !ok {
 		return ot.ErrInvalidSpanContext
@@ -91,7 +89,7 @@ func (r *textMapPropagator) inject(spanContext ot.SpanContext, opaqueCarrier int
 	return nil
 }
 
-func (r *textMapPropagator) extract(opaqueCarrier interface{}) (ot.SpanContext, error) {
+func extractTraceContext(opaqueCarrier interface{}) (ot.SpanContext, error) {
 	carrier, ok := opaqueCarrier.(ot.TextMapReader)
 	if !ok {
 		return nil, ot.ErrInvalidCarrier

--- a/propagation.go
+++ b/propagation.go
@@ -8,9 +8,7 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 )
 
-type textMapPropagator struct {
-	tracer *tracerS
-}
+type textMapPropagator struct{}
 
 // Instana header constants
 const (

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -10,7 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPropagation_Inject_HTTPHeadersCarrier(t *testing.T) {
+func TestTracer_Inject_Extract_HTTPHeaders(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("Foo", "bar")
+
+	headers := http.Header{}
+
+	require.NoError(t, tracer.Inject(sp.Context(), ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
+	sp.Finish()
+
+	sc, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
+	require.NoError(t, err)
+
+	assert.Equal(t, sp.Context(), sc)
+}
+
+func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 	examples := map[string]http.Header{
 		"add headers": {
 			"Authorization": {"Basic 123"},
@@ -50,17 +68,221 @@ func TestPropagation_Inject_HTTPHeadersCarrier(t *testing.T) {
 	}
 }
 
-func TestPropagation_TextMap(t *testing.T) {
-	examples := map[string]map[string]string{
-		"add values": {
-			"key1": "value1",
+func TestTracer_Extract_HTTPHeaders(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	headers := http.Header{
+		"Authorization":   {"Basic 123"},
+		"x-instana-t":     {"1314"},
+		"X-INSTANA-S":     {"2435"},
+		"X-Instana-L":     {"1"},
+		"X-Instana-B-foo": {"bar"},
+	}
+
+	sc, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
+	require.NoError(t, err)
+
+	assert.Equal(t, instana.SpanContext{
+		TraceID: 0x1314,
+		SpanID:  0x2435,
+		Baggage: map[string]string{
+			"foo": "bar",
 		},
-		"update values": {
-			"key1":            "value1",
-			"x-instana-t":     "1314",
-			"x-instana-s":     "1314",
-			"x-instana-l":     "1",
-			"x-instana-b-foo": "hello",
+	}, sc)
+}
+
+func TestTracer_Extract_HTTPHeaders_NoContext(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	headers := http.Header{
+		"Authorization": {"Basic 123"},
+	}
+
+	_, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
+	assert.Equal(t, ot.ErrSpanContextNotFound, err)
+}
+
+func TestTracer_Extract_HTTPHeaders_CorruptedContext(t *testing.T) {
+	examples := map[string]http.Header{
+		"missing trace id": {
+			"X-INSTANA-S": {"1314"},
+			"X-Instana-L": {"1"},
+		},
+		"malformed trace id": {
+			"x-instana-t": {"wrong"},
+			"X-INSTANA-S": {"1314"},
+			"X-Instana-L": {"1"},
+		},
+		"missing span id": {
+			"x-instana-t": {"1314"},
+			"X-Instana-L": {"1"},
+		},
+		"malformed span id": {
+			"x-instana-t": {"1314"},
+			"X-INSTANA-S": {"wrong"},
+			"X-Instana-L": {"1"},
+		},
+	}
+
+	for name, headers := range examples {
+		t.Run(name, func(t *testing.T) {
+			recorder := instana.NewTestRecorder()
+			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+			sp := tracer.StartSpan("test-span")
+			sp.SetBaggageItem("foo", "bar")
+
+			_, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
+			assert.Equal(t, ot.ErrSpanContextCorrupted, err)
+		})
+	}
+}
+
+func TestTracer_Inject_Extract_TextMap(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	carrier := make(map[string]string)
+
+	require.NoError(t, tracer.Inject(sp.Context(), ot.TextMap, ot.TextMapCarrier(carrier)))
+	sp.Finish()
+
+	sc, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
+	require.NoError(t, err)
+
+	assert.Equal(t, sp.Context(), sc)
+}
+
+func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	carrier := map[string]string{
+		"key1": "value1",
+	}
+
+	require.NoError(t, tracer.Inject(sp.Context(), ot.TextMap, ot.TextMapCarrier(carrier)))
+	sp.Finish()
+
+	spans := recorder.GetQueuedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	require.Equal(t, map[string]string{
+		"x-instana-t":     instana.FormatID(span.TraceID),
+		"x-instana-s":     instana.FormatID(span.SpanID),
+		"x-instana-l":     "1",
+		"x-instana-b-foo": "bar",
+		"key1":            "value1",
+	}, carrier)
+}
+
+func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	carrier := map[string]string{
+		"key1":            "value1",
+		"x-instana-t":     "1314",
+		"X-INSTANA-S":     "1314",
+		"X-Instana-L":     "1",
+		"X-INSTANA-b-foo": "hello",
+	}
+
+	require.NoError(t, tracer.Inject(sp.Context(), ot.TextMap, ot.TextMapCarrier(carrier)))
+	sp.Finish()
+
+	spans := recorder.GetQueuedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	require.Equal(t, map[string]string{
+		"x-instana-t":     instana.FormatID(span.TraceID),
+		"X-INSTANA-S":     instana.FormatID(span.SpanID),
+		"X-Instana-L":     "1",
+		"X-INSTANA-b-foo": "bar",
+		"key1":            "value1",
+	}, carrier)
+}
+
+func TestTracer_Extract_TextMap(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	carrier := map[string]string{
+		"key1":            "value1",
+		"x-instana-t":     "1314",
+		"x-instana-s":     "2435",
+		"x-instana-l":     "1",
+		"x-instana-b-foo": "bar",
+	}
+
+	sc, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
+	require.NoError(t, err)
+
+	assert.Equal(t, instana.SpanContext{
+		TraceID: 0x1314,
+		SpanID:  0x2435,
+		Baggage: map[string]string{
+			"foo": "bar",
+		},
+	}, sc)
+}
+
+func TestTracer_Extract_TextMap_NoContext(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test-span")
+	sp.SetBaggageItem("foo", "bar")
+
+	carrier := map[string]string{
+		"key1": "value1",
+	}
+
+	_, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
+	assert.Equal(t, ot.ErrSpanContextNotFound, err)
+}
+
+func TestTracer_Extract_TextMap_CorruptedContext(t *testing.T) {
+	examples := map[string]map[string]string{
+		"missing trace id": {
+			"x-instana-s": "1314",
+			"x-instana-l": "1",
+		},
+		"malformed trace id": {
+			"x-instana-t": "wrong",
+			"x-instana-s": "1314",
+			"x-instana-l": "1",
+		},
+		"missing span id": {
+			"x-instana-t": "1314",
+			"x-instana-l": "1",
+		},
+		"malformed span id": {
+			"x-instana-t": "1314",
+			"x-instana-s": "wrong",
+			"x-instana-l": "1",
 		},
 	}
 
@@ -72,20 +294,8 @@ func TestPropagation_TextMap(t *testing.T) {
 			sp := tracer.StartSpan("test-span")
 			sp.SetBaggageItem("foo", "bar")
 
-			require.NoError(t, tracer.Inject(sp.Context(), ot.TextMap, ot.TextMapCarrier(carrier)))
-			sp.Finish()
-
-			spans := recorder.GetQueuedSpans()
-			require.Len(t, spans, 1)
-
-			span := spans[0]
-			require.Equal(t, map[string]string{
-				"x-instana-t":     instana.FormatID(span.TraceID),
-				"x-instana-s":     instana.FormatID(span.SpanID),
-				"x-instana-l":     "1",
-				"x-instana-b-foo": "bar",
-				"key1":            "value1",
-			}, carrier)
+			_, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
+			assert.Equal(t, ot.ErrSpanContextCorrupted, err)
 		})
 	}
 }

--- a/span.go
+++ b/span.go
@@ -70,7 +70,9 @@ func (r *spanS) FinishWithOptions(opts ot.FinishOptions) {
 	}
 
 	r.Duration = duration
-	r.tracer.options.Recorder.RecordSpan(r)
+	if !r.context.Suppressed {
+		r.tracer.options.Recorder.RecordSpan(r)
+	}
 }
 
 func (r *spanS) appendLog(lr ot.LogRecord) {

--- a/span.go
+++ b/span.go
@@ -173,6 +173,11 @@ func (r *spanS) SetTag(key string, value interface{}) ot.Span {
 		r.ErrorCount++
 	}
 
+	if key == suppressTracingTag {
+		r.context.Suppressed = true
+		return r
+	}
+
 	r.Tags[key] = value
 
 	return r

--- a/span_context.go
+++ b/span_context.go
@@ -30,6 +30,7 @@ func NewRootSpanContext() SpanContext {
 func NewSpanContext(parent SpanContext) SpanContext {
 	c := parent.Clone()
 	c.SpanID, c.ParentID = randomID(), parent.SpanID
+	c.Suppressed = parent.Suppressed
 
 	return c
 }

--- a/span_context.go
+++ b/span_context.go
@@ -4,16 +4,14 @@ package instana
 type SpanContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
 	TraceID int64
-
 	// A probabilistically unique identifier for a span.
 	SpanID int64
-
 	// An optional parent span ID, 0 if this is the root span context.
 	ParentID int64
-
 	// Whether the trace is sampled.
 	Sampled bool
-
+	// Whether the trace is suppressed and should not be sent to the agent.
+	Suppressed bool
 	// The span's associated baggage.
 	Baggage map[string]string // initialized on first use
 }
@@ -61,10 +59,11 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 // Clone returns a deep copy of a SpanContext
 func (c SpanContext) Clone() SpanContext {
 	res := SpanContext{
-		TraceID:  c.TraceID,
-		SpanID:   c.SpanID,
-		ParentID: c.ParentID,
-		Sampled:  c.Sampled,
+		TraceID:    c.TraceID,
+		SpanID:     c.SpanID,
+		ParentID:   c.ParentID,
+		Sampled:    c.Sampled,
+		Suppressed: c.Suppressed,
 	}
 
 	if c.Baggage != nil {

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -77,10 +77,11 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 
 func TestSpanContext_Clone(t *testing.T) {
 	c := instana.SpanContext{
-		TraceID:  1,
-		SpanID:   2,
-		ParentID: 3,
-		Sampled:  true,
+		TraceID:    1,
+		SpanID:     2,
+		ParentID:   3,
+		Sampled:    true,
+		Suppressed: true,
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -12,15 +12,17 @@ func TestNewRootSpanContext(t *testing.T) {
 	assert.NotEmpty(t, c.TraceID)
 	assert.Equal(t, c.SpanID, c.TraceID)
 	assert.False(t, c.Sampled)
+	assert.False(t, c.Suppressed)
 	assert.Empty(t, c.Baggage)
 }
 
 func TestNewSpanContext(t *testing.T) {
 	parent := instana.SpanContext{
-		TraceID:  1,
-		SpanID:   2,
-		ParentID: 3,
-		Sampled:  true,
+		TraceID:    1,
+		SpanID:     2,
+		ParentID:   3,
+		Sampled:    true,
+		Suppressed: true,
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
@@ -31,6 +33,7 @@ func TestNewSpanContext(t *testing.T) {
 	assert.Equal(t, parent.TraceID, c.TraceID)
 	assert.Equal(t, parent.SpanID, c.ParentID)
 	assert.Equal(t, parent.Sampled, c.Sampled)
+	assert.Equal(t, parent.Suppressed, c.Suppressed)
 	assert.Equal(t, parent.Baggage, c.Baggage)
 
 	assert.NotEqual(t, parent.SpanID, c.SpanID)

--- a/span_test.go
+++ b/span_test.go
@@ -254,3 +254,24 @@ func TestSpanErrorLogFields(t *testing.T) {
 
 	assert.Len(t, logRecords, 1)
 }
+
+func TestSpan_Suppressed_StartSpanOption(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test", instana.SuppressTracing())
+	sp.Finish()
+
+	assert.Empty(t, recorder.GetQueuedSpans())
+}
+
+func TestSpan_Suppressed_SetTag(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test")
+	instana.SuppressTracing().Set(sp)
+	sp.Finish()
+
+	assert.Empty(t, recorder.GetQueuedSpans())
+}

--- a/tags.go
+++ b/tags.go
@@ -2,11 +2,20 @@ package instana
 
 import ot "github.com/opentracing/opentracing-go"
 
-const batchSizeTag = "batch_size"
+const (
+	batchSizeTag       = "batch_size"
+	suppressTracingTag = "suppress_tracing"
+)
 
 // BatchSize returns an opentracing.Tag to mark the span as a batched span representing
 // similar span categories. An example of such span would be batch writes to a queue,
 // a database, etc. If the batch size less than 2, then this option has no effect
 func BatchSize(n int) ot.Tag {
 	return ot.Tag{Key: batchSizeTag, Value: n}
+}
+
+// SuppressTracing returns an opentracing.Tag to mark the span and any of its child spans
+// as not to be sent to the agent
+func SuppressTracing() ot.Tag {
+	return ot.Tag{Key: suppressTracingTag, Value: true}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -15,9 +15,14 @@ type tracerS struct {
 	options TracerOptions
 }
 
-func (r *tracerS) Inject(sc ot.SpanContext, format interface{}, carrier interface{}) error {
+func (r *tracerS) Inject(spanContext ot.SpanContext, format interface{}, carrier interface{}) error {
 	switch format {
 	case ot.TextMap, ot.HTTPHeaders:
+		sc, ok := spanContext.(SpanContext)
+		if !ok {
+			return ot.ErrInvalidSpanContext
+		}
+
 		return injectTraceContext(sc, carrier)
 	}
 

--- a/tracer.go
+++ b/tracer.go
@@ -96,6 +96,7 @@ func NewTracerWithEverything(options *Options, recorder SpanRecorder) ot.Tracer 
 		ShouldSample:   shouldSample,
 		MaxLogsPerSpan: MaxLogsPerSpan}}
 	ret.textPropagator = &textMapPropagator{ret}
+	ret.textPropagator = &textMapPropagator{}
 
 	return ret
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -5,20 +5,19 @@ import (
 
 	instana "github.com/instana/go-sensor"
 	"github.com/stretchr/testify/assert"
-	//opentracing "github.com/opentracing/opentracing-go"
 )
 
 func TestTracerAPI(t *testing.T) {
 	tracer := instana.NewTracer()
-	assert.NotNil(t, tracer, "NewTracer returned nil")
+	assert.NotNil(t, tracer)
 
-	opts := instana.Options{LogLevel: instana.Debug}
 	recorder := instana.NewTestRecorder()
-	tracer = instana.NewTracerWithEverything(&opts, recorder)
-	assert.NotNil(t, tracer, "NewTracerWithEverything returned nil")
+
+	tracer = instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	assert.NotNil(t, tracer)
 
 	tracer = instana.NewTracerWithOptions(&instana.Options{})
-	assert.NotNil(t, tracer, "NewTracerWithOptions returned nil")
+	assert.NotNil(t, tracer)
 }
 
 func TestTracerBasics(t *testing.T) {
@@ -32,4 +31,14 @@ func TestTracerBasics(t *testing.T) {
 
 	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
+}
+
+func TestTracer_StartSpan_SuppressTracing(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test", instana.SuppressTracing())
+
+	sc := sp.Context().(instana.SpanContext)
+	assert.True(t, sc.Suppressed)
 }


### PR DESCRIPTION
This PR makes Go sensor respecting the `X-INSTANA-L` header value. The sensor suppresses tracing when this header is set to `"0"` and won't send the span created from this context or any of its child spans to the agent. This value is forwarded downstream to signal that dependent services should also suppress tracing on their side.

To suppress the trace starting from a user-created span, Go sensor provides a new `instana.SuppressTracing()` tag. Once set, it prevents the span and its children from being sent to the agent.