### PR TITLE
Record foreign trace context parent to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,10 @@ The Instana tracer will remap OpenTracing HTTP headers into Instana Headers, so 
 
 ## W3C Trace Context
 
-The Go sensor library implements minimal support of the [W3C Trace Context](https://www.w3.org/TR/trace-context/) by propagating the `traceparent` and `tracestate` HTTP headers. The [`instana.TracingHandlerFunc()`][instana.TracingHandlerFunc] middleware extracts these headers and adds them to the outgoing request without any changes. This is done before the underlying handler is called, so the user can than alter these values inside their handling function.
+The Go sensor library fully supports [the W3C Trace Context standard](https://www.w3.org/TR/trace-context/):
+
+* An [instrumented `http.Client`][instana.RoundTripper] sends the `traceparent` and `tracestate` headers, updating them with the exit span ID and flags.
+* Any `http.Handler` instrumented with [`instana.TracingHandlerFunc()`][instana.TracingHandlerFunc] picks up the trace context passed in the `traceparent` header, potentially restoring the trace from `tracestate` even if the upstream service is not instrumented with Instana.
 
 ## Events API
 
@@ -228,3 +231,4 @@ Following examples are included in the `example` folder:
 * [many.go](./example/many.go) - Demonstrates how to create nested spans within the same execution context
 
 [instana.TracingHandlerFunc]: https://pkg.go.dev/github.com/instana/go-sensor/?tab=doc#TracingHandlerFunc
+[instana.RoundTripper]: https://pkg.go.dev/github.com/instana/go-sensor/?tab=doc#RoundTripper

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -41,9 +41,9 @@ func TracingHandlerFunc(sensor *Sensor, name string, handler http.HandlerFunc) h
 		case nil:
 			opts = append(opts, ext.RPCServerOption(wireContext))
 		case ot.ErrSpanContextNotFound:
-			sensor.Logger().Debug("no span context provided with ", req.Method, req.URL.Path)
+			sensor.Logger().Debug("no span context provided with ", req.Method, " ", req.URL.Path)
 		case ot.ErrUnsupportedFormat:
-			sensor.Logger().Info("unsupported span context format provided with ", req.Method, req.URL.Path)
+			sensor.Logger().Info("unsupported span context format provided with ", req.Method, " ", req.URL.Path)
 		default:
 			sensor.Logger().Warn("failed to extract span context from the request:", err)
 		}

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -24,8 +24,10 @@ func TestTracingHandlerFunc_Write(t *testing.T) {
 		fmt.Fprintln(w, "Ok")
 	})
 
+	req := httptest.NewRequest(http.MethodGet, "/test?q=classified", nil)
+
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/test?q=classified", nil))
+	h.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "Ok\n", rec.Body.String())
@@ -37,6 +39,8 @@ func TestTracingHandlerFunc_Write(t *testing.T) {
 	assert.Equal(t, 0, span.Ec)
 	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
 	assert.False(t, span.Synthetic)
+
+	assert.Nil(t, span.ForeignParent)
 
 	require.IsType(t, instana.HTTPSpanData{}, span.Data)
 	data := span.Data.(instana.HTTPSpanData)
@@ -117,34 +121,74 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 	}, data.Tags)
 }
 
-func TestTracingHandlerFunc_W3CTraceContext(t *testing.T) {
-	const (
-		traceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-01"
-		traceState  = "vendorname1=opaqueValue1,in=abc123;def456"
-	)
+func TestTracingHandlerFunc_W3CTraceContext_ForeignParent(t *testing.T) {
+	examples := map[string]struct {
+		IncomingHeaders map[string]string
+		Expected        *instana.ForeignParent
+	}{
+		"incoming w3c, no instana headers": {
+			IncomingHeaders: map[string]string{
+				w3ctrace.TraceParentHeader: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				w3ctrace.TraceStateHeader:  "in=abc123;def456,vendorname1=opaqueValue1",
+			},
+			Expected: &instana.ForeignParent{
+				TraceID:          "4bf92f3577b34da6a3ce929d0e0e4736",
+				ParentID:         "00f067aa0ba902b7",
+				LatestTraceState: "in=abc123;def456",
+			},
+		},
+		"incoming w3c, with instana headers, latest state from instana": {
+			IncomingHeaders: map[string]string{
+				w3ctrace.TraceParentHeader: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				w3ctrace.TraceStateHeader:  "in=abc123;def456,vendorname1=opaqueValue1",
+				instana.FieldT:             "abc123",
+				instana.FieldS:             "def456",
+			},
+		},
+		"incoming w3c, with instana headers, latest state not from instana": {
+			IncomingHeaders: map[string]string{
+				w3ctrace.TraceParentHeader: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				w3ctrace.TraceStateHeader:  "vendorname1=opaqueValue1,in=abc123;def456",
+				instana.FieldT:             "abc123",
+				instana.FieldS:             "def456",
+			},
+			Expected: &instana.ForeignParent{
+				TraceID:          "4bf92f3577b34da6a3ce929d0e0e4736",
+				ParentID:         "00f067aa0ba902b7",
+				LatestTraceState: "vendorname1=opaqueValue1",
+			},
+		},
+	}
 
-	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
-	}, recorder))
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			recorder := instana.NewTestRecorder()
+			s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
+				Service: "go-sensor-test",
+			}, recorder))
 
-	h := instana.TracingHandlerFunc(s, "test-handler", func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprintln(w, "Ok")
-	})
+			h := instana.TracingHandlerFunc(s, "test-handler", func(w http.ResponseWriter, req *http.Request) {
+				fmt.Fprintln(w, "Ok")
+			})
 
-	rec := httptest.NewRecorder()
+			rec := httptest.NewRecorder()
 
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set(w3ctrace.TraceParentHeader, traceParent)
-	req.Header.Set(w3ctrace.TraceStateHeader, traceState)
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			for k, v := range example.IncomingHeaders {
+				req.Header.Set(k, v)
+			}
 
-	h.ServeHTTP(rec, req)
+			h.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "Ok\n", rec.Body.String())
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, "Ok\n", rec.Body.String())
 
-	assert.Equal(t, traceParent, rec.Header().Get(w3ctrace.TraceParentHeader))
-	assert.Equal(t, traceState, rec.Header().Get(w3ctrace.TraceStateHeader))
+			spans := recorder.GetQueuedSpans()
+			require.Len(t, spans, 1)
+
+			assert.Equal(t, example.Expected, spans[0].ForeignParent)
+		})
+	}
 }
 
 func TestTracingHandlerFunc_SyntheticCall(t *testing.T) {

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -126,7 +126,7 @@ func TestTracingHandlerFunc_W3CTraceContext_ForeignParent(t *testing.T) {
 		IncomingHeaders map[string]string
 		Expected        *instana.ForeignParent
 	}{
-		"incoming w3c, no instana headers": {
+		"incoming w3c, no instana headers, latest state from instana": {
 			IncomingHeaders: map[string]string{
 				w3ctrace.TraceParentHeader: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 				w3ctrace.TraceStateHeader:  "in=abc123;def456,vendorname1=opaqueValue1",

--- a/propagation.go
+++ b/propagation.go
@@ -152,10 +152,10 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 
 func addW3CTraceContext(h http.Header, sc SpanContext) {
 	traceID, spanID := FormatID(sc.TraceID), FormatID(sc.SpanID)
+	trCtx := sc.W3CContext
 
 	// check for an existing w3c trace
-	trCtx, ok := sc.ForeignParent.(w3ctrace.Context)
-	if !ok {
+	if trCtx.IsZero() {
 		// initiate trace if none
 		trCtx = w3ctrace.New(w3ctrace.Parent{
 			Version:  w3ctrace.Version_Max,
@@ -190,7 +190,7 @@ func pickupW3CTraceContext(h http.Header, sc *SpanContext) {
 	if err != nil {
 		return
 	}
-	sc.ForeignParent = trCtx
+	sc.W3CContext = trCtx
 
 	vd, ok := trCtx.State().Fetch(w3ctrace.VendorInstana)
 	if !ok {

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -300,7 +300,6 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 				TraceID: 0x1314,
 				SpanID:  0x2435,
 				Baggage: map[string]string{},
-				Foreign: true,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -313,10 +312,7 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 				"tracestate":  "in=1314;2435,rojo=00f067aa0ba902b7",
 			},
 			Expected: instana.SpanContext{
-				TraceID: 0x1314,
-				SpanID:  0x2435,
 				Baggage: map[string]string{},
-				Foreign: true,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "in=1314;2435,rojo=00f067aa0ba902b7",
@@ -351,20 +347,6 @@ func TestTracer_Extract_HTTPHeaders_NoContext(t *testing.T) {
 		"no w3c trace context": {
 			Headers: map[string]string{
 				"Authorization": "Basic 123",
-			},
-		},
-		"w3c trace context without instana entry": {
-			Headers: map[string]string{
-				"Authorization": "Basic 123",
-				"traceparent":   "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-				"tracestate":    "rojo=00f067aa0ba902b7",
-			},
-		},
-		"w3c trace context with malformed instana entry": {
-			Headers: map[string]string{
-				"Authorization": "Basic 123",
-				"traceparent":   "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-				"tracestate":    "rojo=00f067aa0ba902b7,in=hello",
 			},
 		},
 	}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -117,7 +117,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 			SpanContext: instana.SpanContext{
 				TraceID: 0x2435,
 				SpanID:  0x3546,
-				ForeignParent: w3ctrace.Context{
+				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
 					RawState:  "rojo=00f067aa0ba902b7",
 				},
@@ -135,7 +135,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 			SpanContext: instana.SpanContext{
 				TraceID: 0x2435,
 				SpanID:  0x3546,
-				ForeignParent: w3ctrace.Context{
+				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
 				},
@@ -166,7 +166,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 			SpanContext: instana.SpanContext{
 				TraceID: 0x2435,
 				SpanID:  0x3546,
-				ForeignParent: w3ctrace.Context{
+				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
 					RawState:  "rojo=00f067aa0ba902b7",
 				},
@@ -183,7 +183,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 			SpanContext: instana.SpanContext{
 				TraceID: 0x2435,
 				SpanID:  0x3546,
-				ForeignParent: w3ctrace.Context{
+				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
 				},
@@ -202,11 +202,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
-
 			headers := http.Header{}
-			if example.SpanContext.ForeignParent != nil {
-				w3ctrace.Inject(example.SpanContext.ForeignParent.(w3ctrace.Context), headers)
-			}
 
 			require.NoError(t, tracer.Inject(example.SpanContext, ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
 			assert.Equal(t, example.Expected, headers)
@@ -286,7 +282,7 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 				TraceID: 0x1314,
 				SpanID:  0x2435,
 				Baggage: map[string]string{},
-				ForeignParent: w3ctrace.Context{
+				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
 				},
@@ -295,15 +291,15 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"w3c trace context, no instana headers": {
 			Headers: map[string]string{
 				"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-				"tracestate":  "rojo=00f067aa0ba902b7,in=1314;2435",
+				"tracestate":  "in=1314;2435,rojo=00f067aa0ba902b7",
 			},
 			Expected: instana.SpanContext{
 				TraceID: 0x1314,
 				SpanID:  0x2435,
 				Baggage: map[string]string{},
-				ForeignParent: w3ctrace.Context{
+				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-					RawState:  "rojo=00f067aa0ba902b7,in=1314;2435",
+					RawState:  "in=1314;2435,rojo=00f067aa0ba902b7",
 				},
 			},
 		},

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -270,7 +270,25 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 				Baggage:    map[string]string{},
 			},
 		},
-		"w3c trace context": {
+		"w3c trace context, last vendor is instana": {
+			Headers: map[string]string{
+				"x-instana-t": "1314",
+				"X-INSTANA-S": "2435",
+				"X-Instana-L": "1",
+				"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000002435-01",
+				"tracestate":  "in=1314;2435,rojo=00f067aa0ba902b7",
+			},
+			Expected: instana.SpanContext{
+				TraceID: 0x1314,
+				SpanID:  0x2435,
+				Baggage: map[string]string{},
+				W3CContext: w3ctrace.Context{
+					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000002435-01",
+					RawState:  "in=1314;2435,rojo=00f067aa0ba902b7",
+				},
+			},
+		},
+		"w3c trace context, last vendor not instana": {
 			Headers: map[string]string{
 				"x-instana-t": "1314",
 				"X-INSTANA-S": "2435",
@@ -282,6 +300,7 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 				TraceID: 0x1314,
 				SpanID:  0x2435,
 				Baggage: map[string]string{},
+				Foreign: true,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -297,6 +316,7 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 				TraceID: 0x1314,
 				SpanID:  0x2435,
 				Baggage: map[string]string{},
+				Foreign: true,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "in=1314;2435,rojo=00f067aa0ba902b7",

--- a/span_context.go
+++ b/span_context.go
@@ -22,9 +22,6 @@ type SpanContext struct {
 	Baggage map[string]string // initialized on first use
 	// The W3C trace context
 	W3CContext w3ctrace.Context
-	// A flag that signals that this context comes from a service that is
-	// not monitored by Instana
-	Foreign bool
 	// The 3rd party parent if the context is derived from non-Instana trace
 	ForeignParent interface{}
 }
@@ -127,7 +124,6 @@ func (c SpanContext) Clone() SpanContext {
 		ParentID:      c.ParentID,
 		Sampled:       c.Sampled,
 		Suppressed:    c.Suppressed,
-		Foreign:       c.Foreign,
 		ForeignParent: c.ForeignParent,
 		W3CContext:    c.W3CContext,
 	}

--- a/span_context.go
+++ b/span_context.go
@@ -1,5 +1,7 @@
 package instana
 
+import "github.com/instana/go-sensor/w3ctrace"
+
 // SpanContext holds the basic Span metadata.
 type SpanContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
@@ -14,7 +16,9 @@ type SpanContext struct {
 	Suppressed bool
 	// The span's associated baggage.
 	Baggage map[string]string // initialized on first use
-	// The 3rd-party trace context
+	// The W3C trace context
+	W3CContext w3ctrace.Context
+	// The 3rd party parent if the context is derived from non-Instana trace
 	ForeignParent interface{}
 }
 
@@ -32,8 +36,6 @@ func NewRootSpanContext() SpanContext {
 func NewSpanContext(parent SpanContext) SpanContext {
 	c := parent.Clone()
 	c.SpanID, c.ParentID = randomID(), parent.SpanID
-	c.Suppressed = parent.Suppressed
-	c.ForeignParent = parent.ForeignParent
 
 	return c
 }
@@ -63,12 +65,12 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 // Clone returns a deep copy of a SpanContext
 func (c SpanContext) Clone() SpanContext {
 	res := SpanContext{
-		TraceID:       c.TraceID,
-		SpanID:        c.SpanID,
-		ParentID:      c.ParentID,
-		Sampled:       c.Sampled,
-		Suppressed:    c.Suppressed,
-		ForeignParent: c.ForeignParent,
+		TraceID:    c.TraceID,
+		SpanID:     c.SpanID,
+		ParentID:   c.ParentID,
+		Sampled:    c.Sampled,
+		Suppressed: c.Suppressed,
+		W3CContext: c.W3CContext,
 	}
 
 	if c.Baggage != nil {

--- a/span_context.go
+++ b/span_context.go
@@ -39,7 +39,11 @@ func NewRootSpanContext() SpanContext {
 func NewSpanContext(parent SpanContext) SpanContext {
 	c := parent.Clone()
 	c.SpanID, c.ParentID = randomID(), parent.SpanID
-	c.Foreign = false
+
+	if parent.Foreign {
+		c.Foreign = false
+		c.ForeignParent = parent.W3CContext
+	}
 
 	return c
 }
@@ -69,13 +73,14 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 // Clone returns a deep copy of a SpanContext
 func (c SpanContext) Clone() SpanContext {
 	res := SpanContext{
-		TraceID:    c.TraceID,
-		SpanID:     c.SpanID,
-		ParentID:   c.ParentID,
-		Sampled:    c.Sampled,
-		Suppressed: c.Suppressed,
-		Foreign:    c.Foreign,
-		W3CContext: c.W3CContext,
+		TraceID:       c.TraceID,
+		SpanID:        c.SpanID,
+		ParentID:      c.ParentID,
+		Sampled:       c.Sampled,
+		Suppressed:    c.Suppressed,
+		Foreign:       c.Foreign,
+		ForeignParent: c.ForeignParent,
+		W3CContext:    c.W3CContext,
 	}
 
 	if c.Baggage != nil {

--- a/span_context.go
+++ b/span_context.go
@@ -18,6 +18,9 @@ type SpanContext struct {
 	Baggage map[string]string // initialized on first use
 	// The W3C trace context
 	W3CContext w3ctrace.Context
+	// A flag that signals that this context comes from a service that is
+	// not monitored by Instana
+	Foreign bool
 	// The 3rd party parent if the context is derived from non-Instana trace
 	ForeignParent interface{}
 }
@@ -36,6 +39,7 @@ func NewRootSpanContext() SpanContext {
 func NewSpanContext(parent SpanContext) SpanContext {
 	c := parent.Clone()
 	c.SpanID, c.ParentID = randomID(), parent.SpanID
+	c.Foreign = false
 
 	return c
 }
@@ -70,6 +74,7 @@ func (c SpanContext) Clone() SpanContext {
 		ParentID:   c.ParentID,
 		Sampled:    c.Sampled,
 		Suppressed: c.Suppressed,
+		Foreign:    c.Foreign,
 		W3CContext: c.W3CContext,
 	}
 

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -15,7 +15,6 @@ func TestNewRootSpanContext(t *testing.T) {
 	assert.False(t, c.Sampled)
 	assert.False(t, c.Suppressed)
 	assert.Empty(t, c.Baggage)
-	assert.False(t, c.Foreign)
 	assert.Nil(t, c.ForeignParent)
 }
 
@@ -157,7 +156,6 @@ func TestSpanContext_Clone(t *testing.T) {
 		ParentID:      3,
 		Sampled:       true,
 		Suppressed:    true,
-		Foreign:       true,
 		ForeignParent: []byte("parent"),
 		W3CContext: w3ctrace.New(w3ctrace.Parent{
 			TraceID:  "w3ctraceid",

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -14,8 +14,9 @@ func TestNewRootSpanContext(t *testing.T) {
 	assert.Equal(t, c.SpanID, c.TraceID)
 	assert.False(t, c.Sampled)
 	assert.False(t, c.Suppressed)
-	assert.False(t, c.Foreign)
 	assert.Empty(t, c.Baggage)
+	assert.False(t, c.Foreign)
+	assert.Nil(t, c.ForeignParent)
 }
 
 func TestNewSpanContext(t *testing.T) {
@@ -47,7 +48,9 @@ func TestNewSpanContext(t *testing.T) {
 	assert.NotEqual(t, parent.SpanID, c.SpanID)
 	assert.NotEmpty(t, c.SpanID)
 	assert.False(t, &c.Baggage == &parent.Baggage)
+
 	assert.False(t, c.Foreign)
+	assert.Equal(t, parent.W3CContext, c.ForeignParent)
 }
 
 func TestSpanContext_WithBaggageItem(t *testing.T) {
@@ -89,12 +92,13 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 
 func TestSpanContext_Clone(t *testing.T) {
 	c := instana.SpanContext{
-		TraceID:    1,
-		SpanID:     2,
-		ParentID:   3,
-		Sampled:    true,
-		Suppressed: true,
-		Foreign:    true,
+		TraceID:       1,
+		SpanID:        2,
+		ParentID:      3,
+		Sampled:       true,
+		Suppressed:    true,
+		Foreign:       true,
+		ForeignParent: []byte("parent"),
 		W3CContext: w3ctrace.New(w3ctrace.Parent{
 			TraceID:  "w3ctraceid",
 			ParentID: "w3cparentid",

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -20,37 +20,97 @@ func TestNewRootSpanContext(t *testing.T) {
 }
 
 func TestNewSpanContext(t *testing.T) {
-	parent := instana.SpanContext{
-		TraceID:    1,
-		SpanID:     2,
-		ParentID:   3,
-		Sampled:    true,
-		Suppressed: true,
-		Foreign:    true,
-		W3CContext: w3ctrace.New(w3ctrace.Parent{
-			TraceID:  "w3ctraceid",
-			ParentID: "w3cparentid",
-		}),
-		Baggage: map[string]string{
-			"key1": "value1",
-			"key2": "value2",
+	examples := map[string]instana.SpanContext{
+		"no w3c trace": {
+			TraceID:    1,
+			SpanID:     2,
+			ParentID:   3,
+			Sampled:    true,
+			Suppressed: true,
+			Baggage: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		"with w3c trace, no instana state": {
+			TraceID: 1,
+			SpanID:  2,
+			W3CContext: w3ctrace.Context{
+				RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				RawState:  "vendor1=data",
+			},
+		},
+		"with w3c trace, last state from instana": {
+			TraceID: 1,
+			SpanID:  2,
+			W3CContext: w3ctrace.Context{
+				RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+				RawState:  "in=1234;5678,vendor1=data",
+			},
 		},
 	}
 
-	c := instana.NewSpanContext(parent)
-	assert.Equal(t, parent.TraceID, c.TraceID)
-	assert.Equal(t, parent.SpanID, c.ParentID)
-	assert.Equal(t, parent.Sampled, c.Sampled)
-	assert.Equal(t, parent.Suppressed, c.Suppressed)
-	assert.Equal(t, parent.W3CContext, c.W3CContext)
-	assert.Equal(t, parent.Baggage, c.Baggage)
+	for name, parent := range examples {
+		t.Run(name, func(t *testing.T) {
+			c := instana.NewSpanContext(parent)
+			assert.Equal(t, parent.TraceID, c.TraceID)
+			assert.Equal(t, parent.SpanID, c.ParentID)
+			assert.Equal(t, parent.Sampled, c.Sampled)
+			assert.Equal(t, parent.Suppressed, c.Suppressed)
+			assert.Equal(t, parent.W3CContext, c.W3CContext)
+			assert.Equal(t, parent.Baggage, c.Baggage)
 
-	assert.NotEqual(t, parent.SpanID, c.SpanID)
-	assert.NotEmpty(t, c.SpanID)
-	assert.False(t, &c.Baggage == &parent.Baggage)
+			assert.NotEqual(t, parent.SpanID, c.SpanID)
+			assert.NotEmpty(t, c.SpanID)
+			assert.False(t, &c.Baggage == &parent.Baggage)
+			assert.Nil(t, c.ForeignParent)
+		})
+	}
+}
 
-	assert.False(t, c.Foreign)
-	assert.Equal(t, parent.W3CContext, c.ForeignParent)
+func TestNewSpanContext_ForeignParent(t *testing.T) {
+	examples := map[string]struct {
+		Parent           instana.SpanContext
+		ExpectedTraceID  int64
+		ExpectedParentID int64
+	}{
+		"no trace, last state from instana": {
+			Parent: instana.SpanContext{
+				W3CContext: w3ctrace.Context{
+					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+					RawState:  "in=1234;5678,vendor1=data",
+				},
+			},
+			ExpectedTraceID:  0x1234,
+			ExpectedParentID: 0x5678,
+		},
+		"with trace, last state not from instana": {
+			Parent: instana.SpanContext{
+				TraceID: 0x4321,
+				SpanID:  0x8765,
+				W3CContext: w3ctrace.Context{
+					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+					RawState:  "vendor1=data,in=1234;5678",
+				},
+			},
+			ExpectedTraceID:  0x4321,
+			ExpectedParentID: 0x8765,
+		},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			c := instana.NewSpanContext(example.Parent)
+			assert.NotEqual(t, example.Parent.SpanID, c.SpanID)
+			assert.Equal(t, instana.SpanContext{
+				TraceID:       example.ExpectedTraceID,
+				SpanID:        c.SpanID,
+				ParentID:      example.ExpectedParentID,
+				W3CContext:    example.Parent.W3CContext,
+				ForeignParent: example.Parent.W3CContext,
+			}, c)
+		})
+	}
 }
 
 func TestSpanContext_WithBaggageItem(t *testing.T) {

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -14,6 +14,7 @@ func TestNewRootSpanContext(t *testing.T) {
 	assert.Equal(t, c.SpanID, c.TraceID)
 	assert.False(t, c.Sampled)
 	assert.False(t, c.Suppressed)
+	assert.False(t, c.Foreign)
 	assert.Empty(t, c.Baggage)
 }
 
@@ -24,6 +25,7 @@ func TestNewSpanContext(t *testing.T) {
 		ParentID:   3,
 		Sampled:    true,
 		Suppressed: true,
+		Foreign:    true,
 		W3CContext: w3ctrace.New(w3ctrace.Parent{
 			TraceID:  "w3ctraceid",
 			ParentID: "w3cparentid",
@@ -45,6 +47,7 @@ func TestNewSpanContext(t *testing.T) {
 	assert.NotEqual(t, parent.SpanID, c.SpanID)
 	assert.NotEmpty(t, c.SpanID)
 	assert.False(t, &c.Baggage == &parent.Baggage)
+	assert.False(t, c.Foreign)
 }
 
 func TestSpanContext_WithBaggageItem(t *testing.T) {
@@ -91,6 +94,7 @@ func TestSpanContext_Clone(t *testing.T) {
 		ParentID:   3,
 		Sampled:    true,
 		Suppressed: true,
+		Foreign:    true,
 		W3CContext: w3ctrace.New(w3ctrace.Parent{
 			TraceID:  "w3ctraceid",
 			ParentID: "w3cparentid",

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
+	"github.com/instana/go-sensor/w3ctrace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,12 +19,15 @@ func TestNewRootSpanContext(t *testing.T) {
 
 func TestNewSpanContext(t *testing.T) {
 	parent := instana.SpanContext{
-		TraceID:       1,
-		SpanID:        2,
-		ParentID:      3,
-		Sampled:       true,
-		Suppressed:    true,
-		ForeignParent: []byte("foreign trace"),
+		TraceID:    1,
+		SpanID:     2,
+		ParentID:   3,
+		Sampled:    true,
+		Suppressed: true,
+		W3CContext: w3ctrace.New(w3ctrace.Parent{
+			TraceID:  "w3ctraceid",
+			ParentID: "w3cparentid",
+		}),
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
@@ -35,7 +39,7 @@ func TestNewSpanContext(t *testing.T) {
 	assert.Equal(t, parent.SpanID, c.ParentID)
 	assert.Equal(t, parent.Sampled, c.Sampled)
 	assert.Equal(t, parent.Suppressed, c.Suppressed)
-	assert.Equal(t, parent.ForeignParent, c.ForeignParent)
+	assert.Equal(t, parent.W3CContext, c.W3CContext)
 	assert.Equal(t, parent.Baggage, c.Baggage)
 
 	assert.NotEqual(t, parent.SpanID, c.SpanID)
@@ -82,12 +86,15 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 
 func TestSpanContext_Clone(t *testing.T) {
 	c := instana.SpanContext{
-		TraceID:       1,
-		SpanID:        2,
-		ParentID:      3,
-		Sampled:       true,
-		Suppressed:    true,
-		ForeignParent: []byte("foreign trace"),
+		TraceID:    1,
+		SpanID:     2,
+		ParentID:   3,
+		Sampled:    true,
+		Suppressed: true,
+		W3CContext: w3ctrace.New(w3ctrace.Parent{
+			TraceID:  "w3ctraceid",
+			ParentID: "w3cparentid",
+		}),
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -34,6 +34,11 @@ func New(parent Parent) Context {
 	}
 }
 
+// IsZero returns whether a context is a zero value
+func (c Context) IsZero() bool {
+	return c.RawParent == ""
+}
+
 // Extract extracts the W3C trace context from HTTP headers. Returns ErrContextNotFound if
 // provided value doesn't contain traceparent header.
 func Extract(headers http.Header) (Context, error) {

--- a/w3ctrace/context_test.go
+++ b/w3ctrace/context_test.go
@@ -110,3 +110,34 @@ func TestContext_Parent(t *testing.T) {
 		},
 	}, trCtx.Parent())
 }
+
+func TestContext_IsZero(t *testing.T) {
+	examples := map[string]struct {
+		Context  w3ctrace.Context
+		Expected bool
+	}{
+		"empty": {
+			Context:  w3ctrace.Context{},
+			Expected: true,
+		},
+		"non-empty": {
+			Context: w3ctrace.Context{
+				RawParent: "parent",
+				RawState:  "state",
+			},
+			Expected: false,
+		},
+		"with empty state": {
+			Context: w3ctrace.Context{
+				RawParent: "parent",
+			},
+			Expected: false,
+		},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, example.Expected, example.Context.IsZero())
+		})
+	}
+}

--- a/w3ctrace/state.go
+++ b/w3ctrace/state.go
@@ -50,15 +50,26 @@ func (st State) Add(vendor, data string) State {
 
 // Fetch retrieves stored vendor-specific data for given vendor
 func (st State) Fetch(vendor string) (string, bool) {
+	i := st.Index(vendor)
+	if i < 0 {
+		return "", false
+	}
+
+	return strings.TrimPrefix(st[i], vendor+"="), true
+}
+
+// Index returns the index of vendor-specific data for given vendor in the state.
+// It returns -1 if the state does not contain data for this vendor.
+func (st State) Index(vendor string) int {
 	prefix := vendor + "="
 
-	for _, vd := range st {
+	for i, vd := range st {
 		if strings.HasPrefix(vd, prefix) {
-			return strings.TrimPrefix(vd, prefix), true
+			return i
 		}
 	}
 
-	return "", false
+	return -1
 }
 
 // Remove returns a new state without data for specified vendor. It returns the same state if vendor is empty

--- a/w3ctrace/state_test.go
+++ b/w3ctrace/state_test.go
@@ -92,6 +92,19 @@ func TestState_Fetch(t *testing.T) {
 	})
 }
 
+func TestState_Index(t *testing.T) {
+	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
+
+	t.Run("existing", func(t *testing.T) {
+		assert.Equal(t, 0, st.Index("rojo"))
+		assert.Equal(t, 1, st.Index("congo"))
+	})
+
+	t.Run("non-existing", func(t *testing.T) {
+		assert.Equal(t, -1, st.Index("vendor"))
+	})
+}
+
 func TestState_Remove(t *testing.T) {
 	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
 


### PR DESCRIPTION
In a situation when a trace passes through a service that is not instrumented by Instana, we may loose the trace context, if the `X-INSTANA-` headers are not propagated. With these changes Go sensor sends the foreign parent context found in W3C Trace Context headers of a request coming from non-instrumented service to the agent, so it could be later displayed in the dashboard for manual correlation.