### PR TITLE
Extract shanpshot collector

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,42 @@
+package instana
+
+import (
+	"runtime"
+	"sync"
+	"time"
+)
+
+// SnapshotCollector returns a snapshot of Go runtime
+type SnapshotCollector struct {
+	ServiceName        string
+	CollectionInterval time.Duration
+
+	mu                 sync.RWMutex
+	lastCollectionTime time.Time
+}
+
+// Collect returns a snaphot of current runtime state. Any call this
+// method made before the next interval elapses will return nil
+func (sc *SnapshotCollector) Collect() *SnapshotS {
+	sc.mu.RLock()
+	lastSnapshotCollectionTime := sc.lastCollectionTime
+	sc.mu.RUnlock()
+
+	if time.Since(lastSnapshotCollectionTime) < sc.CollectionInterval {
+		return nil
+	}
+
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.lastCollectionTime = time.Now()
+
+	return &SnapshotS{
+		Name:     sc.ServiceName,
+		Version:  runtime.Version(),
+		Root:     runtime.GOROOT(),
+		MaxProcs: runtime.GOMAXPROCS(0),
+		Compiler: runtime.Compiler,
+		NumCPU:   runtime.NumCPU(),
+	}
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,47 @@
+package instana_test
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	instana "github.com/instana/go-sensor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotCollector_Collect(t *testing.T) {
+	sc := instana.SnapshotCollector{
+		ServiceName:        "test",
+		CollectionInterval: 500 * time.Millisecond,
+	}
+
+	assert.Equal(t, &instana.SnapshotS{
+		Name:     sc.ServiceName,
+		Version:  runtime.Version(),
+		Root:     runtime.GOROOT(),
+		MaxProcs: runtime.GOMAXPROCS(0),
+		Compiler: runtime.Compiler,
+		NumCPU:   runtime.NumCPU(),
+	}, sc.Collect())
+
+	t.Run("second call before collection interval", func(t *testing.T) {
+		assert.Nil(t, sc.Collect())
+	})
+
+	t.Run("second call after collection interval", func(t *testing.T) {
+		oldNumProcs := runtime.GOMAXPROCS(0)
+		defer runtime.GOMAXPROCS(oldNumProcs)
+
+		time.Sleep(sc.CollectionInterval)
+		runtime.GOMAXPROCS(oldNumProcs + 1)
+
+		assert.Equal(t, &instana.SnapshotS{
+			Name:     sc.ServiceName,
+			Version:  runtime.Version(),
+			Root:     runtime.GOROOT(),
+			MaxProcs: oldNumProcs + 1,
+			Compiler: runtime.Compiler,
+			NumCPU:   runtime.NumCPU(),
+		}, sc.Collect())
+	})
+}


### PR DESCRIPTION
This PR extracts Go runtime snapshot collection into `instana.SnapshotCollector`, so it could be reused in other agent implementations.