### PR TITLE
Support EUM script correlation

### DIFF
--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -227,8 +227,6 @@ func TestTracingHandlerFunc_EUMCall(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set(instana.FieldT, "0000000000002435")
-	req.Header.Set(instana.FieldS, "0000000000003546")
 	req.Header.Set(instana.FieldL, "1,correlationType=web;correlationId=eum correlation id")
 
 	h.ServeHTTP(rec, req)

--- a/json_span.go
+++ b/json_span.go
@@ -111,34 +111,38 @@ func newW3CForeignParent(trCtx w3ctrace.Context) *ForeignParent {
 
 // Span represents the OpenTracing span document to be sent to the agent
 type Span struct {
-	TraceID       int64          `json:"t"`
-	ParentID      int64          `json:"p,omitempty"`
-	SpanID        int64          `json:"s"`
-	Timestamp     uint64         `json:"ts"`
-	Duration      uint64         `json:"d"`
-	Name          string         `json:"n"`
-	From          *fromS         `json:"f"`
-	Batch         *batchInfo     `json:"b,omitempty"`
-	Kind          int            `json:"k"`
-	Ec            int            `json:"ec,omitempty"`
-	Data          typedSpanData  `json:"data"`
-	Synthetic     bool           `json:"sy,omitempty"`
-	ForeignParent *ForeignParent `json:"fp,omitempty"`
+	TraceID         int64          `json:"t"`
+	ParentID        int64          `json:"p,omitempty"`
+	SpanID          int64          `json:"s"`
+	Timestamp       uint64         `json:"ts"`
+	Duration        uint64         `json:"d"`
+	Name            string         `json:"n"`
+	From            *fromS         `json:"f"`
+	Batch           *batchInfo     `json:"b,omitempty"`
+	Kind            int            `json:"k"`
+	Ec              int            `json:"ec,omitempty"`
+	Data            typedSpanData  `json:"data"`
+	Synthetic       bool           `json:"sy,omitempty"`
+	ForeignParent   *ForeignParent `json:"fp,omitempty"`
+	CorrelationType string         `json:"crtp,omitempty"`
+	CorrelationID   string         `json:"crid,omitempty"`
 }
 
 func newSpan(span *spanS) Span {
 	data := RegisteredSpanType(span.Operation).ExtractData(span)
 	sp := Span{
-		TraceID:       span.context.TraceID,
-		ParentID:      span.context.ParentID,
-		SpanID:        span.context.SpanID,
-		Timestamp:     uint64(span.Start.UnixNano()) / uint64(time.Millisecond),
-		Duration:      uint64(span.Duration) / uint64(time.Millisecond),
-		Name:          string(data.Type()),
-		Ec:            span.ErrorCount,
-		ForeignParent: newForeignParent(span.context.ForeignParent),
-		Kind:          int(data.Kind()),
-		Data:          data,
+		TraceID:         span.context.TraceID,
+		ParentID:        span.context.ParentID,
+		SpanID:          span.context.SpanID,
+		Timestamp:       uint64(span.Start.UnixNano()) / uint64(time.Millisecond),
+		Duration:        uint64(span.Duration) / uint64(time.Millisecond),
+		Name:            string(data.Type()),
+		Ec:              span.ErrorCount,
+		ForeignParent:   newForeignParent(span.context.ForeignParent),
+		CorrelationType: span.Correlation.Type,
+		CorrelationID:   span.Correlation.ID,
+		Kind:            int(data.Kind()),
+		Data:            data,
 	}
 
 	if bs, ok := span.Tags[batchSizeTag].(int); ok {

--- a/propagation.go
+++ b/propagation.go
@@ -135,7 +135,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 	}
 
 	if traceID == "" && spanID == "" {
-		if spanContext.W3CContext.IsZero() {
+		if spanContext.W3CContext.IsZero() && spanContext.Correlation.ID == "" {
 			return spanContext, ot.ErrSpanContextNotFound
 		}
 

--- a/propagation_internal_test.go
+++ b/propagation_internal_test.go
@@ -1,0 +1,49 @@
+package instana
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	examples := map[string]struct {
+		Value               string
+		ExpectedSuppressed  bool
+		ExpectedCorrelation EUMCorrelationData
+	}{
+		"empty header": {},
+		"level=0, no correlation id": {
+			Value:              "0",
+			ExpectedSuppressed: true,
+		},
+		"level=1, no correlation id": {
+			Value: "1",
+		},
+		"level=0, with correlation id": {
+			Value:              "0   ,   correlationType=web  ;\t  correlationId=Test Value",
+			ExpectedSuppressed: true,
+			ExpectedCorrelation: EUMCorrelationData{
+				Type: "web",
+				ID:   "Test Value",
+			},
+		},
+		"level=1, with correlation id": {
+			Value: "1,correlationType=mobile;correlationId=Test Value",
+			ExpectedCorrelation: EUMCorrelationData{
+				Type: "mobile",
+				ID:   "Test Value",
+			},
+		},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			suppressed, corrData, err := parseLevel(example.Value)
+			require.NoError(t, err)
+			assert.Equal(t, example.ExpectedSuppressed, suppressed)
+			assert.Equal(t, example.ExpectedCorrelation, corrData)
+		})
+	}
+}

--- a/span.go
+++ b/span.go
@@ -9,13 +9,14 @@ import (
 )
 
 type spanS struct {
-	Service    string
-	Operation  string
-	Start      time.Time
-	Duration   time.Duration
-	Tags       ot.Tags
-	Logs       []ot.LogRecord
-	ErrorCount int
+	Service     string
+	Operation   string
+	Start       time.Time
+	Duration    time.Duration
+	Correlation EUMCorrelationData
+	Tags        ot.Tags
+	Logs        []ot.LogRecord
+	ErrorCount  int
 
 	tracer *tracerS
 	mu     sync.Mutex

--- a/span_context.go
+++ b/span_context.go
@@ -6,6 +6,13 @@ import (
 	"github.com/instana/go-sensor/w3ctrace"
 )
 
+// EUMCorrelationData represents the data sent by the Instana End-User Monitoring script
+// integrated into frontend
+type EUMCorrelationData struct {
+	Type string
+	ID   string
+}
+
 // SpanContext holds the basic Span metadata.
 type SpanContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
@@ -22,6 +29,8 @@ type SpanContext struct {
 	Baggage map[string]string // initialized on first use
 	// The W3C trace context
 	W3CContext w3ctrace.Context
+	// Correlation is the correlation data sent by the frontend EUM script
+	Correlation EUMCorrelationData
 	// The 3rd party parent if the context is derived from non-Instana trace
 	ForeignParent interface{}
 }

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -47,6 +47,14 @@ func TestNewSpanContext(t *testing.T) {
 				RawState:  "in=1234;5678,vendor1=data",
 			},
 		},
+		"with correlation data": {
+			TraceID: 1,
+			SpanID:  2,
+			Correlation: instana.EUMCorrelationData{
+				Type: "web",
+				ID:   "1",
+			},
+		},
 	}
 
 	for name, parent := range examples {
@@ -57,6 +65,7 @@ func TestNewSpanContext(t *testing.T) {
 			assert.Equal(t, parent.Sampled, c.Sampled)
 			assert.Equal(t, parent.Suppressed, c.Suppressed)
 			assert.Equal(t, parent.W3CContext, c.W3CContext)
+			assert.Equal(t, instana.EUMCorrelationData{}, c.Correlation)
 			assert.Equal(t, parent.Baggage, c.Baggage)
 
 			assert.NotEqual(t, parent.SpanID, c.SpanID)
@@ -73,6 +82,7 @@ func TestNewSpanContext_EmptyParent(t *testing.T) {
 	assert.Equal(t, c.SpanID, c.TraceID)
 	assert.False(t, c.Sampled)
 	assert.False(t, c.Suppressed)
+	assert.Equal(t, instana.EUMCorrelationData{}, c.Correlation)
 	assert.Empty(t, c.Baggage)
 	assert.Nil(t, c.ForeignParent)
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
+	ot "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,4 +42,19 @@ func TestTracer_StartSpan_SuppressTracing(t *testing.T) {
 
 	sc := sp.Context().(instana.SpanContext)
 	assert.True(t, sc.Suppressed)
+}
+
+func TestTracer_StartSpan_WithCorrelationData(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	sp := tracer.StartSpan("test", ot.ChildOf(instana.SpanContext{
+		Correlation: instana.EUMCorrelationData{
+			Type: "type1",
+			ID:   "id1",
+		},
+	}))
+
+	sc := sp.Context().(instana.SpanContext)
+	assert.Equal(t, instana.EUMCorrelationData{}, sc.Correlation)
 }


### PR DESCRIPTION
Forward the correlation ID and type provided by Instana end-user monitoring script to the host agent in `span.crid` and `span.crtp` fields. These values override provided `X-Instana-T` and `X-Instana-S` header values, effectively forcing a new trace when provided.