### PR TITLE
Ensure that parent span context is not empty before creating a child one

### DIFF
--- a/span_context.go
+++ b/span_context.go
@@ -36,9 +36,15 @@ func NewRootSpanContext() SpanContext {
 	}
 }
 
-// NewSpanContext initializes a new child span context from its parent
+// NewSpanContext initializes a new child span context from its parent. It will
+// ignore the parent context if it contains neither Instana trace and span IDs
+// nor a W3C trace context
 func NewSpanContext(parent SpanContext) SpanContext {
 	foreign := parent.restoreFromForeignTraceContext(parent.W3CContext)
+
+	if parent.TraceID == 0 && parent.SpanID == 0 {
+		return NewRootSpanContext()
+	}
 
 	c := parent.Clone()
 	c.SpanID, c.ParentID = randomID(), parent.SpanID

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -67,6 +67,16 @@ func TestNewSpanContext(t *testing.T) {
 	}
 }
 
+func TestNewSpanContext_EmptyParent(t *testing.T) {
+	c := instana.NewSpanContext(instana.SpanContext{})
+	assert.NotEmpty(t, c.TraceID)
+	assert.Equal(t, c.SpanID, c.TraceID)
+	assert.False(t, c.Sampled)
+	assert.False(t, c.Suppressed)
+	assert.Empty(t, c.Baggage)
+	assert.Nil(t, c.ForeignParent)
+}
+
 func TestNewSpanContext_ForeignParent(t *testing.T) {
 	examples := map[string]struct {
 		Parent           instana.SpanContext


### PR DESCRIPTION
The `opentracing.ChildOf()` [ignores](https://github.com/opentracing/opentracing-go/blob/9b906502e23c426fb1483e9783e7f46b06d19940/tracer.go#L227-L229) `nil` span contexts and acts as noop in this case, so ignoring an error returned by the `(opentracing.Tracer).Extract()` is tolerated. 

In `v1.11.0` we’ve changed the return type of the `instana.extractTraceContext` from an interface type to `instana.SpanContext,` which cannot be `nil`. This results in `tracer.StartSpan()` using the malformed span context with trace ID set `0` as a parent and breaking the trace.

This PR adds an explicit check whether the parent span context is not empty before using it to create a child one.