### PR TITLE
Remove sensor from the list of agent dependencies

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 )
@@ -72,28 +71,12 @@ func (r *agentS) makeURL(prefix string) string {
 }
 
 func (r *agentS) makeHostURL(host string, prefix string) string {
-	envPort := os.Getenv("INSTANA_AGENT_PORT")
-	port := agentDefaultPort
-	if r.sensor.options.AgentPort > 0 {
-		return r.makeFullURL(host, r.sensor.options.AgentPort, prefix)
-	}
-	if envPort == "" {
-		return r.makeFullURL(host, port, prefix)
-	}
-	port, err := strconv.Atoi(envPort)
-	if err != nil {
-		return r.makeFullURL(host, agentDefaultPort, prefix)
-	}
-	return r.makeFullURL(host, port, prefix)
-}
-
-func (r *agentS) makeFullURL(host string, port int, prefix string) string {
 	var buffer bytes.Buffer
 
 	buffer.WriteString("http://")
 	buffer.WriteString(host)
 	buffer.WriteString(":")
-	buffer.WriteString(strconv.Itoa(port))
+	buffer.WriteString(strconv.Itoa(r.sensor.options.AgentPort))
 	buffer.WriteString(prefix)
 	if prefix[len(prefix)-1:] == "." && r.from.PID != "" {
 		buffer.WriteString(r.from.PID)

--- a/agent.go
+++ b/agent.go
@@ -44,6 +44,7 @@ type agentS struct {
 	fsm    *fsmS
 	from   *fromS
 	host   string
+	port   string
 	client *http.Client
 	logger LeveledLogger
 }
@@ -54,6 +55,7 @@ func newAgent(sensor *sensorS) *agentS {
 	agent := &agentS{
 		sensor: sensor,
 		from:   &fromS{},
+		port:   strconv.Itoa(sensor.options.AgentPort),
 		client: &http.Client{Timeout: 5 * time.Second},
 		logger: sensor.logger,
 	}
@@ -76,7 +78,7 @@ func (r *agentS) makeHostURL(host string, prefix string) string {
 	buffer.WriteString("http://")
 	buffer.WriteString(host)
 	buffer.WriteString(":")
-	buffer.WriteString(strconv.Itoa(r.sensor.options.AgentPort))
+	buffer.WriteString(r.port)
 	buffer.WriteString(prefix)
 	if prefix[len(prefix)-1:] == "." && r.from.PID != "" {
 		buffer.WriteString(r.from.PID)

--- a/agent.go
+++ b/agent.go
@@ -40,7 +40,6 @@ type fromS struct {
 }
 
 type agentS struct {
-	sensor *sensorS
 	fsm    *fsmS
 	from   *fromS
 	host   string
@@ -49,16 +48,19 @@ type agentS struct {
 	logger LeveledLogger
 }
 
-func newAgent(sensor *sensorS) *agentS {
-	sensor.logger.Debug("initializing agent")
+func newAgent(host string, port int, logger LeveledLogger) *agentS {
+	if logger == nil {
+		logger = defaultLogger
+	}
+
+	logger.Debug("initializing agent")
 
 	agent := &agentS{
-		sensor: sensor,
 		from:   &fromS{},
-		host:   sensor.options.AgentHost,
-		port:   strconv.Itoa(sensor.options.AgentPort),
+		host:   host,
+		port:   strconv.Itoa(port),
 		client: &http.Client{Timeout: 5 * time.Second},
-		logger: sensor.logger,
+		logger: logger,
 	}
 	agent.fsm = newFSM(agent)
 

--- a/agent.go
+++ b/agent.go
@@ -159,7 +159,7 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 		// Ignore errors while in announced stated (before ready) as
 		// this is the time where the entity is registering in the Instana
 		// backend and it will return 404 until it's done.
-		if !r.sensor.agent.fsm.fsm.Is("announced") {
+		if !r.fsm.fsm.Is("announced") {
 			r.sensor.logger.Info(err, url)
 		}
 	}

--- a/agent.go
+++ b/agent.go
@@ -55,6 +55,7 @@ func newAgent(sensor *sensorS) *agentS {
 	agent := &agentS{
 		sensor: sensor,
 		from:   &fromS{},
+		host:   sensor.options.AgentHost,
 		port:   strconv.Itoa(sensor.options.AgentPort),
 		client: &http.Client{Timeout: 5 * time.Second},
 		logger: sensor.logger,

--- a/agent.go
+++ b/agent.go
@@ -46,6 +46,7 @@ type agentS struct {
 	from   *fromS
 	host   string
 	client *http.Client
+	logger LeveledLogger
 }
 
 func newAgent(sensor *sensorS) *agentS {
@@ -55,10 +56,15 @@ func newAgent(sensor *sensorS) *agentS {
 		sensor: sensor,
 		from:   &fromS{},
 		client: &http.Client{Timeout: 5 * time.Second},
+		logger: sensor.logger,
 	}
 	agent.fsm = newFSM(agent)
 
 	return agent
+}
+
+func (r *agentS) setLogger(l LeveledLogger) {
+	r.logger = l
 }
 
 func (r *agentS) makeURL(prefix string) string {
@@ -160,7 +166,7 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 		// this is the time where the entity is registering in the Instana
 		// backend and it will return 404 until it's done.
 		if !r.fsm.fsm.Is("announced") {
-			r.sensor.logger.Info(err, url)
+			r.logger.Info(err, url)
 		}
 	}
 

--- a/fsm.go
+++ b/fsm.go
@@ -100,7 +100,7 @@ func (r *fsmS) lookupAgentHost(e *f.Event) {
 	}
 
 	hostNames := []string{
-		r.agent.sensor.options.AgentHost,
+		r.agent.host,
 		os.Getenv("INSTANA_AGENT_HOST"),
 		agentDefaultHost,
 	}

--- a/fsm.go
+++ b/fsm.go
@@ -32,8 +32,8 @@ type fsmS struct {
 var procSchedPIDRegex = regexp.MustCompile(`\((\d+),`)
 
 func newFSM(agent *agentS) *fsmS {
-	agent.sensor.logger.Warn("Stan is on the scene. Starting Instana instrumentation.")
-	agent.sensor.logger.Debug("initializing fsm")
+	agent.logger.Warn("Stan is on the scene. Starting Instana instrumentation.")
+	agent.logger.Debug("initializing fsm")
 
 	ret := &fsmS{
 		agent:   agent,
@@ -74,14 +74,14 @@ func (r *fsmS) lookupAgentHost(e *f.Event) {
 
 		gateway, err := getDefaultGateway("/proc/net/route")
 		if err != nil {
-			r.agent.sensor.logger.Error("failed to fetch the default gateway, scheduling retry: ", err)
+			r.agent.logger.Error("failed to fetch the default gateway, scheduling retry: ", err)
 			r.scheduleRetry(e, r.lookupAgentHost)
 
 			return
 		}
 
 		if gateway == "" {
-			r.agent.sensor.logger.Error("default gateway not available, scheduling retry")
+			r.agent.logger.Error("default gateway not available, scheduling retry")
 			r.scheduleRetry(e, r.lookupAgentHost)
 
 			return
@@ -93,7 +93,7 @@ func (r *fsmS) lookupAgentHost(e *f.Event) {
 				return
 			}
 
-			r.agent.sensor.logger.Error("cannot connect to the agent through localhost or default gateway, scheduling retry")
+			r.agent.logger.Error("cannot connect to the agent through localhost or default gateway, scheduling retry")
 			r.scheduleRetry(e, r.lookupAgentHost)
 		})
 
@@ -115,7 +115,7 @@ func (r *fsmS) lookupAgentHost(e *f.Event) {
 }
 
 func (r *fsmS) checkHost(host string, cb func(found bool, host string)) {
-	r.agent.sensor.logger.Debug("checking host", host)
+	r.agent.logger.Debug("checking host", host)
 
 	header, err := r.agent.requestHeader(r.agent.makeHostURL(host, "/"), "GET", "Server")
 
@@ -123,7 +123,7 @@ func (r *fsmS) checkHost(host string, cb func(found bool, host string)) {
 }
 
 func (r *fsmS) lookupSuccess(host string) {
-	r.agent.sensor.logger.Debug("agent lookup success", host)
+	r.agent.logger.Debug("agent lookup success", host)
 
 	r.agent.setHost(host)
 	r.retries = maximumRetries
@@ -133,12 +133,12 @@ func (r *fsmS) lookupSuccess(host string) {
 func (r *fsmS) announceSensor(e *f.Event) {
 	cb := func(b bool, from *fromS) {
 		if b {
-			r.agent.sensor.logger.Info("Host agent available. We're in business. Announced pid:", from.PID)
+			r.agent.logger.Info("Host agent available. We're in business. Announced pid:", from.PID)
 			r.agent.setFrom(from)
 			r.retries = maximumRetries
 			r.fsm.Event(eAnnounce)
 		} else {
-			r.agent.sensor.logger.Error("Cannot announce sensor. Scheduling retry.")
+			r.agent.logger.Error("Cannot announce sensor. Scheduling retry.")
 			r.retries--
 			if r.retries > 0 {
 				r.scheduleRetry(e, r.announceSensor)
@@ -148,12 +148,12 @@ func (r *fsmS) announceSensor(e *f.Event) {
 		}
 	}
 
-	r.agent.sensor.logger.Debug("announcing sensor to the agent")
+	r.agent.logger.Debug("announcing sensor to the agent")
 
 	go func(cb func(b bool, from *fromS)) {
 		defer func() {
 			if err := recover(); err != nil {
-				r.agent.sensor.logger.Debug("Announce recovered:", err)
+				r.agent.logger.Debug("Announce recovered:", err)
 			}
 		}()
 
@@ -186,10 +186,10 @@ func (r *fsmS) announceSensor(e *f.Event) {
 			Args: os.Args[1:],
 		}
 		if name, args, ok := getProcCommandLine(); ok {
-			r.agent.sensor.logger.Debug("got cmdline from /proc: ", name, args)
+			r.agent.logger.Debug("got cmdline from /proc: ", name, args)
 			d.Name, d.Args = name, args
 		} else {
-			r.agent.sensor.logger.Debug("no /proc, using OS reported cmdline")
+			r.agent.logger.Debug("no /proc, using OS reported cmdline")
 		}
 
 		if _, err := os.Stat("/proc"); err == nil {
@@ -200,7 +200,7 @@ func (r *fsmS) announceSensor(e *f.Event) {
 					f, err := tcpConn.File()
 
 					if err != nil {
-						r.agent.sensor.logger.Error(err)
+						r.agent.logger.Error(err)
 					} else {
 						d.Fd = fmt.Sprintf("%v", f.Fd())
 
@@ -228,7 +228,7 @@ func (r *fsmS) testAgent(e *f.Event) {
 			r.retries = maximumRetries
 			r.fsm.Event(eTest)
 		} else {
-			r.agent.sensor.logger.Debug("Agent is not yet ready. Scheduling retry.")
+			r.agent.logger.Debug("Agent is not yet ready. Scheduling retry.")
 			r.retries--
 			if r.retries > 0 {
 				r.scheduleRetry(e, r.testAgent)
@@ -238,7 +238,7 @@ func (r *fsmS) testAgent(e *f.Event) {
 		}
 	}
 
-	r.agent.sensor.logger.Debug("testing communication with the agent")
+	r.agent.logger.Debug("testing communication with the agent")
 
 	go func(cb func(b bool)) {
 		_, err := r.agent.head(r.agent.makeURL(agentDataURL))

--- a/fsm.go
+++ b/fsm.go
@@ -99,19 +99,7 @@ func (r *fsmS) lookupAgentHost(e *f.Event) {
 
 	}
 
-	hostNames := []string{
-		r.agent.host,
-		os.Getenv("INSTANA_AGENT_HOST"),
-		agentDefaultHost,
-	}
-	for _, name := range hostNames {
-		if name == "" {
-			continue
-		}
-
-		go r.checkHost(name, cb)
-		break
-	}
+	go r.checkHost(r.agent.host, cb)
 }
 
 func (r *fsmS) checkHost(host string, cb func(found bool, host string)) {

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package instana
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 // Options allows the user to configure the to-be-initialized
@@ -22,7 +23,9 @@ type Options struct {
 // DefaultOptions returns the default set of options to configure Instana sensor.
 // The service name is set to the name of current executable, the MaxBufferedSpans
 // and ForceTransmissionStartingAt are set to instana.DefaultMaxBufferedSpans and
-// instana.DefaultForceSpanSendAt correspondigly
+// instana.DefaultForceSpanSendAt correspondigly. The AgentHost and AgentPort are
+// taken from the env INSTANA_AGENT_HOST and INSTANA_AGENT_PORT if set, and default
+// to localhost and 46999 otherwise.
 func DefaultOptions() *Options {
 	opts := &Options{}
 	opts.setDefaults()
@@ -41,5 +44,21 @@ func (opts *Options) setDefaults() {
 
 	if opts.Service == "" {
 		opts.Service = filepath.Base(os.Args[0])
+	}
+
+	if opts.AgentHost == "" {
+		opts.AgentHost = agentDefaultHost
+
+		if host := os.Getenv("INSTANA_AGENT_HOST"); host != "" {
+			opts.AgentHost = host
+		}
+	}
+
+	if opts.AgentPort == 0 {
+		opts.AgentPort = agentDefaultPort
+
+		if port, err := strconv.Atoi(os.Getenv("INSTANA_AGENT_PORT")); err == nil {
+			opts.AgentPort = port
+		}
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,18 @@
+package instana_test
+
+import (
+	"testing"
+
+	instana "github.com/instana/go-sensor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	assert.Equal(t, &instana.Options{
+		AgentHost:                   "localhost",
+		AgentPort:                   42699,
+		MaxBufferedSpans:            instana.DefaultMaxBufferedSpans,
+		ForceTransmissionStartingAt: instana.DefaultForceSpanSendAt,
+		Service:                     "go-sensor.test",
+	}, instana.DefaultOptions())
+}

--- a/sensor.go
+++ b/sensor.go
@@ -54,6 +54,10 @@ func newSensor(options *Options) *sensorS {
 
 func (r *sensorS) setLogger(l LeveledLogger) {
 	r.logger = l
+
+	if r.agent != nil {
+		r.agent.setLogger(r.logger)
+	}
 }
 
 // InitSensor intializes the sensor (without tracing) to begin collecting

--- a/sensor.go
+++ b/sensor.go
@@ -46,7 +46,7 @@ func newSensor(options *Options) *sensorS {
 		setLogLevel(l, options.LogLevel)
 	}
 
-	s.agent = newAgent(s)
+	s.agent = newAgent(s.options.AgentHost, s.options.AgentPort, s.logger)
 	s.meter = newMeter(s)
 
 	return s


### PR DESCRIPTION
`instana.agentS` holds a reference to its parent sensor to retrieve the configured agent port and for logging purposes. Besides that the same instance is used by `instana.agentS.fsm` to retrieve the user-configured agent host. The sensor itself also keeps a reference to the agent that is used by `instana.meterS` and `instana.Recorder` to send the data to the host agent.

This all introduces a logical circular dependency between sensor and agent which does not allow using other agent implementations, i.e. a serverless one.

In this PR the sensor resources used by the agent (initial host/port and logger) are moved to the agent itself, making it independent from the sensor.