### PR TITLE
Add synthetic call support

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -48,6 +48,10 @@ func TracingHandlerFunc(sensor *Sensor, name string, handler http.HandlerFunc) h
 			sensor.Logger().Warn("failed to extract span context from the request:", err)
 		}
 
+		if req.Header.Get(FieldSynthetic) == "1" {
+			opts = append(opts, syntheticCall())
+		}
+
 		span := tracer.StartSpan("g.http", opts...)
 		defer span.Finish()
 

--- a/json_span.go
+++ b/json_span.go
@@ -89,6 +89,7 @@ type Span struct {
 	Batch     *batchInfo    `json:"b,omitempty"`
 	Kind      int           `json:"k"`
 	Ec        int           `json:"ec,omitempty"`
+	Synthetic bool          `json:"sy,omitempty"`
 	Data      typedSpanData `json:"data"`
 }
 

--- a/json_span.go
+++ b/json_span.go
@@ -115,6 +115,11 @@ func newSpan(span *spanS, from *fromS) Span {
 		delete(span.Tags, batchSizeTag)
 	}
 
+	if syn, ok := span.Tags[syntheticCallTag].(bool); ok {
+		sp.Synthetic = syn
+		delete(span.Tags, syntheticCallTag)
+	}
+
 	return sp
 }
 

--- a/propagation.go
+++ b/propagation.go
@@ -18,6 +18,9 @@ const (
 	FieldL = "x-instana-l"
 	// FieldB OT Baggage header
 	FieldB = "x-instana-b-"
+	// FieldSynthetic if set to 1, marks the call as synthetic, e.g.
+	// a healthcheck request
+	FieldSynthetic = "x-instana-synthetic"
 )
 
 func injectTraceContext(sc SpanContext, opaqueCarrier interface{}) error {

--- a/tags.go
+++ b/tags.go
@@ -5,6 +5,7 @@ import ot "github.com/opentracing/opentracing-go"
 const (
 	batchSizeTag       = "batch_size"
 	suppressTracingTag = "suppress_tracing"
+	syntheticCallTag   = "synthetic_call"
 )
 
 // BatchSize returns an opentracing.Tag to mark the span as a batched span representing
@@ -18,4 +19,8 @@ func BatchSize(n int) ot.Tag {
 // as not to be sent to the agent
 func SuppressTracing() ot.Tag {
 	return ot.Tag{Key: suppressTracingTag, Value: true}
+}
+
+func syntheticCall() ot.Tag {
+	return ot.Tag{Key: syntheticCallTag, Value: true}
 }


### PR DESCRIPTION
Incoming HTTP calls can be [marked as synthetic](https://docs.instana.io/application_monitoring/endpoints/#synthetic-calls) to be filtered out in the dashboard later. This PR adds support for `X-INSTANA-SYNTHETIC` header: if set to `1`, the entry span will be marked as synthetic before sending it to the agent.