### PR TITLE
Don't start with exit spans

### DIFF
--- a/example_instrumentation_test.go
+++ b/example_instrumentation_test.go
@@ -1,6 +1,7 @@
 package instana_test
 
 import (
+	"context"
 	"net/http"
 
 	instana "github.com/instana/go-sensor"
@@ -23,6 +24,7 @@ func ExampleRoundTripper() {
 	// Here we initialize a new instance of instana.Sensor, however it is STRONGLY recommended
 	// to use a single instance throughout your application
 	sensor := instana.NewSensor("my-http-client")
+	span := sensor.Tracer().StartSpan("entry")
 
 	// http.DefaultTransport is used as a default RoundTripper, however you can provide
 	// your own implementation
@@ -30,7 +32,10 @@ func ExampleRoundTripper() {
 		Transport: instana.RoundTripper(sensor, nil),
 	}
 
-	// Execute request as usual
+	// Inject parent span into therequest context
+	ctx := instana.ContextWithSpan(context.Background(), span)
 	req, _ := http.NewRequest("GET", "https://www.instana.com", nil)
-	client.Do(req)
+
+	// Execute request as usual
+	client.Do(req.WithContext(ctx))
 }

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -53,11 +53,9 @@ func TracingHandlerFunc(sensor *Sensor, name string, handler http.HandlerFunc) h
 			// Be sure to capture any kind of panic / error
 			if err := recover(); err != nil {
 				if e, ok := err.(error); ok {
-					span.SetTag("message", e.Error())
 					span.SetTag("http.error", e.Error())
 					span.LogFields(otlog.Error(e))
 				} else {
-					span.SetTag("message", err)
 					span.SetTag("http.error", err)
 					span.LogFields(otlog.Object("error", err))
 				}
@@ -115,7 +113,6 @@ func RoundTripper(sensor *Sensor, original http.RoundTripper) http.RoundTripper 
 
 		resp, err := original.RoundTrip(req)
 		if err != nil {
-			span.SetTag("message", err.Error())
 			span.SetTag("http.error", err.Error())
 			span.LogFields(otlog.Error(err))
 			return resp, err

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -39,9 +39,9 @@ func TracingHandlerFunc(sensor *Sensor, name string, handler http.HandlerFunc) h
 		case nil:
 			opts = append(opts, ext.RPCServerOption(wireContext))
 		case ot.ErrSpanContextNotFound:
-			sensor.Logger().Debug("no span context provided with", req.Method, req.URL.Path)
+			sensor.Logger().Debug("no span context provided with ", req.Method, req.URL.Path)
 		case ot.ErrUnsupportedFormat:
-			sensor.Logger().Info("unsupported span context format provided with", req.Method, req.URL.Path)
+			sensor.Logger().Info("unsupported span context format provided with ", req.Method, req.URL.Path)
 		default:
 			sensor.Logger().Warn("failed to extract span context from the request:", err)
 		}

--- a/instrumentation/instagrpc/client.go
+++ b/instrumentation/instagrpc/client.go
@@ -73,7 +73,7 @@ func StreamClientInterceptor(sensor *instana.Sensor) grpc.StreamClientIntercepto
 func startClientSpan(parentSpan ot.Span, target, method, callType string, sensor *instana.Sensor) ot.Span {
 	host, port, err := net.SplitHostPort(target)
 	if err != nil {
-		sensor.Logger().Info("failed to extract server host and port from request metadata: %s", err)
+		sensor.Logger().Info("failed to extract server host and port from request metadata:", err)
 
 		// take our best guess and use :authority as a host if the net.SplitHostPort() fails to parse
 		host, port = target, ""

--- a/instrumentation/instagrpc/rpc_error.go
+++ b/instrumentation/instagrpc/rpc_error.go
@@ -21,6 +21,5 @@ func addRPCError(sp ot.Span, err interface{}) {
 	}
 
 	sp.SetTag("rpc.error", errMessage)
-	sp.SetTag("message", errMessage)
 	sp.LogFields(logField)
 }


### PR DESCRIPTION
In Instana trace must always begin with an entry span, representing an incoming request, a CLI command invocation, etc. Traces that does not start with an entry span are discarded and never get converted into a call. This PR changes the instrumentation of `http.Client` and `google.golang.org/grpc.{Unary,Stream}ClientInterceptor` that create exit spans, to disable tracing if there is no parent span provided via `context.Context`.

I've also made some minor formatting improvements to the log messages written by instrumentation code and removed the obsolete `message` span tag that contained duplicate error message.