### PR TITLE
Collect custom HTTP headers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -35,6 +35,7 @@ type agentResponse struct {
 		Matcher string   `json:"matcher"`
 		List    []string `json:"list"`
 	} `json:"secrets"`
+	ExtraHTTPHeaders []string `json:"extraHeaders"`
 }
 
 type discoveryS struct {
@@ -293,6 +294,8 @@ func (r *agentS) applyHostAgentSettings(resp agentResponse) {
 			sensor.options.Tracer.Secrets = m
 		}
 	}
+
+	sensor.options.Tracer.CollectableHTTPHeaders = resp.ExtraHTTPHeaders
 }
 
 func (r *agentS) setHost(host string) {

--- a/json_span.go
+++ b/json_span.go
@@ -278,6 +278,8 @@ type HTTPSpanTags struct {
 	Path string `json:"path,omitempty"`
 	// Params are the request query string parameters
 	Params string `json:"params,omitempty"`
+	// Headers are the captured request/response headers
+	Headers map[string]string `json:"header,omitempty"`
 	// PathTemplate is the raw template string used to route the request
 	PathTemplate string `json:"path_tpl,omitempty"`
 	// The name:port of the host to which the request had been sent
@@ -303,6 +305,11 @@ func NewHTTPSpanTags(span *spanS) HTTPSpanTags {
 			readStringTag(&tags.Path, v)
 		case "http.params":
 			readStringTag(&tags.Params, v)
+		case "http.header":
+			if m, ok := v.(map[string]string); ok {
+				tags.Headers = m
+			}
+			tags.Headers = v.(map[string]string)
 		case "http.path_tpl":
 			readStringTag(&tags.PathTemplate, v)
 		case "http.host":

--- a/options.go
+++ b/options.go
@@ -60,6 +60,6 @@ func (opts *Options) setDefaults() {
 	}
 
 	if opts.Tracer.Secrets == nil {
-		opts.Tracer = DefaultTracerOptions()
+		opts.Tracer.Secrets = DefaultSecretsMatcher()
 	}
 }

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -12,6 +12,9 @@ const TestServiceName = "test_service"
 func TestMain(m *testing.M) {
 	instana.InitSensor(&instana.Options{
 		Service: TestServiceName,
+		Tracer: instana.TracerOptions{
+			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
+		},
 	})
 
 	os.Exit(m.Run())

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -1,0 +1,18 @@
+package instana_test
+
+import (
+	"os"
+	"testing"
+
+	instana "github.com/instana/go-sensor"
+)
+
+const TestServiceName = "test_service"
+
+func TestMain(m *testing.M) {
+	instana.InitSensor(&instana.Options{
+		Service: TestServiceName,
+	})
+
+	os.Exit(m.Run())
+}

--- a/span_test.go
+++ b/span_test.go
@@ -6,11 +6,11 @@ import (
 	"time"
 
 	instana "github.com/instana/go-sensor"
+	"github.com/instana/testify/assert"
+	"github.com/instana/testify/require"
 	ot "github.com/opentracing/opentracing-go"
 	ext "github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	"github.com/instana/testify/assert"
-	"github.com/instana/testify/require"
 )
 
 func TestBasicSpan(t *testing.T) {
@@ -33,7 +33,7 @@ func TestBasicSpan(t *testing.T) {
 
 	require.IsType(t, instana.SDKSpanData{}, span.Data)
 	data := span.Data.(instana.SDKSpanData)
-	assert.Empty(t, data.Service)
+	assert.Equal(t, TestServiceName, data.Service)
 
 	assert.Equal(t, "test", data.Tags.Name)
 	assert.Nil(t, data.Tags.Custom["tags"])

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -14,6 +14,10 @@ type TracerOptions struct {
 	//
 	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#secrets for details
 	Secrets Matcher
+	// CollectableHTTPHeaders is a case-insensitive list of HTTP headers to be collected from HTTP requests and sent to the agent
+	//
+	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#capture-custom-http-headers for details
+	CollectableHTTPHeaders []string
 }
 
 // DefaultTracerOptions returns the default set of options to configure a tracer


### PR DESCRIPTION
This PR introduces the HTTP header collection feature to the HTTP instrumentation wrappers. Both request and response headers defined either in the `(instana.TracerOptions).CollectableHTTPHeaders` provided to `instana.InitSensor()` or the `extra-http-headers` filed of `com.instana.tracing` section of the [Host Agent Configuration file](https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#capture-custom-http-headers) are now attached to the request/response span and sent to the host agent for collection.

Closes https://github.com/instana/go-sensor/issues/64