### PR TITLE
Fix autoprofile timer data race

### DIFF
--- a/autoprofile/internal/timer_test.go
+++ b/autoprofile/internal/timer_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,40 +10,37 @@ import (
 )
 
 func TestTimer_Restart(t *testing.T) {
-	var fired int
+	var fired int64
 	timer := internal.NewTimer(0, 20*time.Millisecond, func() {
-		fired++
+		atomic.AddInt64(&fired, 1)
 	})
 
 	time.Sleep(30 * time.Millisecond)
 	timer.Stop()
 
-	assert.Equal(t, 1, fired)
+	assert.EqualValues(t, 1, atomic.LoadInt64(&fired))
 
 	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 1, fired)
+	assert.EqualValues(t, 1, atomic.LoadInt64(&fired))
 }
 
 func TestTimer_Sleep(t *testing.T) {
-	var fired int
-	timer := internal.NewTimer(20*time.Millisecond, 0, func() {
-		fired++
+	var fired int64
+	timer := internal.NewTimer(0, 20*time.Millisecond, func() {
+		atomic.AddInt64(&fired, 1)
 	})
 
 	time.Sleep(30 * time.Millisecond)
 	timer.Stop()
 
-	assert.Equal(t, 1, fired)
+	assert.EqualValues(t, 1, atomic.LoadInt64(&fired))
 }
 
 func TestTimer_Sleep_Stopped(t *testing.T) {
-	var fired int
 	timer := internal.NewTimer(20*time.Millisecond, 0, func() {
-		fired++
+		t.Error("stopped timer has fired")
 	})
 
 	timer.Stop()
 	time.Sleep(30 * time.Millisecond)
-
-	assert.Equal(t, 0, fired)
 }


### PR DESCRIPTION
Both `(internal.Timer).intervalDone` and `(internal.Timer).intervalTicker` are initialized in a goroutine after the delay has passed. If `(*internal.Timer).Stop()` is called shortly after the delay has passed, but before the ticker is initialized, there is a chance that the `t.intervalTicker != nil` check will be evaluated to `false`, but the ticker will still be created. As a result, the goroutine that executes `job()` will leak without any way to stop it.

Here is a diagram to illustrate the above
```
             internal.NewTimer()
                     |
                     |
                     v
      internal.Timer.delayTimer fires
                     |-------------------- (*internal.Timer).Stop() --------------> called
                     |                                                                |
                     |                                                                v
                     |                                                (internal.Timer).delayTimer stopped
                     |                                                                |
                     |                                                                v
                     |                          check whether the (internal.Timer).intervalTicker has already been initialized
                     |                                                                |
                     |                                                                v
                     |<------------------------------------------------------------ return
                     v
internal.Timer.intervalTickerDone initialized
                     |
                     v
  internal.Timer.intervalTicker initialized
                     |
                     v
           enter ticker goroutine
```

This PR synchronizes the ticker start and stop operations using a `sync.Mutex`.