### PR TITLE
Vendor test dependencies on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - go: 1.12.x
     - go: 1.13.x
     - go: 1.14.x
+    - go: 1.15.x
       env: RUN_LINTER=yes
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ matrix:
   include:
     - go: tip
     - go: 1.9.x
+      env: VENDOR_DEPS=yes
     - go: 1.10.x
+      env: VENDOR_DEPS=yes
     - go: 1.11.x
     - go: 1.12.x
     - go: 1.13.x

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,19 @@ MODULES = $(filter-out $(EXCLUDE_DIRS), $(shell find . -name go.mod -exec dirnam
 LINTER ?= $(shell go env GOPATH)/bin/golangci-lint
 INTEGRATION_TESTS = fargate_integration
 
+# the Go version to vendor dependencies listed in go.mod
+VENDOR_GO_VERSION ?= go1.15
+VENDOR_GO = $(shell go env GOPATH)/bin/$(VENDOR_GO_VERSION)
+MODULES_VENDOR = $(addsuffix /vendor,$(MODULES))
+
 ifdef RUN_LINTER
 test: $(LINTER)
+endif
+
+ifdef VENDOR_DEPS
+# We need to vendor all dependencies at once before running test, so the `go get -t -d ./...`
+# on go1.9 and go1.10 does not try to re-download them
+test: $(MODULES_VENDOR)
 endif
 
 test: $(MODULES)
@@ -24,4 +35,13 @@ $(LINTER):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/a2bc9b7a99e3280805309d71036e8c2106853250/install.sh \
 	| sh -s -- -b $(basename $(GOPATH))/bin v1.23.8
 
-.PHONY: test $(MODULES) $(INTEGRATION_TESTS)
+
+$(MODULES_VENDOR): $(VENDOR_GO)
+	cd $(shell dirname $@) && $(VENDOR_GO) mod vendor 
+	find $@ -name go.mod -delete
+
+$(VENDOR_GO):
+	go get golang.org/dl/$(VENDOR_GO_VERSION)
+	$(VENDOR_GO) download
+
+.PHONY: test vendor $(MODULES) $(INTEGRATION_TESTS)


### PR DESCRIPTION
This PR adds a workaround for testing against Go versions prior to go1.11 that ignore module versions listed in `go.mod` and use one available in `master` instead. The latest versions of these modules are not guaranteed to be compatible with legacy versions of Go leading to false negative test failures.

Whenever the `VENDOR_DEPS` variable is set, `make test` will download the `go` tool with modules support (`go1.15`) and vendor all dependencies before executing tests.