### PR TITLE
Refactor sensor init

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -48,10 +48,17 @@ type agentS struct {
 	client *http.Client
 }
 
-func (r *agentS) init() {
-	r.client = &http.Client{Timeout: 5 * time.Second}
-	r.fsm = newFSM(r)
-	r.setFrom(&fromS{})
+func newAgent(sensor *sensorS) *agentS {
+	sensor.logger.Debug("initializing agent")
+
+	agent := &agentS{
+		sensor: sensor,
+		from:   &fromS{},
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+	agent.fsm = newFSM(agent)
+
+	return agent
 }
 
 func (r *agentS) makeURL(prefix string) string {

--- a/agent.go
+++ b/agent.go
@@ -50,15 +50,8 @@ type agentS struct {
 
 func (r *agentS) init() {
 	r.client = &http.Client{Timeout: 5 * time.Second}
-	r.fsm = r.initFsm()
+	r.fsm = newFSM(r)
 	r.setFrom(&fromS{})
-}
-
-func (r *agentS) initFsm() *fsmS {
-	ret := &fsmS{agent: r}
-	ret.init()
-
-	return ret
 }
 
 func (r *agentS) makeURL(prefix string) string {

--- a/meter.go
+++ b/meter.go
@@ -58,7 +58,6 @@ type EntityData struct {
 type meterS struct {
 	sensor            *sensorS
 	numGC             uint32
-	ticker            *time.Ticker
 	snapshotCountdown int
 }
 
@@ -67,12 +66,12 @@ func newMeter(sensor *sensorS) *meterS {
 
 	meter := &meterS{
 		sensor: sensor,
-		ticker: time.NewTicker(1 * time.Second),
 	}
 
+	ticker := time.NewTicker(1 * time.Second)
 	go func() {
 		meter.snapshotCountdown = 1
-		for range meter.ticker.C {
+		for range ticker.C {
 			if meter.sensor.agent.canSend() {
 				meter.snapshotCountdown--
 				var s *SnapshotS

--- a/options.go
+++ b/options.go
@@ -1,5 +1,10 @@
 package instana
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // Options allows the user to configure the to-be-initialized
 // sensor
 type Options struct {
@@ -12,4 +17,29 @@ type Options struct {
 	EnableAutoProfile           bool
 	MaxBufferedProfiles         int
 	IncludeProfilerFrames       bool
+}
+
+// DefaultOptions returns the default set of options to configure Instana sensor.
+// The service name is set to the name of current executable, the MaxBufferedSpans
+// and ForceTransmissionStartingAt are set to instana.DefaultMaxBufferedSpans and
+// instana.DefaultForceSpanSendAt correspondigly
+func DefaultOptions() *Options {
+	opts := &Options{}
+	opts.setDefaults()
+
+	return opts
+}
+
+func (opts *Options) setDefaults() {
+	if opts.MaxBufferedSpans == 0 {
+		opts.MaxBufferedSpans = DefaultMaxBufferedSpans
+	}
+
+	if opts.ForceTransmissionStartingAt == 0 {
+		opts.ForceTransmissionStartingAt = DefaultForceSpanSendAt
+	}
+
+	if opts.Service == "" {
+		opts.Service = filepath.Base(os.Args[0])
+	}
 }

--- a/sensor.go
+++ b/sensor.go
@@ -36,17 +36,8 @@ func (r *sensorS) init(options *Options) {
 
 	r.setOptions(options)
 	r.configureServiceName()
-	r.agent = r.initAgent()
+	r.agent = newAgent(r)
 	r.meter = r.initMeter()
-}
-
-func (r *sensorS) initAgent() *agentS {
-	r.logger.Debug("initializing agent")
-
-	ret := &agentS{sensor: r}
-	ret.init()
-
-	return ret
 }
 
 func (r *sensorS) initMeter() *meterS {

--- a/sensor.go
+++ b/sensor.go
@@ -37,16 +37,7 @@ func (r *sensorS) init(options *Options) {
 	r.setOptions(options)
 	r.configureServiceName()
 	r.agent = newAgent(r)
-	r.meter = r.initMeter()
-}
-
-func (r *sensorS) initMeter() *meterS {
-	r.logger.Debug("initializing meter")
-
-	ret := &meterS{sensor: r}
-	ret.init()
-
-	return ret
+	r.meter = newMeter(r)
 }
 
 func (r *sensorS) setOptions(options *Options) {

--- a/sensor.go
+++ b/sensor.go
@@ -3,7 +3,6 @@ package instana
 import (
 	"errors"
 	"os"
-	"path/filepath"
 
 	"github.com/instana/go-sensor/autoprofile"
 	"github.com/instana/go-sensor/logger"
@@ -24,59 +23,37 @@ type sensorS struct {
 
 var sensor *sensorS
 
-func (r *sensorS) init(options *Options) {
-	// sensor can be initialized explicitly or implicitly through OpenTracing global init
-	if r.meter != nil {
-		return
+func newSensor(options *Options) *sensorS {
+	if options == nil {
+		options = DefaultOptions()
+	} else {
+		options.setDefaults()
 	}
 
-	if r.logger == nil {
-		r.setLogger(defaultLogger)
+	s := &sensorS{
+		options:     options,
+		serviceName: options.Service,
 	}
+	s.setLogger(defaultLogger)
 
-	r.setOptions(options)
-	r.configureServiceName()
-	r.agent = newAgent(r)
-	r.meter = newMeter(r)
-}
-
-func (r *sensorS) setOptions(options *Options) {
-	r.options = options
-	if r.options == nil {
-		r.options = &Options{}
-	}
-
-	if r.options.MaxBufferedSpans == 0 {
-		r.options.MaxBufferedSpans = DefaultMaxBufferedSpans
-	}
-
-	if r.options.ForceTransmissionStartingAt == 0 {
-		r.options.ForceTransmissionStartingAt = DefaultForceSpanSendAt
+	// override service name with an env value if set
+	if name, ok := os.LookupEnv("INSTANA_SERVICE_NAME"); ok {
+		s.serviceName = name
 	}
 
 	// handle the legacy (instana.Options).LogLevel value if we use logger.Logger to log
-	if l, ok := r.logger.(*logger.Logger); ok {
-		setLogLevel(l, r.options.LogLevel)
+	if l, ok := s.logger.(*logger.Logger); ok {
+		setLogLevel(l, options.LogLevel)
 	}
+
+	s.agent = newAgent(s)
+	s.meter = newMeter(s)
+
+	return s
 }
 
 func (r *sensorS) setLogger(l LeveledLogger) {
 	r.logger = l
-}
-
-func (r *sensorS) configureServiceName() {
-	if name, ok := os.LookupEnv("INSTANA_SERVICE_NAME"); ok {
-		r.serviceName = name
-		return
-	}
-
-	if r.options != nil {
-		r.serviceName = r.options.Service
-	}
-
-	if r.serviceName == "" {
-		r.serviceName = filepath.Base(os.Args[0])
-	}
 }
 
 // InitSensor intializes the sensor (without tracing) to begin collecting
@@ -86,8 +63,7 @@ func InitSensor(options *Options) {
 		return
 	}
 
-	sensor = &sensorS{}
-	sensor.init(options)
+	sensor = newSensor(options)
 
 	// enable auto-profiling
 	if options.EnableAutoProfile {


### PR DESCRIPTION
This PR simplifies initial sensor setup by combining multiple `init*` functions for `meterS`, `agentS` and `sensorS` into a single constructor function. It also adds a new method `instana.DefaultOptions()` that returns an instance of `instana.Options` pre-filled with default values.