### PR TITLE
Dont send default service name with traces

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,10 +41,6 @@ func (opts *Options) setDefaults() {
 		opts.ForceTransmissionStartingAt = DefaultForceSpanSendAt
 	}
 
-	if opts.Service == "" {
-		opts.Service = binaryName
-	}
-
 	if opts.AgentHost == "" {
 		opts.AgentHost = agentDefaultHost
 

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package instana
 
 import (
 	"os"
-	"path/filepath"
 	"strconv"
 )
 
@@ -43,7 +42,7 @@ func (opts *Options) setDefaults() {
 	}
 
 	if opts.Service == "" {
-		opts.Service = filepath.Base(os.Args[0])
+		opts.Service = binaryName
 	}
 
 	if opts.AgentHost == "" {

--- a/options_test.go
+++ b/options_test.go
@@ -13,6 +13,5 @@ func TestDefaultOptions(t *testing.T) {
 		AgentPort:                   42699,
 		MaxBufferedSpans:            instana.DefaultMaxBufferedSpans,
 		ForceTransmissionStartingAt: instana.DefaultForceSpanSendAt,
-		Service:                     "go-sensor.test",
 	}, instana.DefaultOptions())
 }

--- a/sensor.go
+++ b/sensor.go
@@ -3,6 +3,7 @@ package instana
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/instana/go-sensor/autoprofile"
 	"github.com/instana/go-sensor/logger"
@@ -30,6 +31,7 @@ type sensorS struct {
 }
 
 var sensor *sensorS
+var binaryName = filepath.Base(os.Args[0])
 
 func newSensor(options *Options) *sensorS {
 	if options == nil {

--- a/sensor.go
+++ b/sensor.go
@@ -44,6 +44,10 @@ func newSensor(options *Options) *sensorS {
 		options:     options,
 		serviceName: options.Service,
 	}
+	if s.serviceName == "" {
+		s.serviceName = binaryName
+	}
+
 	s.setLogger(defaultLogger)
 
 	// override service name with an env value if set

--- a/span_test.go
+++ b/span_test.go
@@ -22,7 +22,7 @@ func TestBasicSpan(t *testing.T) {
 	sp.Finish()
 
 	spans := recorder.GetQueuedSpans()
-	assert.Equal(t, 1, len(spans))
+	require.Len(t, spans, 1)
 	span := spans[0]
 
 	assert.NotEmpty(t, span.SpanID)
@@ -33,7 +33,7 @@ func TestBasicSpan(t *testing.T) {
 
 	require.IsType(t, instana.SDKSpanData{}, span.Data)
 	data := span.Data.(instana.SDKSpanData)
-	assert.Equal(t, "go-sensor.test", data.Service)
+	assert.Empty(t, data.Service)
 
 	assert.Equal(t, "test", data.Tags.Name)
 	assert.Nil(t, data.Tags.Custom["tags"])
@@ -52,7 +52,7 @@ func TestSpanHeritage(t *testing.T) {
 	parentSpan.Finish()
 
 	spans := recorder.GetQueuedSpans()
-	assert.Equal(t, len(spans), 2)
+	require.Len(t, spans, 2)
 
 	cSpan, pSpan := spans[0], spans[1]
 

--- a/tracer.go
+++ b/tracer.go
@@ -71,7 +71,7 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 	return &spanS{
 		context:   sc,
 		tracer:    r,
-		Service:   sensor.serviceName,
+		Service:   sensor.options.Service,
 		Operation: operationName,
 		Start:     startTime,
 		Duration:  -1,


### PR DESCRIPTION
This PR addresses an issue when a custom service name configured via `instana.Options` caused two services appearing under the same runtime in UI if an app is running in a containerized environment. Once merged, the tracer will only populate the `data.service.name` tag if the service name has been set explicitly either via `INSTANA_SERVICE_NAME` env var or `(instana.Options).Service` config option.