### PR TITLE
Fix log messages

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -289,7 +289,7 @@ func (r *agentS) applyHostAgentSettings(resp agentResponse) {
 	if resp.Secrets.Matcher != "" {
 		m, err := NamedMatcher(resp.Secrets.Matcher, resp.Secrets.List)
 		if err != nil {
-			r.logger.Warn("failed to apply secrets matcher configuration: %s", err)
+			r.logger.Warn("failed to apply secrets matcher configuration: ", err)
 		} else {
 			sensor.options.Tracer.Secrets = m
 		}

--- a/fsm.go
+++ b/fsm.go
@@ -103,7 +103,7 @@ func (r *fsmS) lookupAgentHost(e *f.Event) {
 }
 
 func (r *fsmS) checkHost(host string, cb func(found bool, host string)) {
-	r.agent.logger.Debug("checking host", host)
+	r.agent.logger.Debug("checking host ", host)
 
 	header, err := r.agent.requestHeader(r.agent.makeHostURL(host, "/"), "GET", "Server")
 
@@ -111,7 +111,7 @@ func (r *fsmS) checkHost(host string, cb func(found bool, host string)) {
 }
 
 func (r *fsmS) lookupSuccess(host string) {
-	r.agent.logger.Debug("agent lookup success", host)
+	r.agent.logger.Debug("agent lookup success ", host)
 
 	r.agent.setHost(host)
 	r.retries = maximumRetries

--- a/matcher.go
+++ b/matcher.go
@@ -48,7 +48,7 @@ func NamedMatcher(name string, list []string) (Matcher, error) {
 		for _, s := range list {
 			ex, err := regexp.Compile(s)
 			if err != nil {
-				sensor.logger.Warn("ignoring malformed regexp secrets matcher %s: %s", s, err)
+				sensor.logger.Warn("ignoring malformed regexp secrets matcher ", s, ": ", err)
 				continue
 			}
 

--- a/propagation.go
+++ b/propagation.go
@@ -116,7 +116,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		case FieldL:
 			suppressed, corrData, err := parseLevel(v)
 			if err != nil {
-				sensor.logger.Info("failed to parse %s: %s %q", k, err, v)
+				sensor.logger.Info("failed to parse ", k, ": ", err, " (", v, ")")
 				// use defaults
 				suppressed, corrData = false, EUMCorrelationData{}
 			}


### PR DESCRIPTION
Minor improvements in log message formatting:
* Don't use formatting terms, such as `%s`, `%q`, etc. in calls to `instana.Logger` methods, as they don't perform any formatting
* Add trailing spaces in log messages, where a string variable is printed after a constant string