### PR TITLE
Replace int-to-string casts with conversion

### DIFF
--- a/autoprofile/internal/pprof/profile/proto.go
+++ b/autoprofile/internal/pprof/profile/proto.go
@@ -21,7 +21,10 @@
 
 package profile
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type buffer struct {
 	field int
@@ -232,7 +235,7 @@ func decodeField(b *buffer, data []byte) ([]byte, error) {
 		b.u64 = uint64(le32(data[:4]))
 		data = data[4:]
 	default:
-		return nil, errors.New("unknown type: " + string(b.typ))
+		return nil, fmt.Errorf("unknown type: %d", b.typ)
 	}
 
 	return data, nil

--- a/example/autoprofile/demo.go
+++ b/example/autoprofile/demo.go
@@ -46,7 +46,7 @@ func leakMemory(duration int, size int) {
 	for j := 0; j < duration; j++ {
 		go func() {
 			for i := 0; i < size; i++ {
-				mem = append(mem, string(i))
+				mem = append(mem, strconv.Itoa(i))
 			}
 		}()
 


### PR DESCRIPTION
The upcoming change in Go 1.15 `go vet` command disallows type casts from `int` to `string`. This PR replaces `string(int)` conversions with explicit formatting.

https://github.com/golang/go/issues/3939