### PR TITLE
Add support for HTTP templated paths

### DIFF
--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -20,11 +20,7 @@ func TestTracingHandlerFunc_Write(t *testing.T) {
 		Service: "go-sensor-test",
 	}, recorder))
 
-	h := instana.TracingHandlerFunc(s, "test-handler", func(w http.ResponseWriter, req *http.Request) {
-		if sp, ok := instana.SpanFromContext(req.Context()); ok {
-			sp.SetTag("http.path_tpl", "/{action}")
-		}
-
+	h := instana.TracingHandlerFunc(s, "/{action}", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
 	})
 
@@ -66,7 +62,7 @@ func TestTracingHandlerFunc_WriteHeaders(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
 
-	h := instana.TracingHandlerFunc(s, "test-handler", func(w http.ResponseWriter, req *http.Request) {
+	h := instana.TracingHandlerFunc(s, "/test", func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
@@ -98,7 +94,7 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
 
-	h := instana.TracingHandlerFunc(s, "test-handler", func(w http.ResponseWriter, req *http.Request) {
+	h := instana.TracingHandlerFunc(s, "/test", func(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "something went wrong", http.StatusInternalServerError)
 	})
 
@@ -222,7 +218,7 @@ func TestTracingHandlerFunc_PanicHandling(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
 
-	h := instana.TracingHandlerFunc(s, "test-handler", func(w http.ResponseWriter, req *http.Request) {
+	h := instana.TracingHandlerFunc(s, "/test", func(w http.ResponseWriter, req *http.Request) {
 		panic("something went wrong")
 	})
 

--- a/json_span.go
+++ b/json_span.go
@@ -272,6 +272,8 @@ type HTTPSpanTags struct {
 	Method string `json:"method,omitempty"`
 	// Path is the path part of the request URL
 	Path string `json:"path,omitempty"`
+	// PathTemplate is the raw template string used to route the request
+	PathTemplate string `json:"path_tpl,omitempty"`
 	// The name:port of the host to which the request had been sent
 	Host string `json:"host,omitempty"`
 	// The name of the protocol used for request ("http" or "https")
@@ -293,6 +295,8 @@ func NewHTTPSpanTags(span *spanS) HTTPSpanTags {
 			readStringTag(&tags.Method, v)
 		case "http.path":
 			readStringTag(&tags.Path, v)
+		case "http.path_tpl":
+			readStringTag(&tags.PathTemplate, v)
 		case "http.host":
 			readStringTag(&tags.Host, v)
 		case "http.protocol":


### PR DESCRIPTION
This PR adds support for forwarding the path template used to match an HTTP request to the handler. The template string can either be specified during the instrumentation by providing it as an argument to `instana.TracingHandlerFunc()` or added as a custom tag `http.path_tpl` to the incoming request span.

### Providing path template during instrumentation

```go
// Provide the template string as an argument to instana.TracingHandlerFunc()
instrumentedHandler := instana.TracingHandlerFunc(sensor, "/articles/{category}/{id:[0-9]+}", Handler)
// Register your instrumented handler
r.HandleFunc("/articles/{category}/{id:[0-9]+}", instrumentedHandler)
```

Please note that the agent will attempt to detect whether a request has been routed via pattern matching by comparing it to `(*http.Request).Path` and only populate the `http.path_tpl` if these values differ.

### Adding a path template to the request span

```go
func Handler(w http.ResponseWriter, req *http.Request) {
	// Extract the request span from context and add an `http.path_tpl` tag to it
	if parent, ok := instana.SpanFromContext(req.Context()); ok {
		parent.SetTag("http.path_tpl", "/articles/{category}/{id:[0-9]+}")
	}

	// ...
}
```