### PR TITLE
Collect HTTP request parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Instana Go sensor consists of two parts:
 * [Common Operations](#common-operations)
   * [Setting the sensor log output](#setting-the-sensor-log-output)
   * [Trace Context Propagation](#trace-context-propagation)
+  * [Secrets Filtering](#secrets-filtering)
   * [HTTP servers and clients](#http-servers-and-clients)
     * [Instrumenting HTTP request handling](#instrumenting-http-request-handling)
     * [Instrumenting HTTP request execution](#instrumenting-http-request-execution)
@@ -177,7 +178,16 @@ func MyFunc(ctx context.Context) {
 }
 ```
 
+### Secrets Filtering
+
+Certain instrumentations provided by the Go sensor package, e.g. the [HTTP servers and clients](#http-servers-and-clients) wrappers, collect data that may contain sensitive information, such as passwords, keys and secrets. To avoid leaking these values the Go sensor replaces them with `<redacted>` before sending to the agent. The list of parameter name matchers is defined in `com.instana.secrets` section of the [Host Agent Configuration file](https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#secrets) and will be sent to the in-app tracer during the announcement phase (requires agent Go trace plugin `com.instana.sensor-golang-trace` v1.3.0 and above).
+
+The default setting for the secrets matcher is `contains-ignore-case` with following list of terms: `key`, `password`, `secret`. This would redact the value of a parameter which name _contains_ any of these strings ignoring the case.
+
 ### HTTP servers and clients
+
+The Go sensor module provides instrumentation for clients and servers that use `net/http` package. Once activated (see below) this
+instrumentation automatically collects information about incoming and outgoing requests and sends it to the Instana agent. See the [instana.HTTPSpanTags][instana.HTTPSpanTags] documentation to learn which call details are collected.
 
 #### Instrumenting HTTP request handling
 
@@ -351,3 +361,4 @@ For more examples please consult the [godoc][godoc].
 [pkg.go.dev]: https://pkg.go.dev/github.com/instana/go-sensor
 [instana.TracingHandlerFunc]: https://pkg.go.dev/github.com/instana/go-sensor/?tab=doc#TracingHandlerFunc
 [instana.RoundTripper]: https://pkg.go.dev/github.com/instana/go-sensor/?tab=doc#RoundTripper
+[instana.HTTPSpanTags]: https://pkg.go.dev/github.com/instana/go-sensor/?tab=doc#HTTPSpanTags

--- a/adapters.go
+++ b/adapters.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"runtime"
 
+	"github.com/opentracing/opentracing-go"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -12,6 +13,14 @@ import (
 
 type SpanSensitiveFunc func(span ot.Span)
 type ContextSensitiveFunc func(span ot.Span, ctx context.Context)
+
+// Tracer extends the opentracing.Tracer interface
+type Tracer interface {
+	opentracing.Tracer
+
+	// Options gets the current tracer options
+	Options() TracerOptions
+}
 
 // Sensor is used to inject tracing information into requests
 type Sensor struct {

--- a/agent.go
+++ b/agent.go
@@ -278,8 +278,8 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 	return ret, err
 }
 
-func (r *agentS) setFrom(from *fromS) {
-	r.from = from
+func (r *agentS) applyHostAgentSettings(resp agentResponse) {
+	r.from = newHostAgentFromS(int(resp.Pid), resp.HostID)
 }
 
 func (r *agentS) setHost(host string) {

--- a/agent.go
+++ b/agent.go
@@ -29,8 +29,12 @@ const (
 )
 
 type agentResponse struct {
-	Pid    uint32 `json:"pid"`
-	HostID string `json:"agentUuid"`
+	Pid     uint32 `json:"pid"`
+	HostID  string `json:"agentUuid"`
+	Secrets struct {
+		Matcher string   `json:"matcher"`
+		List    []string `json:"list"`
+	} `json:"secrets"`
 }
 
 type discoveryS struct {
@@ -280,6 +284,15 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 
 func (r *agentS) applyHostAgentSettings(resp agentResponse) {
 	r.from = newHostAgentFromS(int(resp.Pid), resp.HostID)
+
+	if resp.Secrets.Matcher != "" {
+		m, err := NamedMatcher(resp.Secrets.Matcher, resp.Secrets.List)
+		if err != nil {
+			r.logger.Warn("failed to apply secrets matcher configuration: %s", err)
+		} else {
+			sensor.options.Tracer.Secrets = m
+		}
+	}
 }
 
 func (r *agentS) setHost(host string) {

--- a/json_span.go
+++ b/json_span.go
@@ -276,6 +276,8 @@ type HTTPSpanTags struct {
 	Method string `json:"method,omitempty"`
 	// Path is the path part of the request URL
 	Path string `json:"path,omitempty"`
+	// Params are the request query string parameters
+	Params string `json:"params,omitempty"`
 	// PathTemplate is the raw template string used to route the request
 	PathTemplate string `json:"path_tpl,omitempty"`
 	// The name:port of the host to which the request had been sent
@@ -299,6 +301,8 @@ func NewHTTPSpanTags(span *spanS) HTTPSpanTags {
 			readStringTag(&tags.Method, v)
 		case "http.path":
 			readStringTag(&tags.Path, v)
+		case "http.params":
+			readStringTag(&tags.Params, v)
 		case "http.path_tpl":
 			readStringTag(&tags.PathTemplate, v)
 		case "http.host":

--- a/matcher.go
+++ b/matcher.go
@@ -62,3 +62,10 @@ func NamedMatcher(name string, list []string) (Matcher, error) {
 		return nil, fmt.Errorf("unknown secrets matcher type %q", name)
 	}
 }
+
+// DefaultSecretsMatcher returns the default secrets matcher, that matches strings containing
+// "key", "password" and "secret" ignoring the case
+func DefaultSecretsMatcher() Matcher {
+	m, _ := NamedMatcher(ContainsIgnoreCaseMatcher, []string{"key", "password", "secret"})
+	return m
+}

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,64 @@
+package instana
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/instana/go-sensor/secrets"
+)
+
+const (
+	// EqualsMatcher matches the string exactly
+	EqualsMatcher = "equals"
+	// EqualsIgnoreCaseMatcher matches the string exactly ignoring the case
+	EqualsIgnoreCaseMatcher = "equals-ignore-case"
+	// Contains matches the substring in a string
+	ContainsMatcher = "contains"
+	// ContainsIgnoreCaseMatcher matches the substring in a string ignoring the case
+	ContainsIgnoreCaseMatcher = "contains-ignore-case"
+	// RegexpMatcher matches the string using a set of regular expressions. Each item in a term list
+	// provided to instana.NamedMatcher() must be a valid regular expression that can be compiled using
+	// regexp.Compile()
+	RegexpMatcher = "regex"
+	// NoneMatcher does not match any string
+	NoneMatcher = "none"
+)
+
+// Matcher verifies whether a string meets predefined conditions
+type Matcher interface {
+	Match(s string) bool
+}
+
+// NamedMatcher returns a secrets matcher supported by Instana host agent configuration
+//
+// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#secrets
+func NamedMatcher(name string, list []string) (Matcher, error) {
+	switch strings.ToLower(name) {
+	case EqualsMatcher:
+		return secrets.NewEqualsMatcher(list...), nil
+	case EqualsIgnoreCaseMatcher:
+		return secrets.NewEqualsIgnoreCaseMatcher(list...), nil
+	case ContainsMatcher:
+		return secrets.NewContainsMatcher(list...), nil
+	case ContainsIgnoreCaseMatcher:
+		return secrets.NewContainsIgnoreCaseMatcher(list...), nil
+	case RegexpMatcher:
+		var exps []*regexp.Regexp
+		for _, s := range list {
+			ex, err := regexp.Compile(s)
+			if err != nil {
+				sensor.logger.Warn("ignoring malformed regexp secrets matcher %s: %s", s, err)
+				continue
+			}
+
+			exps = append(exps, ex)
+		}
+
+		return secrets.NewRegexpMatcher(exps...)
+	case NoneMatcher:
+		return secrets.NoneMatcher{}, nil
+	default:
+		return nil, fmt.Errorf("unknown secrets matcher type %q", name)
+	}
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,71 @@
+package instana_test
+
+import (
+	"testing"
+
+	instana "github.com/instana/go-sensor"
+	"github.com/instana/testify/assert"
+	"github.com/instana/testify/require"
+)
+
+func TestNamedMatcher(t *testing.T) {
+	examples := map[string]struct {
+		List               []string
+		MatchingStrings    []string
+		NonMatchingStrings []string
+	}{
+		"equals": {
+			List:               []string{"foo", "bar"},
+			MatchingStrings:    []string{"foo", "bar"},
+			NonMatchingStrings: []string{"Foo", "foobar", "baz"},
+		},
+		"equals-ignore-case": {
+			List:               []string{"foo", "bar"},
+			MatchingStrings:    []string{"foo", "bar", "Foo"},
+			NonMatchingStrings: []string{"foobar", "baz"},
+		},
+		"contains": {
+			List:               []string{"foo", "bar"},
+			MatchingStrings:    []string{"foo", "foobar", "Foobar"},
+			NonMatchingStrings: []string{"baz", "FooBar"},
+		},
+		"contains-ignore-case": {
+			List:               []string{"foo", "bar"},
+			MatchingStrings:    []string{"foo", "foobar", "Foobar", "FooBar"},
+			NonMatchingStrings: []string{"baz"},
+		},
+		"regex": {
+			List:               []string{"(?i)foo.+", "ba[rz]"},
+			MatchingStrings:    []string{"foobar", "Foobar", "FooBar", "baz"},
+			NonMatchingStrings: []string{"foo", "bap"},
+		},
+		"none": {
+			List:               []string{"foo", "bar"},
+			NonMatchingStrings: []string{"foo", "bar", "baz"},
+		},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			m, err := instana.NamedMatcher(name, example.List)
+			require.NoError(t, err)
+
+			for _, s := range example.MatchingStrings {
+				t.Run(s, func(t *testing.T) {
+					assert.True(t, m.Match(s))
+				})
+			}
+
+			for _, s := range example.NonMatchingStrings {
+				t.Run(s, func(t *testing.T) {
+					assert.False(t, m.Match(s))
+				})
+			}
+		})
+	}
+}
+
+func TestNamedMatcher_Unsupported(t *testing.T) {
+	_, err := instana.NamedMatcher("custom", []string{"foo", "bar"})
+	assert.Error(t, err)
+}

--- a/options.go
+++ b/options.go
@@ -5,8 +5,7 @@ import (
 	"strconv"
 )
 
-// Options allows the user to configure the to-be-initialized
-// sensor
+// Options allows the user to configure the to-be-initialized sensor
 type Options struct {
 	Service                     string
 	AgentHost                   string
@@ -17,6 +16,7 @@ type Options struct {
 	EnableAutoProfile           bool
 	MaxBufferedProfiles         int
 	IncludeProfilerFrames       bool
+	Tracer                      TracerOptions
 }
 
 // DefaultOptions returns the default set of options to configure Instana sensor.
@@ -26,7 +26,9 @@ type Options struct {
 // taken from the env INSTANA_AGENT_HOST and INSTANA_AGENT_PORT if set, and default
 // to localhost and 46999 otherwise.
 func DefaultOptions() *Options {
-	opts := &Options{}
+	opts := &Options{
+		Tracer: DefaultTracerOptions(),
+	}
 	opts.setDefaults()
 
 	return opts
@@ -55,5 +57,9 @@ func (opts *Options) setDefaults() {
 		if port, err := strconv.Atoi(os.Getenv("INSTANA_AGENT_PORT")); err == nil {
 			opts.AgentPort = port
 		}
+	}
+
+	if opts.Tracer.Secrets == nil {
+		opts.Tracer = DefaultTracerOptions()
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -13,5 +13,6 @@ func TestDefaultOptions(t *testing.T) {
 		AgentPort:                   42699,
 		MaxBufferedSpans:            instana.DefaultMaxBufferedSpans,
 		ForceTransmissionStartingAt: instana.DefaultForceSpanSendAt,
+		Tracer:                      instana.DefaultTracerOptions(),
 	}, instana.DefaultOptions())
 }

--- a/secrets/matchers.go
+++ b/secrets/matchers.go
@@ -7,6 +7,12 @@ import (
 	"strings"
 )
 
+// NoneMatcher does not match any string. It's used as a default value for (instana.Options).Secrets
+type NoneMatcher struct{}
+
+// Match returns false for any string
+func (m NoneMatcher) Match(s string) bool { return false }
+
 // EqualsMatcher matches a string that is contained in the terms list. This is the
 // matcher for the 'equals' match type
 type EqualsMatcher struct {

--- a/secrets/matchers.go
+++ b/secrets/matchers.go
@@ -1,0 +1,149 @@
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// EqualsMatcher matches a string that is contained in the terms list. This is the
+// matcher for the 'equals' match type
+type EqualsMatcher struct {
+	list []string
+}
+
+// NewEqualsMatcher returns an EqualsMatcher for a list of terms
+func NewEqualsMatcher(terms ...string) EqualsMatcher {
+	return EqualsMatcher{terms}
+}
+
+// Match returns true if provided value present in matcher's terms list
+func (m EqualsMatcher) Match(s string) bool {
+	for _, term := range m.list {
+		if term == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// EqualsIgnoreCaseMatcher is the case-insensitive version of EqualsMatcher. This
+// is the matcher for the 'equals-ignore-case' match type
+type EqualsIgnoreCaseMatcher struct {
+	m EqualsMatcher
+}
+
+// NewEqualsIgnoreCaseMatcher returns an EqualsIgnoreCaseMatcher for a list of terms
+func NewEqualsIgnoreCaseMatcher(terms ...string) EqualsIgnoreCaseMatcher {
+	for i := range terms {
+		terms[i] = strings.ToLower(terms[i])
+	}
+
+	return EqualsIgnoreCaseMatcher{
+		m: NewEqualsMatcher(terms...),
+	}
+}
+
+// Match returns true if provided value present in matcher's terms list regardless of the case
+func (m EqualsIgnoreCaseMatcher) Match(s string) bool {
+	return m.m.Match(strings.ToLower(s))
+}
+
+// ContainsMatcher matches a string if it contains at any of the terms in the matcher's list.
+// This is the matcher for the 'contains' match type
+type ContainsMatcher struct {
+	list []string
+}
+
+// NewContainsMatcher returns a ContainsMatcher for a list of terms
+func NewContainsMatcher(terms ...string) ContainsMatcher {
+	return ContainsMatcher{terms}
+}
+
+// Match returns true if a string contains any of matcher's terms
+func (m ContainsMatcher) Match(s string) bool {
+	for _, term := range m.list {
+		if strings.Contains(s, term) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ContainsIgnoreCaseMatcher is the case-insensitive version of ContainsMatcher. This
+// is the matcher for the 'contains-ignore-case' match type
+type ContainsIgnoreCaseMatcher struct {
+	m ContainsMatcher
+}
+
+// NewContainsIgnoreCaseMatcher returns a ContainsIgnoreCaseMatcher for a list of terms
+func NewContainsIgnoreCaseMatcher(terms ...string) ContainsIgnoreCaseMatcher {
+	for i := range terms {
+		terms[i] = strings.ToLower(terms[i])
+	}
+
+	return ContainsIgnoreCaseMatcher{
+		m: NewContainsMatcher(terms...),
+	}
+}
+
+// Match returns true if a string contains any of matcher's terms regardless of the case
+func (m ContainsIgnoreCaseMatcher) Match(s string) bool {
+	return m.m.Match(strings.ToLower(s))
+}
+
+var matchNothingRegexpMatcher = RegexpMatcher{regexp.MustCompile(".^")}
+
+// RegexpMatcher matches a string using a set of regular expressions. This is the matcher
+// for the 'regex' match type
+type RegexpMatcher struct {
+	re *regexp.Regexp
+}
+
+// NewRegexpMatcher returns a RegexpMatcher for a list of regular expressions
+func NewRegexpMatcher(terms ...*regexp.Regexp) (RegexpMatcher, error) {
+	if len(terms) == 0 {
+		return matchNothingRegexpMatcher, nil
+	}
+
+	// combine expressions into one using OR, i.e.
+	// [RE1, RE2, ..., REn] -> (RE1)|(RE2)|...|(REn)
+	buf := bytes.NewBuffer([]byte(`(\A`))
+	sep := []byte(`\z)|(\A`)
+
+	for _, term := range terms {
+		reBytes := []byte(term.String())
+		// strip leading beginning-of-line matchers, as they are already included into the combined expression
+		reBytes = bytes.TrimPrefix(bytes.TrimLeft(reBytes, "^"), []byte(`\A`))
+		// strip trailing end-of-line matchers, as they are already included into the combined expression
+		reBytes = bytes.TrimSuffix(bytes.TrimRight(reBytes, "$"), []byte(`\z`))
+
+		buf.Write(reBytes)
+		buf.Write(sep)
+	}
+	buf.Truncate(buf.Len() - len(sep)) // trim trailing separator
+	buf.WriteString(`\z)`)
+
+	combined := buf.String()
+
+	re, err := regexp.Compile(combined)
+	if err != nil {
+		return matchNothingRegexpMatcher, fmt.Errorf("malformed regexp %q: %s", combined, err)
+	}
+
+	return RegexpMatcher{re}, nil
+}
+
+// Match returns true if a string fully matches any of matcher's regular expessions. If an expression matches only
+// a part of string, this method returns false:
+//
+//     m := NewRegexpMatcher(regexp.MustCompile(`aaa`), regexp.MustCompile(`bbb`))
+//     m.Match("aaa") // returns true
+//     m.Match("bbb") // returns true
+//     m.Match("aaabbb") // returns false, as both regular expressions match only a part of the string
+func (m RegexpMatcher) Match(s string) bool {
+	return m.re.MatchString(s)
+}

--- a/secrets/matchers_test.go
+++ b/secrets/matchers_test.go
@@ -1,0 +1,122 @@
+package secrets_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/instana/go-sensor/secrets"
+	"github.com/instana/testify/assert"
+	"github.com/instana/testify/require"
+)
+
+func TestEqualsMatcher(t *testing.T) {
+	m := secrets.NewEqualsMatcher("one", "two")
+	examples := map[string]bool{
+		"":           false,
+		"one":        true,
+		"two":        true,
+		"ONE":        false,
+		"tWo":        false,
+		"onetwo":     false,
+		"two ":       false,
+		" one":       false,
+		"fourty-two": false,
+		"hello!":     false,
+	}
+
+	for s, expected := range examples {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, expected, m.Match(s))
+		})
+	}
+}
+
+func TestEqualsIgnoreCaseMatcher(t *testing.T) {
+	m := secrets.NewEqualsIgnoreCaseMatcher("One", "TWO")
+	examples := map[string]bool{
+		"":           false,
+		"one":        true,
+		"two":        true,
+		"ONE":        true,
+		"tWo":        true,
+		"onetwo":     false,
+		"two ":       false,
+		" one":       false,
+		"fourty-two": false,
+		"hello!":     false,
+	}
+
+	for s, expected := range examples {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, expected, m.Match(s))
+		})
+	}
+}
+
+func TestContainsMatcher(t *testing.T) {
+	m := secrets.NewContainsMatcher("one", "two")
+	examples := map[string]bool{
+		"":           false,
+		"one":        true,
+		"two":        true,
+		"ONE":        false,
+		"tWo":        false,
+		"onetwo":     true,
+		"two ":       true,
+		" one":       true,
+		"fourty-two": true,
+		"hello!":     false,
+	}
+
+	for s, expected := range examples {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, expected, m.Match(s))
+		})
+	}
+}
+
+func TestContainsIgnoreCaseMatcher(t *testing.T) {
+	m := secrets.NewContainsIgnoreCaseMatcher("one", "two")
+	examples := map[string]bool{
+		"":           false,
+		"one":        true,
+		"two":        true,
+		"ONE":        true,
+		"tWo":        true,
+		"onetwo":     true,
+		"two ":       true,
+		" one":       true,
+		"fourty-TWO": true,
+		"hello!":     false,
+	}
+
+	for s, expected := range examples {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, expected, m.Match(s))
+		})
+	}
+}
+
+func TestRegexpMatcher(t *testing.T) {
+	m, err := secrets.NewRegexpMatcher(regexp.MustCompile(`(?i)\Aone\z`), regexp.MustCompile(`^two$`))
+	require.NoError(t, err)
+
+	examples := map[string]bool{
+		"":           false,
+		"one":        true,
+		"two":        true,
+		"ONE":        true,
+		"tWo":        false,
+		"onetwo":     false,
+		"two ":       false,
+		" one":       false,
+		"fourty-TWO": false,
+		"hello!":     false,
+	}
+
+	for s, expected := range examples {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, expected, m.Match(s))
+		})
+	}
+}

--- a/span.go
+++ b/span.go
@@ -72,7 +72,7 @@ func (r *spanS) FinishWithOptions(opts ot.FinishOptions) {
 
 	r.Duration = duration
 	if !r.context.Suppressed {
-		r.tracer.options.Recorder.RecordSpan(r)
+		r.tracer.recorder.RecordSpan(r)
 	}
 }
 

--- a/span.go
+++ b/span.go
@@ -73,14 +73,14 @@ func (r *spanS) FinishWithOptions(opts ot.FinishOptions) {
 }
 
 func (r *spanS) appendLog(lr ot.LogRecord) {
-	maxLogs := r.tracer.options.MaxLogsPerSpan
+	maxLogs := r.tracer.Options().MaxLogsPerSpan
 	if maxLogs == 0 || len(r.Logs) < maxLogs {
 		r.Logs = append(r.Logs, lr)
 	}
 }
 
 func (r *spanS) Log(ld ot.LogData) {
-	if r.tracer.options.DropAllLogs {
+	if r.tracer.Options().DropAllLogs {
 		return
 	}
 
@@ -118,7 +118,7 @@ func (r *spanS) LogFields(fields ...otlog.Field) {
 		Fields: fields,
 	}
 
-	if r.tracer.options.DropAllLogs {
+	if r.tracer.Options().DropAllLogs {
 		return
 	}
 

--- a/tracer.go
+++ b/tracer.go
@@ -83,6 +83,11 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 	}
 }
 
+// Options returns current tracer options
+func (r *tracerS) Options() TracerOptions {
+	return r.options
+}
+
 // NewTracer initializes a new tracer with default options
 func NewTracer() ot.Tracer {
 	return NewTracerWithOptions(nil)

--- a/tracer.go
+++ b/tracer.go
@@ -71,8 +71,6 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 		delete(opts.Tags, suppressTracingTag)
 	}
 
-	sc.Sampled = r.options.ShouldSample(sc.TraceID)
-
 	return &spanS{
 		context:     sc,
 		tracer:      r,
@@ -83,10 +81,6 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 		Correlation: corrData,
 		Tags:        opts.Tags,
 	}
-}
-
-func shouldSample(traceID int64) bool {
-	return false
 }
 
 // NewTracer Get a new Tracer with the default options applied.
@@ -105,7 +99,6 @@ func NewTracerWithEverything(options *Options, recorder SpanRecorder) ot.Tracer 
 	ret := &tracerS{
 		recorder: recorder,
 		options: TracerOptions{
-			ShouldSample:   shouldSample,
 			MaxLogsPerSpan: MaxLogsPerSpan,
 		},
 	}

--- a/tracer.go
+++ b/tracer.go
@@ -13,7 +13,6 @@ const (
 
 type tracerS struct {
 	recorder SpanRecorder
-	options  TracerOptions
 }
 
 func (r *tracerS) Inject(spanContext ot.SpanContext, format interface{}, carrier interface{}) error {
@@ -85,7 +84,11 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 
 // Options returns current tracer options
 func (r *tracerS) Options() TracerOptions {
-	return r.options
+	if sensor.options == nil {
+		return DefaultTracerOptions()
+	}
+
+	return sensor.options.Tracer
 }
 
 // NewTracer initializes a new tracer with default options
@@ -104,11 +107,6 @@ func NewTracerWithEverything(options *Options, recorder SpanRecorder) ot.Tracer 
 
 	tracer := &tracerS{
 		recorder: recorder,
-		options:  DefaultTracerOptions(),
-	}
-
-	if options != nil {
-		tracer.options = options.Tracer
 	}
 
 	return tracer

--- a/tracer.go
+++ b/tracer.go
@@ -83,25 +83,28 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 	}
 }
 
-// NewTracer Get a new Tracer with the default options applied.
+// NewTracer initializes a new tracer with default options
 func NewTracer() ot.Tracer {
-	return NewTracerWithOptions(&Options{})
+	return NewTracerWithOptions(nil)
 }
 
-// NewTracerWithOptions Get a new Tracer with the specified options.
+// NewTracerWithOptions initializes and configures a new tracer that collects and sends spans to the host agent
 func NewTracerWithOptions(options *Options) ot.Tracer {
 	return NewTracerWithEverything(options, NewRecorder())
 }
 
-// NewTracerWithEverything Get a new Tracer with the works.
+// NewTracerWithEverything initializes and configures a new tracer
 func NewTracerWithEverything(options *Options, recorder SpanRecorder) ot.Tracer {
 	InitSensor(options)
-	ret := &tracerS{
+
+	tracer := &tracerS{
 		recorder: recorder,
-		options: TracerOptions{
-			MaxLogsPerSpan: MaxLogsPerSpan,
-		},
+		options:  DefaultTracerOptions(),
 	}
 
-	return ret
+	if options != nil {
+		tracer.options = options.Tracer
+	}
+
+	return tracer
 }

--- a/tracer.go
+++ b/tracer.go
@@ -12,7 +12,8 @@ const (
 )
 
 type tracerS struct {
-	options TracerOptions
+	recorder SpanRecorder
+	options  TracerOptions
 }
 
 func (r *tracerS) Inject(spanContext ot.SpanContext, format interface{}, carrier interface{}) error {
@@ -102,8 +103,8 @@ func NewTracerWithOptions(options *Options) ot.Tracer {
 func NewTracerWithEverything(options *Options, recorder SpanRecorder) ot.Tracer {
 	InitSensor(options)
 	ret := &tracerS{
+		recorder: recorder,
 		options: TracerOptions{
-			Recorder:       recorder,
 			ShouldSample:   shouldSample,
 			MaxLogsPerSpan: MaxLogsPerSpan,
 		},

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -1,7 +1,6 @@
 package instana
 
 import (
-	bt "github.com/opentracing/basictracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -21,76 +20,12 @@ type Matcher interface {
 // TracerOptions allows creating a customized Tracer via NewWithOptions. The object
 // must not be updated when there is an active tracer using it.
 type TracerOptions struct {
-	// ShouldSample is a function which is called when creating a new Span and
-	// determines whether that Span is sampled. The randomized TraceID is supplied
-	// to allow deterministic sampling decisions to be made across different nodes.
-	// For example,
-	//
-	//   func(traceID uint64) { return traceID % 64 == 0 }
-	//
-	// samples every 64th trace on average.
-	ShouldSample func(traceID int64) bool
-	// TrimUnsampledSpans turns potentially expensive operations on unsampled
-	// Spans into no-ops. More precisely, tags and log events are silently
-	// discarded. If NewSpanEventListener is set, the callbacks will still fire.
-	TrimUnsampledSpans bool
-	// NewSpanEventListener can be used to enhance the tracer by effectively
-	// attaching external code to trace events. See NetTraceIntegrator for a
-	// practical example, and event.go for the list of possible events.
-	NewSpanEventListener func() func(bt.SpanEvent)
-	// DropAllLogs turns log events on all Spans into no-ops.
-	// If NewSpanEventListener is set, the callbacks will still fire.
+	// DropAllLogs turns log events on all spans into no-ops
 	DropAllLogs bool
-	// MaxLogsPerSpan limits the number of Logs in a span (if set to a nonzero
+	// MaxLogsPerSpan limits the number of log records in a span (if set to a non-zero
 	// value). If a span has more logs than this value, logs are dropped as
-	// necessary (and replaced with a log describing how many were dropped).
-	//
-	// About half of the MaxLogPerSpan logs kept are the oldest logs, and about
-	// half are the newest logs.
-	//
-	// If NewSpanEventListener is set, the callbacks will still fire for all log
-	// events. This value is ignored if DropAllLogs is true.
+	// necessary
 	MaxLogsPerSpan int
-	// DebugAssertSingleGoroutine internally records the ID of the goroutine
-	// creating each Span and verifies that no operation is carried out on
-	// it on a different goroutine.
-	// Provided strictly for development purposes.
-	// Passing Spans between goroutine without proper synchronization often
-	// results in use-after-Finish() errors. For a simple example, consider the
-	// following pseudocode:
-	//
-	//  func (s *Server) Handle(req http.Request) error {
-	//    sp := s.StartSpan("server")
-	//    defer sp.Finish()
-	//    wait := s.queueProcessing(opentracing.ContextWithSpan(context.Background(), sp), req)
-	//    select {
-	//    case resp := <-wait:
-	//      return resp.Error
-	//    case <-time.After(10*time.Second):
-	//      sp.LogEvent("timed out waiting for processing")
-	//      return ErrTimedOut
-	//    }
-	//  }
-	//
-	// This looks reasonable at first, but a request which spends more than ten
-	// seconds in the queue is abandoned by the main goroutine and its trace
-	// finished, leading to use-after-finish when the request is finally
-	// processed. Note also that even joining on to a finished Span via
-	// StartSpanWithOptions constitutes an illegal operation.
-	//
-	// Code bases which do not require (or decide they do not want) Spans to
-	// be passed across goroutine boundaries can run with this flag enabled in
-	// tests to increase their chances of spotting wrong-doers.
-	DebugAssertSingleGoroutine bool
-	// DebugAssertUseAfterFinish is provided strictly for development purposes.
-	// When set, it attempts to exacerbate issues emanating from use of Spans
-	// after calling Finish by running additional assertions.
-	DebugAssertUseAfterFinish bool
-	// EnableSpanPool enables the use of a pool, so that the tracer reuses spans
-	// after Finish has been called on it. Adds a slight performance gain as it
-	// reduces allocations. However, if you have any use-after-finish race
-	// conditions the code may panic.
-	EnableSpanPool bool
 	// Secrets is a secrets matcher used to filter out sensitive data from HTTP requests, database
 	// connection strings, etc. By default tracer does not filter any values. Package `secrets`
 	// provides a set of secret matchers supported by the host agent configuration.

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -4,11 +4,6 @@ import (
 	"github.com/instana/go-sensor/secrets"
 )
 
-// Matcher verifies whether a string meets predefined conditions
-type Matcher interface {
-	Match(s string) bool
-}
-
 // TracerOptions carry the tracer configuration
 type TracerOptions struct {
 	// DropAllLogs turns log events on all spans into no-ops

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -1,9 +1,5 @@
 package instana
 
-import (
-	"github.com/instana/go-sensor/secrets"
-)
-
 // TracerOptions carry the tracer configuration
 type TracerOptions struct {
 	// DropAllLogs turns log events on all spans into no-ops
@@ -24,6 +20,6 @@ type TracerOptions struct {
 func DefaultTracerOptions() TracerOptions {
 	return TracerOptions{
 		MaxLogsPerSpan: MaxLogsPerSpan,
-		Secrets:        secrets.NoneMatcher{},
+		Secrets:        DefaultSecretsMatcher(),
 	}
 }

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -1,24 +1,15 @@
 package instana
 
 import (
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/instana/go-sensor/secrets"
 )
-
-// Tracer extends the opentracing.Tracer interface
-type Tracer interface {
-	opentracing.Tracer
-
-	// Options gets the Options used in New() or NewWithOptions().
-	Options() TracerOptions
-}
 
 // Matcher verifies whether a string meets predefined conditions
 type Matcher interface {
 	Match(s string) bool
 }
 
-// TracerOptions allows creating a customized Tracer via NewWithOptions. The object
-// must not be updated when there is an active tracer using it.
+// TracerOptions carry the tracer configuration
 type TracerOptions struct {
 	// DropAllLogs turns log events on all spans into no-ops
 	DropAllLogs bool
@@ -32,4 +23,12 @@ type TracerOptions struct {
 	//
 	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#secrets for details
 	Secrets Matcher
+}
+
+// DefaultTracerOptions returns the default set of options to configure a tracer
+func DefaultTracerOptions() TracerOptions {
+	return TracerOptions{
+		MaxLogsPerSpan: MaxLogsPerSpan,
+		Secrets:        secrets.NoneMatcher{},
+	}
 }

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -34,8 +34,6 @@ type TracerOptions struct {
 	// Spans into no-ops. More precisely, tags and log events are silently
 	// discarded. If NewSpanEventListener is set, the callbacks will still fire.
 	TrimUnsampledSpans bool
-	// Recorder receives Spans which have been finished.
-	Recorder SpanRecorder
 	// NewSpanEventListener can be used to enhance the tracer by effectively
 	// attaching external code to trace events. See NetTraceIntegrator for a
 	// practical example, and event.go for the list of possible events.

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -13,6 +13,11 @@ type Tracer interface {
 	Options() TracerOptions
 }
 
+// Matcher verifies whether a string meets predefined conditions
+type Matcher interface {
+	Match(s string) bool
+}
+
 // TracerOptions allows creating a customized Tracer via NewWithOptions. The object
 // must not be updated when there is an active tracer using it.
 type TracerOptions struct {
@@ -88,4 +93,10 @@ type TracerOptions struct {
 	// reduces allocations. However, if you have any use-after-finish race
 	// conditions the code may panic.
 	EnableSpanPool bool
+	// Secrets is a secrets matcher used to filter out sensitive data from HTTP requests, database
+	// connection strings, etc. By default tracer does not filter any values. Package `secrets`
+	// provides a set of secret matchers supported by the host agent configuration.
+	//
+	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#secrets for details
+	Secrets Matcher
 }

--- a/tracer_options_test.go
+++ b/tracer_options_test.go
@@ -1,0 +1,16 @@
+package instana_test
+
+import (
+	"testing"
+
+	instana "github.com/instana/go-sensor"
+	"github.com/instana/go-sensor/secrets"
+	"github.com/instana/testify/assert"
+)
+
+func TestDefaultTracerOptions(t *testing.T) {
+	assert.Equal(t, instana.TracerOptions{
+		MaxLogsPerSpan: 2,
+		Secrets:        secrets.NoneMatcher{},
+	}, instana.DefaultTracerOptions())
+}

--- a/tracer_options_test.go
+++ b/tracer_options_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
-	"github.com/instana/go-sensor/secrets"
 	"github.com/instana/testify/assert"
 )
 
 func TestDefaultTracerOptions(t *testing.T) {
 	assert.Equal(t, instana.TracerOptions{
 		MaxLogsPerSpan: 2,
-		Secrets:        secrets.NoneMatcher{},
+		Secrets:        instana.DefaultSecretsMatcher(),
 	}, instana.DefaultTracerOptions())
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
-	ot "github.com/opentracing/opentracing-go"
 	"github.com/instana/testify/assert"
+	ot "github.com/opentracing/opentracing-go"
 )
 
 func TestTracerAPI(t *testing.T) {


### PR DESCRIPTION
This PR updates the HTTP server and client instrumentation to collect and send the query string parameters to the agent. To avoid leaking sensitive data, the tracer now supports secrets matcher provided in `(instana.Options).Tracer.Secrets`. This matcher can be specified during the sensor initialization or in [the Host Agent Configuration file](https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#secrets) and filters out any HTTP parameters which name match the criteria. The host agent configuration takes precedence.

The default filtering rule is `contains-ignore-case` with the following list of match terms: `key`, `password` and `secret`. If an HTTP parameter name contains any of these strings regardless of case, it's value will be replaced with `<redacted>` before sent to the host agent.