### PR TITLE
Add Commit() method to sarama.ConsumerGroupSession mock

### DIFF
--- a/instrumentation/instasarama/consumer_group_handler_test.go
+++ b/instrumentation/instasarama/consumer_group_handler_test.go
@@ -206,6 +206,7 @@ type testConsumerGroupSession struct {
 	Messages []*sarama.ConsumerMessage
 }
 
+func (s *testConsumerGroupSession) Commit()                    {}
 func (s *testConsumerGroupSession) Claims() map[string][]int32 { return nil }
 func (s *testConsumerGroupSession) MemberID() string           { return "" }
 func (s *testConsumerGroupSession) GenerationID() int32        { return 0 }


### PR DESCRIPTION
The [upcoming changes](https://github.com/Shopify/sarama/pull/1699) in `github.com/Shopify/sarama` introduce a new method to the `sarama.ConsumerGroupSession` type. This PR modifies the test mock to satisfy the updated interface.