### PR TITLE
Propagate w3c trace context

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ The tracer is able to protocol and piggyback OpenTracing baggage, tags and logs.
 
 The Instana tracer will remap OpenTracing HTTP headers into Instana Headers, so parallel use with some other OpenTracing model is not possible. The Instana tracer is based on the OpenTracing Go basictracer with necessary modifications to map to the Instana tracing model. Also, sampling isn't implemented yet and will be focus of future work.
 
+## W3C Trace Context
+
+The Go sensor library implements minimal support of the [W3C Trace Context](https://www.w3.org/TR/trace-context/) by propagating the `traceparent` and `tracestate` HTTP headers. The [`instana.TracingHandlerFunc()`][instana.TracingHandlerFunc] middleware extracts these headers and adds them to the outgoing request without any changes. This is done before the underlying handler is called, so the user can than alter these values inside their handling function.
+
 ## Events API
 
 The sensor, be it instantiated explicitly or implicitly through the tracer, provides a simple wrapper API to send events to Instana as described in [its documentation](https://docs.instana.io/quick_start/api/#event-sdk-rest-web-service).
@@ -222,3 +226,5 @@ Following examples are included in the `example` folder:
 * [database/elasticsearch.go](./example/database/elasticsearch.go) - Demonstrates how to instrument a database client (Elasticsearch in this case)
 * [httpclient/multi_request.go](./example/httpclient/multi_request.go) - Demonstrates the instrumentation of an HTTP client
 * [many.go](./example/many.go) - Demonstrates how to create nested spans within the same execution context
+
+[instana.TracingHandlerFunc]: https://pkg.go.dev/github.com/instana/go-sensor/?tab=doc#TracingHandlerFunc

--- a/w3ctrace/middleware.go
+++ b/w3ctrace/middleware.go
@@ -1,0 +1,15 @@
+package w3ctrace
+
+import "net/http"
+
+// TracingHandlerFunc is an HTTP middleware that forwards the W3C context found in request
+// with the response
+func TracingHandlerFunc(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if trCtx, err := Extract(req.Header); err == nil {
+			Inject(trCtx, w.Header())
+		}
+
+		handler(w, req)
+	}
+}

--- a/w3ctrace/middleware_test.go
+++ b/w3ctrace/middleware_test.go
@@ -1,0 +1,51 @@
+package w3ctrace_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/instana/go-sensor/w3ctrace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracingHandlerFunc(t *testing.T) {
+	h := w3ctrace.TracingHandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Test", "value")
+		w.Write([]byte("Ok"))
+	})
+
+	resp := httptest.NewRecorder()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("traceparent", exampleTraceParent)
+	req.Header.Set("tracestate", exampleTraceState)
+
+	h(resp, req)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
+	assert.Equal(t, "Ok", resp.Body.String())
+
+	assert.Equal(t, "value", resp.Header().Get("X-Test"))
+	assert.Equal(t, exampleTraceParent, resp.Header().Get(w3ctrace.TraceParentHeader))
+	assert.Equal(t, exampleTraceState, resp.Header().Get(w3ctrace.TraceStateHeader))
+}
+
+func TestTracingHandlerFunc_NoContext(t *testing.T) {
+	h := w3ctrace.TracingHandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Test", "value")
+		w.Write([]byte("Ok"))
+	})
+
+	resp := httptest.NewRecorder()
+
+	req := httptest.NewRequest("GET", "/", nil)
+
+	h(resp, req)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
+	assert.Equal(t, "Ok", resp.Body.String())
+
+	assert.Equal(t, "value", resp.Header().Get("X-Test"))
+	assert.Empty(t, resp.Header().Get(w3ctrace.TraceParentHeader))
+	assert.Empty(t, resp.Header().Get(w3ctrace.TraceStateHeader))
+}

--- a/w3ctrace/w3ctrace.go
+++ b/w3ctrace/w3ctrace.go
@@ -1,0 +1,46 @@
+package w3ctrace
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+const (
+	// W3C trace context header names as defined by https://www.w3.org/TR/trace-context/
+	TraceParentHeader = "traceparent"
+	TraceStateHeader  = "tracestate"
+)
+
+var ErrContextNotFound = errors.New("no w3c context")
+
+// Context represents the W3C trace context
+type Context struct {
+	RawParent string
+	RawState  string
+}
+
+// Extract extracts the W3C trace context from HTTP headers. Returns ErrContextNotFound if
+// provided value doesn't contain traceparent header.
+func Extract(headers http.Header) (Context, error) {
+	var tr Context
+
+	for k, v := range headers {
+		if len(v) == 0 {
+			continue
+		}
+
+		switch {
+		case strings.EqualFold(k, TraceParentHeader):
+			tr.RawParent = v[0]
+		case strings.EqualFold(k, TraceStateHeader):
+			tr.RawState = v[0]
+		}
+	}
+
+	if tr.RawParent == "" {
+		return tr, ErrContextNotFound
+	}
+
+	return tr, nil
+}

--- a/w3ctrace/w3ctrace.go
+++ b/w3ctrace/w3ctrace.go
@@ -44,3 +44,16 @@ func Extract(headers http.Header) (Context, error) {
 
 	return tr, nil
 }
+
+// Inject adds the w3c trace context headers, overriding any previously set values
+func Inject(trCtx Context, headers http.Header) {
+	// delete existing headers ignoring the header name case
+	for k := range headers {
+		if strings.EqualFold(k, TraceParentHeader) || strings.EqualFold(k, TraceStateHeader) {
+			delete(headers, k)
+		}
+	}
+
+	headers.Set(TraceParentHeader, trCtx.RawParent)
+	headers.Set(TraceStateHeader, trCtx.RawState)
+}

--- a/w3ctrace/w3ctrace_test.go
+++ b/w3ctrace/w3ctrace_test.go
@@ -1,0 +1,52 @@
+package w3ctrace_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/instana/go-sensor/w3ctrace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	exampleTraceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	exampleTraceState  = "vendorname1=opaqueValue1 , vendorname2=opaqueValue2"
+)
+
+func TestExtract(t *testing.T) {
+	examples := map[string]struct {
+		ParentHeader string
+		StateHeader  string
+	}{
+		"lower case": {"traceparent", "tracestate"},
+		"upper case": {"TRACEPARENT", "TRACESTATE"},
+		"mixed case": {"Traceparent", "Tracestate"},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			headers := http.Header{}
+			// set raw headers to preserve header name case
+			headers[example.ParentHeader] = []string{exampleTraceParent}
+			headers[example.StateHeader] = []string{exampleTraceState}
+
+			tr, err := w3ctrace.Extract(headers)
+			require.NoError(t, err)
+
+			assert.Equal(t, w3ctrace.Context{
+				RawParent: exampleTraceParent,
+				RawState:  exampleTraceState,
+			}, tr)
+		})
+	}
+}
+
+func TestExtract_NoContext(t *testing.T) {
+	headers := http.Header{}
+	headers.Set(w3ctrace.TraceStateHeader, exampleTraceState)
+
+	_, err := w3ctrace.Extract(headers)
+	assert.Equal(t, w3ctrace.ErrContextNotFound, err)
+}
+RawParent

--- a/w3ctrace/w3ctrace_test.go
+++ b/w3ctrace/w3ctrace_test.go
@@ -49,4 +49,29 @@ func TestExtract_NoContext(t *testing.T) {
 	_, err := w3ctrace.Extract(headers)
 	assert.Equal(t, w3ctrace.ErrContextNotFound, err)
 }
-RawParent
+
+func TestInject(t *testing.T) {
+	examples := map[string]http.Header{
+		"add": {
+			"Authorization": []string{"Basic 123"},
+		},
+		"update": {
+			"Authorization": []string{"Basic 123"},
+			"traceparent":   []string{"00-abcdef1-01"},
+			"TraceState":    []string{"x=y"},
+		},
+	}
+
+	for name, headers := range examples {
+		t.Run(name, func(t *testing.T) {
+			w3ctrace.Inject(w3ctrace.Context{
+				RawParent: exampleTraceParent,
+				RawState:  exampleTraceState,
+			}, headers)
+
+			assert.Equal(t, "Basic 123", headers.Get("Authorization"))
+			assert.Equal(t, exampleTraceParent, headers.Get(w3ctrace.TraceParentHeader))
+			assert.Equal(t, exampleTraceState, headers.Get(w3ctrace.TraceStateHeader))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds minimum support for [W3C trace context](https://www.w3.org/TR/trace-context/) as described in the spec:

> At a minimum they MUST propagate the `traceparent` and `tracestate` headers and guarantee traces are not broken. This behavior is also referred to as forwarding a trace.

The `instana.TracingHandlerFunc()` middleware will extract the W3C trace context headers from an incoming request and make sure they are added to the response without any changes.