### PR TITLE
Extract agent interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: go
 matrix:
   include:
     - go: tip
-    - go: 1.8.x
-      env: EXCLUDE_DIRS="./instrumentation/instagrpc ./instrumentation/instasarama"
     - go: 1.9.x
     - go: 1.10.x
     - go: 1.11.x

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![golang banner 2017-07-11](https://disznc.s3.amazonaws.com/Instana-Go-2017-07-11-at-16.01.45.png)
 
 # Instana Go Sensor
-go-sensor requires Go version 1.8 or greater.
+go-sensor requires Go version 1.9 or greater.
 
 The Instana Go sensor consists of two parts:
 

--- a/agent.go
+++ b/agent.go
@@ -40,15 +40,16 @@ type fromS struct {
 }
 
 type agentS struct {
-	fsm    *fsmS
-	from   *fromS
-	host   string
-	port   string
-	client *http.Client
-	logger LeveledLogger
+	ServiceName string
+	fsm         *fsmS
+	from        *fromS
+	host        string
+	port        string
+	client      *http.Client
+	logger      LeveledLogger
 }
 
-func newAgent(host string, port int, logger LeveledLogger) *agentS {
+func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS {
 	if logger == nil {
 		logger = defaultLogger
 	}
@@ -56,11 +57,12 @@ func newAgent(host string, port int, logger LeveledLogger) *agentS {
 	logger.Debug("initializing agent")
 
 	agent := &agentS{
-		from:   &fromS{},
-		host:   host,
-		port:   strconv.Itoa(port),
-		client: &http.Client{Timeout: 5 * time.Second},
-		logger: logger,
+		ServiceName: serviceName,
+		from:        &fromS{},
+		host:        host,
+		port:        strconv.Itoa(port),
+		client:      &http.Client{Timeout: 5 * time.Second},
+		logger:      logger,
 	}
 	agent.fsm = newFSM(agent)
 

--- a/agent.go
+++ b/agent.go
@@ -79,6 +79,15 @@ func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS 
 	return agent
 }
 
+// Ready returns whether the agent has finished the announcement and is ready to send data
+func (agent *agentS) Ready() bool {
+	return agent.canSend()
+}
+
+func (agent *agentS) canSend() bool {
+	return agent.fsm.fsm.Current() == "ready"
+}
+
 // SendMetrics sends collected entity data to the host agent
 func (agent *agentS) SendMetrics(data *MetricsS) {
 	pid, err := strconv.Atoi(agent.from.PID)

--- a/agent.go
+++ b/agent.go
@@ -67,6 +67,15 @@ func newAgent(host string, port int, logger LeveledLogger) *agentS {
 	return agent
 }
 
+// SendMetrics sends collected entity data to the host agent
+func (agent *agentS) SendMetrics(data *EntityData) {
+	_, err := agent.request(agent.makeURL(agentDataURL), "POST", data)
+
+	if err != nil {
+		agent.reset()
+	}
+}
+
 func (r *agentS) setLogger(l LeveledLogger) {
 	r.logger = l
 }

--- a/agent.go
+++ b/agent.go
@@ -105,6 +105,19 @@ func (agent *agentS) SendMetrics(data *MetricsS) error {
 	return nil
 }
 
+// SendEvent sends an event using Instana Events API
+func (agent *agentS) SendEvent(event *EventData) error {
+	_, err := agent.request(agent.makeURL(agentEventURL), "POST", event)
+	if err != nil {
+		// do not reset the agent as it might be not initialized at this state yet
+		agent.logger.Warn("failed to send event ", event.Title, " to the host agent: ", err)
+
+		return err
+	}
+
+	return nil
+}
+
 func (r *agentS) setLogger(l LeveledLogger) {
 	r.logger = l
 }

--- a/agent.go
+++ b/agent.go
@@ -141,9 +141,19 @@ func (agent *agentS) SendSpans(spans []Span) error {
 	return nil
 }
 
+type hostAgentProfile struct {
+	autoprofile.Profile
+	ProcessID string `json:"pid"`
+}
+
 // SendProfiles sends profile data to the agent
 func (agent *agentS) SendProfiles(profiles []autoprofile.Profile) error {
-	_, err := agent.request(agent.makeURL(agentProfilesURL), "POST", profiles)
+	agentProfiles := make([]hostAgentProfile, 0, len(profiles))
+	for _, p := range profiles {
+		agentProfiles = append(agentProfiles, hostAgentProfile{p, agent.from.PID})
+	}
+
+	_, err := agent.request(agent.makeURL(agentProfilesURL), "POST", agentProfiles)
 	if err != nil {
 		agent.logger.Error("failed to send profile data to the host agent: ", err)
 		agent.reset()

--- a/agent.go
+++ b/agent.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/instana/go-sensor/autoprofile"
 )
 
 const (
@@ -123,6 +125,19 @@ func (agent *agentS) SendSpans(spans []Span) error {
 	_, err := agent.request(agent.makeURL(agentTracesURL), "POST", spans)
 	if err != nil {
 		agent.logger.Error("failed to send spans to the host agent: ", err)
+		agent.reset()
+
+		return err
+	}
+
+	return nil
+}
+
+// SendProfiles sends profile data to the agent
+func (agent *agentS) SendProfiles(profiles []autoprofile.Profile) error {
+	_, err := agent.request(agent.makeURL(agentProfilesURL), "POST", profiles)
+	if err != nil {
+		agent.logger.Error("failed to send profile data to the host agent: ", err)
 		agent.reset()
 
 		return err

--- a/agent.go
+++ b/agent.go
@@ -118,6 +118,19 @@ func (agent *agentS) SendEvent(event *EventData) error {
 	return nil
 }
 
+// SendSpans sends collected spans to the host agent
+func (agent *agentS) SendSpans(spans []Span) error {
+	_, err := agent.request(agent.makeURL(agentTracesURL), "POST", spans)
+	if err != nil {
+		agent.logger.Error("failed to send spans to the host agent: ", err)
+		agent.reset()
+
+		return err
+	}
+
+	return nil
+}
+
 func (r *agentS) setLogger(l LeveledLogger) {
 	r.logger = l
 }

--- a/agent.go
+++ b/agent.go
@@ -80,10 +80,17 @@ func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS 
 }
 
 // SendMetrics sends collected entity data to the host agent
-func (agent *agentS) SendMetrics(data *EntityData) {
-	_, err := agent.request(agent.makeURL(agentDataURL), "POST", data)
+func (agent *agentS) SendMetrics(data *MetricsS) {
+	pid, err := strconv.Atoi(agent.from.PID)
+	if err != nil && agent.from.PID != "" {
+		agent.logger.Debug("agent got malformed PID %q", agent.from.PID)
+	}
 
-	if err != nil {
+	if _, err = agent.request(agent.makeURL(agentDataURL), "POST", &EntityData{
+		PID:      pid,
+		Snapshot: agent.collectSnapshot(),
+		Metrics:  data,
+	}); err != nil {
 		agent.reset()
 	}
 }

--- a/agent.go
+++ b/agent.go
@@ -85,7 +85,7 @@ func (agent *agentS) Ready() bool {
 }
 
 // SendMetrics sends collected entity data to the host agent
-func (agent *agentS) SendMetrics(data *MetricsS) {
+func (agent *agentS) SendMetrics(data *MetricsS) error {
 	pid, err := strconv.Atoi(agent.from.PID)
 	if err != nil && agent.from.PID != "" {
 		agent.logger.Debug("agent got malformed PID %q", agent.from.PID)
@@ -96,8 +96,13 @@ func (agent *agentS) SendMetrics(data *MetricsS) {
 		Snapshot: agent.collectSnapshot(),
 		Metrics:  data,
 	}); err != nil {
+		agent.logger.Error("failed to send metrics to the host agent: ", err)
 		agent.reset()
+
+		return err
 	}
+
+	return nil
 }
 
 func (r *agentS) setLogger(l LeveledLogger) {

--- a/agent.go
+++ b/agent.go
@@ -48,10 +48,9 @@ type fromS struct {
 }
 
 type agentS struct {
-	ServiceName string
-	from        *fromS
-	host        string
-	port        string
+	from *fromS
+	host string
+	port string
 
 	snapshotMu                 sync.RWMutex
 	lastSnapshotCollectionTime time.Time
@@ -69,12 +68,11 @@ func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS 
 	logger.Debug("initializing agent")
 
 	agent := &agentS{
-		ServiceName: serviceName,
-		from:        &fromS{},
-		host:        host,
-		port:        strconv.Itoa(port),
-		client:      &http.Client{Timeout: 5 * time.Second},
-		logger:      logger,
+		from:   &fromS{},
+		host:   host,
+		port:   strconv.Itoa(port),
+		client: &http.Client{Timeout: 5 * time.Second},
+		logger: logger,
 	}
 	agent.fsm = newFSM(agent)
 
@@ -268,7 +266,7 @@ func (agent *agentS) collectSnapshot() *SnapshotS {
 	agent.logger.Debug("collected snapshot")
 
 	return &SnapshotS{
-		Name:     agent.ServiceName,
+		Name:     sensor.serviceName,
 		Version:  runtime.Version(),
 		Root:     runtime.GOROOT(),
 		MaxProcs: runtime.GOMAXPROCS(0),

--- a/agent.go
+++ b/agent.go
@@ -81,10 +81,6 @@ func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS 
 
 // Ready returns whether the agent has finished the announcement and is ready to send data
 func (agent *agentS) Ready() bool {
-	return agent.canSend()
-}
-
-func (agent *agentS) canSend() bool {
 	return agent.fsm.fsm.Current() == "ready"
 }
 

--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -91,13 +91,9 @@ func Disable() {
 }
 
 // SetGetExternalPIDFunc configures the profiler to use provided function to retrieve the current PID
-func SetGetExternalPIDFunc(fn func() string) {
-	if fn == nil {
-		fn = internal.GetLocalPID
-	}
-
-	internal.GetPID = fn
-}
+//
+// Deprecated: this is a noop function, the PID is populated by the agent before sending
+func SetGetExternalPIDFunc(fn func() string) {}
 
 // SetSendProfilesFunc configures the profiler to use provided function to write collected profiles
 func SetSendProfilesFunc(fn SendProfilesFunc) {

--- a/autoprofile/internal/allocation_sampler_test.go
+++ b/autoprofile/internal/allocation_sampler_test.go
@@ -22,8 +22,8 @@ func TestCreateAllocationCallGraph(t *testing.T) {
 	samp := internal.NewAllocationSampler()
 	internal.IncludeProfilerFrames = true
 
-	p, err := samp.Profile(500*1e6, 120)
+	profile, err := samp.Profile(500*1e6, 120)
 	require.NoError(t, err)
 
-	assert.Contains(t, fmt.Sprintf("%v", p.ToMap()), "TestCreateAllocationCallGraph")
+	assert.Contains(t, fmt.Sprintf("%v", internal.NewAgentProfile(profile)), "TestCreateAllocationCallGraph")
 }

--- a/autoprofile/internal/block_sampler_test.go
+++ b/autoprofile/internal/block_sampler_test.go
@@ -24,7 +24,7 @@ func TestCreateBlockProfile(t *testing.T) {
 	profile, err := blockSampler.Profile(500*1e6, 120)
 	require.NoError(t, err)
 
-	assert.Contains(t, fmt.Sprintf("%v", profile.ToMap()), "simulateBlocking")
+	assert.Contains(t, fmt.Sprintf("%v", internal.NewAgentProfile(profile)), "simulateBlocking")
 }
 
 func simulateBlocking(d time.Duration) {

--- a/autoprofile/internal/cpu_sampler_test.go
+++ b/autoprofile/internal/cpu_sampler_test.go
@@ -24,7 +24,7 @@ func TestCreateCPUProfile(t *testing.T) {
 	profile, err := cpuSampler.Profile(500*1e6, 120)
 	require.NoError(t, err)
 
-	assert.Contains(t, fmt.Sprintf("%v", profile.ToMap()), "simulateCPULoad")
+	assert.Contains(t, fmt.Sprintf("%v", internal.NewAgentProfile(profile)), "simulateCPULoad")
 }
 
 func simulateCPULoad(d time.Duration) {

--- a/autoprofile/internal/profile.go
+++ b/autoprofile/internal/profile.go
@@ -77,7 +77,7 @@ type Profile struct {
 }
 
 func NewProfile(category string, typ string, unit string, roots []*CallSite, duration int64, timespan int64) *Profile {
-	p := &Profile{
+	return &Profile{
 		ProcessID: strconv.Itoa(os.Getpid()),
 		ID:        GenerateUUID(),
 		Runtime:   RuntimeGolang,
@@ -89,31 +89,6 @@ func NewProfile(category string, typ string, unit string, roots []*CallSite, dur
 		Timespan:  timespan * 1000,
 		Timestamp: time.Now().Unix() * 1000,
 	}
-
-	return p
-}
-
-func (p *Profile) ToMap() map[string]interface{} {
-	rootsMap := make([]interface{}, 0)
-
-	for _, root := range p.Roots {
-		rootsMap = append(rootsMap, root.ToMap())
-	}
-
-	profileMap := map[string]interface{}{
-		"pid":       p.ProcessID,
-		"id":        p.ID,
-		"runtime":   p.Runtime,
-		"category":  p.Category,
-		"type":      p.Type,
-		"unit":      p.Unit,
-		"roots":     rootsMap,
-		"duration":  p.Duration,
-		"timespan":  p.Timespan,
-		"timestamp": p.Timestamp,
-	}
-
-	return profileMap
 }
 
 // AgentCallSite is a presenter type used to serialize a call site
@@ -185,25 +160,6 @@ func (cs *CallSite) Increment(value float64, numSamples int64) {
 
 func (cs *CallSite) Measurement() (value float64, numSamples int64) {
 	return cs.measurement, cs.numSamples
-}
-
-func (cs *CallSite) ToMap() map[string]interface{} {
-	childrenMap := make([]interface{}, 0)
-	for _, child := range cs.children {
-		childrenMap = append(childrenMap, child.ToMap())
-	}
-
-	m, ns := cs.Measurement()
-	callSiteMap := map[string]interface{}{
-		"method_name": cs.MethodName,
-		"file_name":   cs.FileName,
-		"file_line":   cs.FileLine,
-		"measurement": m,
-		"num_samples": ns,
-		"children":    childrenMap,
-	}
-
-	return callSiteMap
 }
 
 func (cs *CallSite) findChild(methodName, fileName string, fileLine int64) *CallSite {

--- a/autoprofile/internal/profile.go
+++ b/autoprofile/internal/profile.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -32,7 +31,6 @@ const (
 // to JSON format supported by Instana profile sensor
 type AgentProfile struct {
 	ID        string          `json:"id"`
-	ProcessID string          `json:"pid"`
 	Runtime   string          `json:"runtime"`
 	Category  string          `json:"category"`
 	Type      string          `json:"type"`
@@ -50,7 +48,6 @@ func NewAgentProfile(p *Profile) AgentProfile {
 	}
 
 	return AgentProfile{
-		ProcessID: p.ProcessID,
 		ID:        p.ID,
 		Runtime:   p.Runtime,
 		Category:  p.Category,
@@ -65,7 +62,6 @@ func NewAgentProfile(p *Profile) AgentProfile {
 
 type Profile struct {
 	ID        string
-	ProcessID string
 	Runtime   string
 	Category  string
 	Type      string
@@ -78,7 +74,6 @@ type Profile struct {
 
 func NewProfile(category string, typ string, unit string, roots []*CallSite, duration int64, timespan int64) *Profile {
 	return &Profile{
-		ProcessID: strconv.Itoa(os.Getpid()),
 		ID:        GenerateUUID(),
 		Runtime:   RuntimeGolang,
 		Category:  category,

--- a/autoprofile/internal/recorder.go
+++ b/autoprofile/internal/recorder.go
@@ -77,7 +77,7 @@ func (pr *Recorder) Size() int {
 	return len(pr.queue)
 }
 
-func (pr *Recorder) Record(record map[string]interface{}) {
+func (pr *Recorder) Record(record AgentProfile) {
 	if pr.MaxBufferedProfiles < 1 {
 		return
 	}

--- a/autoprofile/internal/recorder.go
+++ b/autoprofile/internal/recorder.go
@@ -12,10 +12,10 @@ const (
 )
 
 // SendProfilesFunc is a callback to emit collected profiles from recorder
-type SendProfilesFunc func(interface{}) error
+type SendProfilesFunc func([]AgentProfile) error
 
 // NoopSendProfiles is the default function to be called by Recorded to send collected profiles
-func NoopSendProfiles(interface{}) error {
+func NoopSendProfiles([]AgentProfile) error {
 	logger.Warn(
 		"autoprofile.SendProfiles callback is not set, ",
 		"make sure that you have it configured using autoprofile.SetSendProfilesFunc() in your code",
@@ -31,7 +31,7 @@ type Recorder struct {
 
 	started            Flag
 	flushTimer         *Timer
-	queue              []interface{}
+	queue              []AgentProfile
 	queueLock          *sync.Mutex
 	lastFlushTimestamp int64
 	backoffSeconds     int64
@@ -43,7 +43,7 @@ func NewRecorder() *Recorder {
 		SendProfiles:        NoopSendProfiles,
 		MaxBufferedProfiles: DefaultMaxBufferedProfiles,
 
-		queue:     make([]interface{}, 0),
+		queue:     make([]AgentProfile, 0),
 		queueLock: &sync.Mutex{},
 	}
 
@@ -106,7 +106,7 @@ func (pr *Recorder) Flush() {
 
 	pr.queueLock.Lock()
 	outgoing := pr.queue
-	pr.queue = make([]interface{}, 0)
+	pr.queue = make([]AgentProfile, 0)
 	pr.queueLock.Unlock()
 
 	pr.lastFlushTimestamp = now

--- a/autoprofile/internal/recorder_test.go
+++ b/autoprofile/internal/recorder_test.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/instana/go-sensor/autoprofile/internal"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRecorder_Flush(t *testing.T) {
-	var profiles interface{}
+	var profiles []internal.AgentProfile
 
 	rec := internal.NewRecorder()
-	rec.SendProfiles = func(p interface{}) error {
+	rec.SendProfiles = func(p []internal.AgentProfile) error {
 		profiles = p
 		return nil
 	}
@@ -23,15 +22,14 @@ func TestRecorder_Flush(t *testing.T) {
 
 	rec.Flush()
 
-	require.IsType(t, []interface{}{}, profiles)
-	assert.Len(t, profiles.([]interface{}), 2)
+	assert.Len(t, profiles, 2)
 
 	assert.Equal(t, 0, rec.Size())
 }
 
 func TestRecorder_Flush_Fail(t *testing.T) {
 	rec := internal.NewRecorder()
-	rec.SendProfiles = func(profiles interface{}) error {
+	rec.SendProfiles = func(profiles []internal.AgentProfile) error {
 		return errors.New("some error")
 	}
 

--- a/autoprofile/internal/recorder_test.go
+++ b/autoprofile/internal/recorder_test.go
@@ -18,12 +18,8 @@ func TestRecorder_Flush(t *testing.T) {
 		return nil
 	}
 
-	rec.Record(map[string]interface{}{
-		"a": 1,
-	})
-	rec.Record(map[string]interface{}{
-		"a": 2,
-	})
+	rec.Record(internal.AgentProfile{ID: "1"})
+	rec.Record(internal.AgentProfile{ID: "2"})
 
 	rec.Flush()
 
@@ -39,12 +35,8 @@ func TestRecorder_Flush_Fail(t *testing.T) {
 		return errors.New("some error")
 	}
 
-	rec.Record(map[string]interface{}{
-		"a": 1,
-	})
-	rec.Record(map[string]interface{}{
-		"a": 2,
-	})
+	rec.Record(internal.AgentProfile{ID: "1"})
+	rec.Record(internal.AgentProfile{ID: "2"})
 
 	rec.Flush()
 

--- a/autoprofile/internal/sampler_scheduler.go
+++ b/autoprofile/internal/sampler_scheduler.go
@@ -2,23 +2,13 @@ package internal
 
 import (
 	"math/rand"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/instana/go-sensor/autoprofile/internal/logger"
 )
 
-var (
-	GetPID        = GetLocalPID
-	samplerActive Flag
-)
-
-func GetLocalPID() string {
-	logger.Warn("using the local process pid as a default")
-	return strconv.Itoa(os.Getpid())
-}
+var samplerActive Flag
 
 type SamplerConfig struct {
 	LogPrefix          string
@@ -129,14 +119,6 @@ func (ss *SamplerScheduler) Report() {
 			logger.Debug(ss.config.LogPrefix, "not recording empty profile")
 			ss.Reset()
 			return
-		}
-
-		externalPID := GetPID()
-		if externalPID != "" {
-			profile.ProcessID = externalPID
-			logger.Debug("using external PID", externalPID)
-		} else {
-			logger.Info("external PID from agent is not available, using own PID")
 		}
 
 		ss.profileRecorder.Record(NewAgentProfile(profile))

--- a/autoprofile/internal/sampler_scheduler.go
+++ b/autoprofile/internal/sampler_scheduler.go
@@ -139,7 +139,7 @@ func (ss *SamplerScheduler) Report() {
 			logger.Info("external PID from agent is not available, using own PID")
 		}
 
-		ss.profileRecorder.Record(profile.ToMap())
+		ss.profileRecorder.Record(NewAgentProfile(profile))
 		logger.Debug(ss.config.LogPrefix, "recorded profile")
 	}
 

--- a/event.go
+++ b/event.go
@@ -39,7 +39,7 @@ func SendDefaultServiceEvent(title string, text string, sev severity, duration t
 		// configured on the sensor) so we send blank.
 		SendServiceEvent("", title, text, sev, duration)
 	} else {
-		SendServiceEvent(sensor.serviceName, title, text, sev, duration)
+		SendServiceEvent(sensor.agent.ServiceName, title, text, sev, duration)
 	}
 }
 

--- a/event.go
+++ b/event.go
@@ -34,16 +34,17 @@ const (
 
 // SendDefaultServiceEvent sends a default event which already contains the service and host
 func SendDefaultServiceEvent(title string, text string, sev severity, duration time.Duration) {
-	if sensor == nil {
-		// Since no sensor was initialized, there is no default service (as
-		// configured on the sensor) so we send blank.
-		SendServiceEvent("", title, text, sev, duration)
-	} else {
-		SendServiceEvent(sensor.agent.ServiceName, title, text, sev, duration)
+	var service string
+	if sensor != nil {
+		service = sensor.serviceName
 	}
+
+	// If the sensor is not yet initialized, there is no default service (as
+	// configured on the sensor) so we will send blank instead
+	SendServiceEvent(service, title, text, sev, duration)
 }
 
-// SendServiceEvent send an event on a specific service
+// SendServiceEvent sends an event on a specific service
 func SendServiceEvent(service string, title string, text string, sev severity, duration time.Duration) {
 	sendEvent(&EventData{
 		Title:    title,
@@ -56,7 +57,7 @@ func SendServiceEvent(service string, title string, text string, sev severity, d
 	})
 }
 
-// SendHostEvent send an event on the current host
+// SendHostEvent sends an event on the current host
 func SendHostEvent(title string, text string, sev severity, duration time.Duration) {
 	sendEvent(&EventData{
 		Title:    title,
@@ -73,6 +74,7 @@ func sendEvent(event *EventData) {
 		// normal host, docker, kubernetes etc..
 		InitSensor(&Options{})
 	}
-	//we do fire & forget here, because the whole pid dance isn't necessary to send events
-	go sensor.agent.request(sensor.agent.makeURL(agentEventURL), "POST", event)
+
+	// we do fire & forget here, because the whole pid dance isn't necessary to send events
+	go sensor.agent.SendEvent(event)
 }

--- a/fsm.go
+++ b/fsm.go
@@ -238,7 +238,3 @@ func (r *fsmS) reset() {
 	r.retries = maximumRetries
 	r.fsm.Event(eInit)
 }
-
-func (r *agentS) canSend() bool {
-	return r.fsm.fsm.Current() == "ready"
-}

--- a/json_span.go
+++ b/json_span.go
@@ -126,7 +126,7 @@ type Span struct {
 	ForeignParent *ForeignParent `json:"fp,omitempty"`
 }
 
-func newSpan(span *spanS, from *fromS) Span {
+func newSpan(span *spanS) Span {
 	data := RegisteredSpanType(span.Operation).ExtractData(span)
 	sp := Span{
 		TraceID:       span.context.TraceID,
@@ -136,7 +136,6 @@ func newSpan(span *spanS, from *fromS) Span {
 		Duration:      uint64(span.Duration) / uint64(time.Millisecond),
 		Name:          string(data.Type()),
 		Ec:            span.ErrorCount,
-		From:          from,
 		ForeignParent: newForeignParent(span.context.ForeignParent),
 		Kind:          int(data.Kind()),
 		Data:          data,

--- a/meter.go
+++ b/meter.go
@@ -88,20 +88,12 @@ func newMeter(sensor *sensorS) *meterS {
 					Metrics:  meter.collectMetrics(),
 				}
 
-				go meter.send(d)
+				go meter.sensor.agent.SendMetrics(d)
 			}
 		}
 	}()
 
 	return meter
-}
-
-func (r *meterS) send(d *EntityData) {
-	_, err := r.sensor.agent.request(r.sensor.agent.makeURL(agentDataURL), "POST", d)
-
-	if err != nil {
-		r.sensor.agent.reset()
-	}
 }
 
 func (r *meterS) collectMemoryMetrics() *MemoryS {

--- a/meter.go
+++ b/meter.go
@@ -61,12 +61,16 @@ type meterS struct {
 	agent  metricSender
 }
 
-func newMeter(sensor *sensorS) *meterS {
-	sensor.logger.Debug("initializing meter")
+func newMeter(agent metricSender, logger LeveledLogger) *meterS {
+	if logger == nil {
+		logger = defaultLogger
+	}
+
+	logger.Debug("initializing meter")
 
 	meter := &meterS{
-		logger: sensor.logger,
-		agent:  sensor.agent,
+		logger: logger,
+		agent:  agent,
 	}
 
 	ticker := time.NewTicker(1 * time.Second)

--- a/meter.go
+++ b/meter.go
@@ -135,7 +135,7 @@ func (r *meterS) collectMetrics() *MetricsS {
 
 func (r *meterS) collectSnapshot() *SnapshotS {
 	return &SnapshotS{
-		Name:     r.sensor.serviceName,
+		Name:     r.sensor.agent.ServiceName,
 		Version:  runtime.Version(),
 		Root:     runtime.GOROOT(),
 		MaxProcs: runtime.GOMAXPROCS(0),

--- a/meter.go
+++ b/meter.go
@@ -2,7 +2,6 @@ package instana
 
 import (
 	"runtime"
-	"strconv"
 	"time"
 )
 
@@ -65,16 +64,11 @@ func newMeter(sensor *sensorS) *meterS {
 	ticker := time.NewTicker(1 * time.Second)
 	go func() {
 		for range ticker.C {
-			if meter.sensor.agent.canSend() {
-				pid, _ := strconv.Atoi(meter.sensor.agent.from.PID)
-				d := &EntityData{
-					PID:      pid,
-					Snapshot: meter.sensor.agent.collectSnapshot(),
-					Metrics:  meter.collectMetrics(),
-				}
-
-				go meter.sensor.agent.SendMetrics(d)
+			if !meter.sensor.agent.canSend() {
+				continue
 			}
+
+			go meter.sensor.agent.SendMetrics(meter.collectMetrics())
 		}
 	}()
 

--- a/meter.go
+++ b/meter.go
@@ -52,6 +52,8 @@ type EntityData struct {
 type meterS struct {
 	sensor *sensorS
 	numGC  uint32
+
+	logger LeveledLogger
 }
 
 func newMeter(sensor *sensorS) *meterS {
@@ -59,6 +61,7 @@ func newMeter(sensor *sensorS) *meterS {
 
 	meter := &meterS{
 		sensor: sensor,
+		logger: sensor.logger,
 	}
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -73,6 +76,10 @@ func newMeter(sensor *sensorS) *meterS {
 	}()
 
 	return meter
+}
+
+func (m *meterS) setLogger(l LeveledLogger) {
+	m.logger = l
 }
 
 func (r *meterS) collectMemoryMetrics() *MemoryS {

--- a/meter.go
+++ b/meter.go
@@ -64,7 +64,7 @@ func newMeter(sensor *sensorS) *meterS {
 	ticker := time.NewTicker(1 * time.Second)
 	go func() {
 		for range ticker.C {
-			if !meter.sensor.agent.canSend() {
+			if !meter.sensor.agent.Ready() {
 				continue
 			}
 

--- a/recorder.go
+++ b/recorder.go
@@ -61,7 +61,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 		r.spans = r.spans[1:]
 	}
 
-	r.spans = append(r.spans, newSpan(span, sensor.agent.from))
+	r.spans = append(r.spans, newSpan(span))
 
 	if r.testMode || !sensor.agent.Ready() {
 		return

--- a/recorder.go
+++ b/recorder.go
@@ -124,13 +124,9 @@ func (r *Recorder) clearQueuedSpans() {
 // Retrieve the queued spans and post them to the host agent asynchronously.
 func (r *Recorder) send() {
 	spansToSend := r.GetQueuedSpans()
-	if len(spansToSend) > 0 {
-		go func() {
-			_, err := sensor.agent.request(sensor.agent.makeURL(agentTracesURL), "POST", spansToSend)
-			if err != nil {
-				sensor.logger.Debug("Posting traces failed in send(): ", err)
-				sensor.agent.reset()
-			}
-		}()
+	if len(spansToSend) == 0 {
+		return
 	}
+
+	go sensor.agent.SendSpans(spansToSend)
 }

--- a/recorder.go
+++ b/recorder.go
@@ -46,7 +46,7 @@ func (r *Recorder) init() {
 	ticker := time.NewTicker(1 * time.Second)
 	go func() {
 		for range ticker.C {
-			if sensor.agent.canSend() {
+			if sensor.agent.Ready() {
 				r.send()
 			}
 		}
@@ -58,7 +58,7 @@ func (r *Recorder) init() {
 func (r *Recorder) RecordSpan(span *spanS) {
 	// If we're not announced and not in test mode then just
 	// return
-	if !r.testMode && !sensor.agent.canSend() {
+	if !r.testMode && !sensor.agent.Ready() {
 		return
 	}
 
@@ -71,7 +71,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 
 	r.spans = append(r.spans, newSpan(span, sensor.agent.from))
 
-	if r.testMode || !sensor.agent.canSend() {
+	if r.testMode || !sensor.agent.Ready() {
 		return
 	}
 

--- a/sensor.go
+++ b/sensor.go
@@ -58,6 +58,10 @@ func (r *sensorS) setLogger(l LeveledLogger) {
 	if r.agent != nil {
 		r.agent.setLogger(r.logger)
 	}
+
+	if r.meter != nil {
+		r.meter.setLogger(r.logger)
+	}
 }
 
 // InitSensor intializes the sensor (without tracing) to begin collecting

--- a/sensor.go
+++ b/sensor.go
@@ -82,7 +82,7 @@ func InitSensor(options *Options) {
 		})
 
 		autoprofile.SetSendProfilesFunc(func(profiles interface{}) error {
-			if !sensor.agent.canSend() {
+			if !sensor.agent.Ready() {
 				return errors.New("sender not ready")
 			}
 

--- a/sensor.go
+++ b/sensor.go
@@ -47,7 +47,7 @@ func newSensor(options *Options) *sensorS {
 	}
 
 	s.agent = newAgent(s.serviceName, s.options.AgentHost, s.options.AgentPort, s.logger)
-	s.meter = newMeter(s)
+	s.meter = newMeter(s.agent, s.logger)
 
 	return s
 }

--- a/sensor.go
+++ b/sensor.go
@@ -13,9 +13,17 @@ const (
 	DefaultForceSpanSendAt  = 500
 )
 
+type agentClient interface {
+	Ready() bool
+	SendMetrics(data *MetricsS) error
+	SendEvent(event *EventData) error
+	SendSpans(spans []Span) error
+	SendProfiles(profiles []autoprofile.Profile) error
+}
+
 type sensorS struct {
 	meter       *meterS
-	agent       *agentS
+	agent       agentClient
 	logger      LeveledLogger
 	options     *Options
 	serviceName string
@@ -55,8 +63,8 @@ func newSensor(options *Options) *sensorS {
 func (r *sensorS) setLogger(l LeveledLogger) {
 	r.logger = l
 
-	if r.agent != nil {
-		r.agent.setLogger(r.logger)
+	if agent, ok := r.agent.(*agentS); ok && agent != nil {
+		agent.setLogger(r.logger)
 	}
 
 	if r.meter != nil {

--- a/sensor.go
+++ b/sensor.go
@@ -46,7 +46,7 @@ func newSensor(options *Options) *sensorS {
 		setLogLevel(l, options.LogLevel)
 	}
 
-	s.agent = newAgent(s.options.AgentHost, s.options.AgentPort, s.logger)
+	s.agent = newAgent(s.serviceName, s.options.AgentHost, s.options.AgentPort, s.logger)
 	s.meter = newMeter(s)
 
 	return s

--- a/sensor.go
+++ b/sensor.go
@@ -81,24 +81,14 @@ func InitSensor(options *Options) {
 			MaxBufferedProfiles:   options.MaxBufferedProfiles,
 		})
 
-		autoprofile.SetGetExternalPIDFunc(func() string {
-			return sensor.agent.from.PID
-		})
-
-		autoprofile.SetSendProfilesFunc(func(profiles interface{}) error {
+		autoprofile.SetSendProfilesFunc(func(profiles []autoprofile.Profile) error {
 			if !sensor.agent.Ready() {
 				return errors.New("sender not ready")
 			}
 
 			sensor.logger.Debug("sending profiles to agent")
 
-			_, err := sensor.agent.request(sensor.agent.makeURL(agentProfilesURL), "POST", profiles)
-			if err != nil {
-				sensor.agent.reset()
-				sensor.logger.Error(err)
-			}
-
-			return err
+			return sensor.agent.SendProfiles(profiles)
 		})
 
 		autoprofile.Enable()


### PR DESCRIPTION
This PR drops support for `go1.8` and introduces the following API for Instana agent:
```
interface {
	Ready() bool
	SendMetrics(data *instana.MetricsS) error
	SendEvent(event *instana.EventData) error
	SendSpans(spans []instana.Span) error
	SendProfiles(profiles []autoprofile.Profile) error
}
```
A stable interface allows to use different agent implementations depending on the environment.

There were some minor changes to the `autoprofile` API:
* `autoprofile.SetGetExternalPIDFunc()` is a noop function now, since PID is now being populated within the agent on send
* `autoprofile.SetSendProfilesFunc()` expects `autoprofile.SendProfilesFunc` as an argument that accepts data of concrete type instead of `interface{}` to avoid sending malformed data to the agent