### PR TITLE
Add an Action to pull the latest module version via proxy.golang.org on release

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,17 @@
+name: Renew pkg.go.dev documentation
+
+on:
+  release:
+    types:
+      - created
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '**/v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build:
+    name: Renew documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Pull new module version
+      uses: andrewslotin/go-proxy-pull-action@v1.0.0


### PR DESCRIPTION
[pkg.go.dev](https://pkg.go.dev) uses `proxy.golang.org` cache to discover new modules and versions. This PR adds a GitHub action triggered whenever a new version is released, pulling it via `proxy.golang.org` to warm up its cache.