### PR TITLE
Enable AutoProfile™ via an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,27 @@ To learn more, see the [Events API](https://github.com/instana/go-sensor/blob/ma
 
 AutoProfile™ generates and reports process profiles to Instana. Unlike development-time and on-demand profilers, where a user must manually initiate profiling, AutoProfile™ automatically schedules and continuously performs profiling appropriate for critical production environments.
 
+### Activation from within the application code
+
+To enable continuous profiling for your service provide `EnableAutoProfile: true` while initializing the sensor:
+
+```go
+func main() {
+	instana.InitSensor(&instana.Options{
+		EnableAutoProfile: true,
+		// ...other options
+	})
+
+	// ...
+}
+```
+
+To temporarily turn AutoProfile™ on and off from your code, call `autoprofile.Enable()` and `autoprofile.Disable()`.
+
+### Activation without code changes
+
+To enable AutoProfile™ for an app without code changes, set `INSTANA_AUTO_PROFILE=true` env variable. Note that this value takes precedence and overrides any attempt to disable profiling from inside the application code.
+
 ## Examples
 
 Following examples are included in the `example` folder:

--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -1,6 +1,8 @@
 package autoprofile
 
 import (
+	"os"
+
 	"github.com/instana/go-sensor/autoprofile/internal"
 	"github.com/instana/go-sensor/autoprofile/internal/logger"
 	instalogger "github.com/instana/go-sensor/logger"
@@ -79,6 +81,11 @@ func Enable() {
 // Disable disables the auto profiling (default)
 func Disable() {
 	if !enabled {
+		return
+	}
+
+	if _, ok := os.LookupEnv("INSTANA_AUTO_PROFILE"); ok {
+		logger.Info("INSTANA_AUTO_PROFILE is set, ignoring the attempt to disable AutoProfile™")
 		return
 	}
 

--- a/sensor.go
+++ b/sensor.go
@@ -81,24 +81,24 @@ func InitSensor(options *Options) {
 
 	sensor = newSensor(options)
 
-	// enable auto-profiling
+	// configure auto-profiling
+	autoprofile.SetLogger(sensor.logger)
+	autoprofile.SetOptions(autoprofile.Options{
+		IncludeProfilerFrames: options.IncludeProfilerFrames,
+		MaxBufferedProfiles:   options.MaxBufferedProfiles,
+	})
+
+	autoprofile.SetSendProfilesFunc(func(profiles []autoprofile.Profile) error {
+		if !sensor.agent.Ready() {
+			return errors.New("sender not ready")
+		}
+
+		sensor.logger.Debug("sending profiles to agent")
+
+		return sensor.agent.SendProfiles(profiles)
+	})
+
 	if options.EnableAutoProfile {
-		autoprofile.SetLogger(sensor.logger)
-		autoprofile.SetOptions(autoprofile.Options{
-			IncludeProfilerFrames: options.IncludeProfilerFrames,
-			MaxBufferedProfiles:   options.MaxBufferedProfiles,
-		})
-
-		autoprofile.SetSendProfilesFunc(func(profiles []autoprofile.Profile) error {
-			if !sensor.agent.Ready() {
-				return errors.New("sender not ready")
-			}
-
-			sensor.logger.Debug("sending profiles to agent")
-
-			return sensor.agent.SendProfiles(profiles)
-		})
-
 		autoprofile.Enable()
 	}
 

--- a/sensor.go
+++ b/sensor.go
@@ -98,7 +98,11 @@ func InitSensor(options *Options) {
 		return sensor.agent.SendProfiles(profiles)
 	})
 
-	if options.EnableAutoProfile {
+	if _, ok := os.LookupEnv("INSTANA_AUTO_PROFILE"); ok || options.EnableAutoProfile {
+		if !options.EnableAutoProfile {
+			sensor.logger.Info("INSTANA_AUTO_PROFILE is set, activating AutoProfile™")
+		}
+
 		autoprofile.Enable()
 	}
 


### PR DESCRIPTION
This PR introduces a new configuration env variable `INSTANA_AUTO_PROFILE` to forcefully enable the AutoProfile™ without code changes. Once set, this value overrides any attempts to disable the profiling from the app code.