### PR TITLE
Participate in w3c context

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -102,7 +102,12 @@ func addW3CTraceContext(h http.Header, sc SpanContext) {
 		})
 	}
 
+	p := trCtx.Parent()
+	p.ParentID = spanID
+
+	trCtx.RawParent = p.String()
 	trCtx.RawState = trCtx.State().Add(w3ctrace.VendorInstana, traceID+";"+spanID).String()
+
 	w3ctrace.Inject(trCtx, h)
 }
 

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -11,69 +11,94 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTracer_Inject_Extract_HTTPHeaders(t *testing.T) {
-	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
-
-	sp := tracer.StartSpan("test-span")
-	sp.SetBaggageItem("Foo", "bar")
-
-	headers := http.Header{}
-
-	require.NoError(t, tracer.Inject(sp.Context(), ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
-	sp.Finish()
-
-	sc, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
-	require.NoError(t, err)
-
-	assert.Equal(t, sp.Context(), sc)
-}
-
 func TestTracer_Inject_HTTPHeaders(t *testing.T) {
-	examples := map[string]http.Header{
-		"add headers": {
-			"Authorization": {"Basic 123"},
+	examples := map[string]struct {
+		SpanContext instana.SpanContext
+		Headers     http.Header
+		Expected    http.Header
+	}{
+		"no trace context": {
+			SpanContext: instana.SpanContext{
+				TraceID: 0x2435,
+				SpanID:  0x3546,
+				Baggage: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Headers: http.Header{
+				"Authorization": {"Basic 123"},
+			},
+			Expected: http.Header{
+				"Authorization":   {"Basic 123"},
+				"X-Instana-T":     {"2435"},
+				"X-Instana-S":     {"3546"},
+				"X-Instana-L":     {"1"},
+				"X-Instana-B-Foo": {"bar"},
+				"Traceparent":     {"00-00000000000000000000000000002435-0000000000003546-01"},
+				"Tracestate":      {"in=2435;3546"},
+			},
 		},
-		"update headers": {
-			"Authorization":   {"Basic 123"},
-			"x-instana-t":     {"1314"},
-			"X-INSTANA-S":     {"1314"},
-			"X-Instana-L":     {"1"},
-			"X-Instana-B-foo": {"hello"},
+		"with instana trace": {
+			SpanContext: instana.SpanContext{
+				TraceID: 0x2435,
+				SpanID:  0x3546,
+				Baggage: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Headers: http.Header{
+				"Authorization":   {"Basic 123"},
+				"x-instana-t":     {"1314"},
+				"X-INSTANA-S":     {"1314"},
+				"X-Instana-L":     {"1"},
+				"X-Instana-B-foo": {"hello"},
+			},
+			Expected: http.Header{
+				"Authorization":   {"Basic 123"},
+				"X-Instana-T":     {"2435"},
+				"X-Instana-S":     {"3546"},
+				"X-Instana-L":     {"1"},
+				"X-Instana-B-Foo": {"bar"},
+				"Traceparent":     {"00-00000000000000000000000000002435-0000000000003546-01"},
+				"Tracestate":      {"in=2435;3546"},
+			},
 		},
-	}
-
-	for name, headers := range examples {
-		t.Run(name, func(t *testing.T) {
-			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
-
-			sc := instana.SpanContext{
+		"with w3c trace": {
+			SpanContext: instana.SpanContext{
 				TraceID: 0x2435,
 				SpanID:  0x3546,
 				ForeignParent: w3ctrace.Context{
-					RawParent: "w3cparent",
-					RawState:  "vendor=w3cstate",
+					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+					RawState:  "rojo=00f067aa0ba902b7",
 				},
 				Baggage: map[string]string{
 					"foo": "bar",
 				},
-			}
+			},
+			Headers: http.Header{
+				"Authorization": {"Basic 123"},
+				"Traceparent":   {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+				"Tracestate":    {"rojo=00f067aa0ba902b7"},
+			},
+			Expected: http.Header{
+				"Authorization":   {"Basic 123"},
+				"X-Instana-T":     {"2435"},
+				"X-Instana-S":     {"3546"},
+				"X-Instana-L":     {"1"},
+				"X-Instana-B-Foo": {"bar"},
+				"Traceparent":     {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+				"Tracestate":      {"in=2435;3546,rojo=00f067aa0ba902b7"},
+			},
+		},
+	}
 
-			require.NoError(t, tracer.Inject(sc, ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			recorder := instana.NewTestRecorder()
+			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
-			// Instana trace context
-			assert.Equal(t, "2435", headers.Get("X-Instana-T"))
-			assert.Equal(t, "3546", headers.Get("X-Instana-S"))
-			assert.Equal(t, "1", headers.Get("X-Instana-L"))
-			assert.Equal(t, "bar", headers.Get("X-Instana-B-foo"))
-			// W3C trace context
-			assert.Equal(t, "w3cparent", headers.Get(w3ctrace.TraceParentHeader))
-			assert.Equal(t, "in=2435;3546,vendor=w3cstate", headers.Get(w3ctrace.TraceStateHeader))
-			// Original headers
-			assert.Equal(t, "Basic 123", headers.Get("Authorization"))
-
-			assert.Len(t, headers, 7)
+			require.NoError(t, tracer.Inject(example.SpanContext, ot.HTTPHeaders, ot.HTTPHeadersCarrier(example.Headers)))
+			assert.Equal(t, example.Expected, example.Headers)
 		})
 	}
 }
@@ -219,24 +244,6 @@ func TestTracer_Extract_HTTPHeaders_CorruptedContext(t *testing.T) {
 			assert.Equal(t, ot.ErrSpanContextCorrupted, err)
 		})
 	}
-}
-
-func TestTracer_Inject_Extract_TextMap(t *testing.T) {
-	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
-
-	sp := tracer.StartSpan("test-span")
-	sp.SetBaggageItem("foo", "bar")
-
-	carrier := make(map[string]string)
-
-	require.NoError(t, tracer.Inject(sp.Context(), ot.TextMap, ot.TextMapCarrier(carrier)))
-	sp.Finish()
-
-	sc, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
-	require.NoError(t, err)
-
-	assert.Equal(t, sp.Context(), sc)
 }
 
 func TestTracer_Inject_TextMap_AddValues(t *testing.T) {

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -86,7 +86,7 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 				"X-Instana-S":     {"3546"},
 				"X-Instana-L":     {"1"},
 				"X-Instana-B-Foo": {"bar"},
-				"Traceparent":     {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+				"Traceparent":     {"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000003546-01"},
 				"Tracestate":      {"in=2435;3546,rojo=00f067aa0ba902b7"},
 			},
 		},

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -53,7 +53,7 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 				SpanID:  0x3546,
 				ForeignParent: w3ctrace.Context{
 					RawParent: "w3cparent",
-					RawState:  "w3cstate",
+					RawState:  "vendor=w3cstate",
 				},
 				Baggage: map[string]string{
 					"foo": "bar",
@@ -69,7 +69,7 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 			assert.Equal(t, "bar", headers.Get("X-Instana-B-foo"))
 			// W3C trace context
 			assert.Equal(t, "w3cparent", headers.Get(w3ctrace.TraceParentHeader))
-			assert.Equal(t, "w3cstate", headers.Get(w3ctrace.TraceStateHeader))
+			assert.Equal(t, "in=2435;3546,vendor=w3cstate", headers.Get(w3ctrace.TraceStateHeader))
 			// Original headers
 			assert.Equal(t, "Basic 123", headers.Get("Authorization"))
 

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -27,6 +27,13 @@ type Context struct {
 	RawState  string
 }
 
+// New initializes a new W3C trace context from given parent
+func New(parent Parent) Context {
+	return Context{
+		RawParent: parent.String(),
+	}
+}
+
 // Extract extracts the W3C trace context from HTTP headers. Returns ErrContextNotFound if
 // provided value doesn't contain traceparent header.
 func Extract(headers http.Header) (Context, error) {

--- a/w3ctrace/context_test.go
+++ b/w3ctrace/context_test.go
@@ -14,6 +14,16 @@ const (
 	exampleTraceState  = "vendorname1=opaqueValue1 , vendorname2=opaqueValue2"
 )
 
+func TestNew(t *testing.T) {
+	p := w3ctrace.Parent{
+		Version:  w3ctrace.Version_Max,
+		TraceID:  "1234",
+		ParentID: "5678",
+	}
+
+	assert.Equal(t, w3ctrace.Context{RawParent: p.String()}, w3ctrace.New(p))
+}
+
 func TestExtract(t *testing.T) {
 	examples := map[string]struct {
 		ParentHeader string

--- a/w3ctrace/state.go
+++ b/w3ctrace/state.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// Instana vendor key in the `tracestate` list
+const VendorInstana = "in"
+
 // State is list of key=value pairs representing vendor-specific data in the trace context
 type State []string
 

--- a/w3ctrace/state.go
+++ b/w3ctrace/state.go
@@ -48,6 +48,19 @@ func (st State) Add(vendor, data string) State {
 	return newSt
 }
 
+// Fetch retrieves stored vendor-specific data for given vendor
+func (st State) Fetch(vendor string) (string, bool) {
+	prefix := vendor + "="
+
+	for _, vd := range st {
+		if strings.HasPrefix(vd, prefix) {
+			return strings.TrimPrefix(vd, prefix), true
+		}
+	}
+
+	return "", false
+}
+
 // Remove returns a new state without data for specified vendor. It returns the same state if vendor is empty
 func (st State) Remove(vendor string) State {
 	if vendor == "" {

--- a/w3ctrace/state_test.go
+++ b/w3ctrace/state_test.go
@@ -73,6 +73,25 @@ func TestState_Add_MaximumReached(t *testing.T) {
 	assert.Equal(t, st[w3ctrace.MaxStateEntries-1], "vendor1=data")
 }
 
+func TestState_Fetch(t *testing.T) {
+	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
+
+	t.Run("existing", func(t *testing.T) {
+		if vd, ok := st.Fetch("rojo"); assert.True(t, ok) {
+			assert.Equal(t, "00f067aa0ba902b7", vd)
+		}
+
+		if vd, ok := st.Fetch("congo"); assert.True(t, ok) {
+			assert.Equal(t, "t61rcWkgMzE", vd)
+		}
+	})
+
+	t.Run("non-existing", func(t *testing.T) {
+		_, ok := st.Fetch("vendor")
+		assert.False(t, ok)
+	})
+}
+
 func TestState_Remove(t *testing.T) {
 	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
 


### PR DESCRIPTION
This PR implements [W3C trace participation](https://w3c.github.io/trace-context/#design-overview) for Instana Go sensor in a following way:

* The parent ID in `traceparent` header is updated to be the span ID of Instana exit span
* The `sampled` flag in `traceparent` header represents whether Instana has traced this call or not
* Go sensor adds it's trace context to the `tracestate` header
* Instana trace context takes precedence over W3C values, i.e. the call will be not be sampled if the `X-INSTANA-L` header is set to `0` despite the value of [W3C `sampled` flag](https://w3c.github.io/trace-context/#sampled-flag) and vice versa.