### PR TITLE
Enforce the use of modules in go1.11 and go1.12 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ matrix:
     - go: 1.10.x
       env: VENDOR_DEPS=yes
     - go: 1.11.x
+      env: GO111MODULE=on
     - go: 1.12.x
+      env: GO111MODULE=on
     - go: 1.13.x
     - go: 1.14.x
     - go: 1.15.x


### PR DESCRIPTION
Make sure that tests are using the module version specified in `go.mod`