### PR TITLE
Mark HTTP entry spans as errors if the response status is 500 and above

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -76,6 +76,10 @@ func TracingHandlerFunc(sensor *Sensor, name string, handler http.HandlerFunc) h
 		w3ctrace.TracingHandlerFunc(handler)(wrapped, req.WithContext(ctx))
 
 		if wrapped.Status > 0 {
+			if wrapped.Status > http.StatusInternalServerError {
+				span.SetTag("http.error", http.StatusText(wrapped.Status))
+			}
+
 			span.SetTag("http.status", wrapped.Status)
 		}
 	}


### PR DESCRIPTION
Whenever the instrumented handler responds with an HTTP error (status is 500 and above), the call will be marked as an error to be highlighted in the dashboard and also appear in the errors list.