### PR TITLE
Send AWS Fargate Docker container metrics

### DIFF
--- a/acceptor/docker_stats.go
+++ b/acceptor/docker_stats.go
@@ -1,0 +1,199 @@
+package acceptor
+
+import "github.com/instana/go-sensor/docker"
+
+// DockerNetworkStatsDelta represents the difference between two network interface stats
+type DockerNetworkStatsDelta struct {
+	Bytes   int `json:"bytes,omitempty"`
+	Packets int `json:"packets,omitempty"`
+	Dropped int `json:"dropped,omitempty"`
+	Errors  int `json:"errors,omitempty"`
+}
+
+// IsZero returns true is there is no difference between interface stats
+func (d DockerNetworkStatsDelta) IsZero() bool {
+	return d.Bytes == 0 && d.Packets == 0 && d.Dropped == 0 && d.Errors == 0
+}
+
+// DockerNetworkStatsDelta represents the difference between two network interface stats
+type DockerNetworkAggregatedStatsDelta struct {
+	Rx *DockerNetworkStatsDelta `json:"rx,omitempty"`
+	Tx *DockerNetworkStatsDelta `json:"tx,omitempty"`
+}
+
+// NewDockerNetworkAggregatedStatsDelta calculates the aggregated difference between two snapshots
+// of network interface stats. It returns nil if aggregated stats for both snapshots are equal.
+func NewDockerNetworkAggregatedStatsDelta(prev, next map[string]docker.ContainerNetworkStats) *DockerNetworkAggregatedStatsDelta {
+	var rxDelta, txDelta DockerNetworkStatsDelta
+
+	for _, stats := range next {
+		rxDelta.Bytes += stats.RxBytes
+		rxDelta.Packets += stats.RxPackets
+		rxDelta.Dropped += stats.RxDropped
+		rxDelta.Errors += stats.RxErrors
+
+		txDelta.Bytes += stats.TxBytes
+		txDelta.Packets += stats.TxPackets
+		txDelta.Dropped += stats.TxDropped
+		txDelta.Errors += stats.TxErrors
+	}
+
+	for _, stats := range prev {
+		rxDelta.Bytes -= stats.RxBytes
+		rxDelta.Packets -= stats.RxPackets
+		rxDelta.Dropped -= stats.RxDropped
+		rxDelta.Errors -= stats.RxErrors
+
+		txDelta.Bytes -= stats.TxBytes
+		txDelta.Packets -= stats.TxPackets
+		txDelta.Dropped -= stats.TxDropped
+		txDelta.Errors -= stats.TxErrors
+	}
+
+	if rxDelta.IsZero() && txDelta.IsZero() {
+		return nil
+	}
+
+	var delta DockerNetworkAggregatedStatsDelta
+	if !rxDelta.IsZero() {
+		delta.Rx = &rxDelta
+	}
+	if !txDelta.IsZero() {
+		delta.Tx = &txDelta
+	}
+
+	return &delta
+}
+
+// DockerCPUStatsDelta represents the difference between two CPU usage stats
+type DockerCPUStatsDelta struct {
+	Total           float64 `json:"total_usage,omitempty"`
+	User            float64 `json:"user_usage,omitempty"`
+	System          float64 `json:"system_usage,omitempty"`
+	ThrottlingCount int     `json:"throttling_count,omitempty"`
+	ThrottlingTime  int     `json:"throttling_time,omitempty"`
+}
+
+// NewDockerCPUStatsDelta calculates the difference between two CPU usage stats. It returns nil if stats are equal.
+func NewDockerCPUStatsDelta(prev, next docker.ContainerCPUStats) *DockerCPUStatsDelta {
+	if prev == next {
+		return nil
+	}
+
+	delta := DockerCPUStatsDelta{
+		ThrottlingCount: next.Throttling.Periods - prev.Throttling.Periods,
+		ThrottlingTime:  next.Throttling.Time - prev.Throttling.Time,
+	}
+
+	if systemDelta := next.System - prev.System; systemDelta > 0 {
+		if totalDelta := next.Usage.Total - prev.Usage.Total; totalDelta > 0 {
+			delta.Total = (float64(totalDelta) / float64(systemDelta)) * float64(next.OnlineCPUs)
+		}
+		if kernelDelta := next.Usage.Kernel - prev.Usage.Kernel; kernelDelta > 0 {
+			delta.System = (float64(kernelDelta) / float64(systemDelta)) * float64(next.OnlineCPUs)
+		}
+		if userDelta := next.Usage.User - prev.Usage.User; userDelta > 0 {
+			delta.User = (float64(userDelta) / float64(systemDelta)) * float64(next.OnlineCPUs)
+		}
+	}
+
+	return &delta
+}
+
+// DockerMemoryStatsUpdate represents the memory stats that have changed since the last measurement
+type DockerMemoryStatsUpdate struct {
+	ActiveAnon   *int `json:"active_anon,omitempty"`
+	ActiveFile   *int `json:"active_file,omitempty"`
+	InactiveAnon *int `json:"inactive_anon,omitempty"`
+	InactiveFile *int `json:"inactive_file,omitempty"`
+	TotalCache   *int `json:"total_cache,omitempty"`
+	TotalRss     *int `json:"total_rss,omitempty"`
+	Usage        *int `json:"usage,omitempty"`
+	MaxUsage     *int `json:"max_usage,omitempty"`
+	Limit        *int `json:"limit,omitempty"`
+}
+
+// NewDockerMemoryStatsUpdate returns the fields that have been updated since the last measurement.
+// It returns nil if nothing has changed.
+func NewDockerMemoryStatsUpdate(prev, next docker.ContainerMemoryStats) *DockerMemoryStatsUpdate {
+	if prev == next {
+		return nil
+	}
+
+	var delta DockerMemoryStatsUpdate
+	if prev.Usage != next.Usage {
+		delta.Usage = &next.Usage
+	}
+	if prev.MaxUsage != next.MaxUsage {
+		delta.MaxUsage = &next.MaxUsage
+	}
+	if prev.Limit != next.Limit {
+		delta.Limit = &next.Limit
+	}
+
+	if prev.Stats == next.Stats {
+		return &delta
+	}
+
+	if prev.Stats.ActiveAnon != next.Stats.ActiveAnon {
+		delta.ActiveAnon = &next.Stats.ActiveAnon
+	}
+	if prev.Stats.ActiveFile != next.Stats.ActiveFile {
+		delta.ActiveFile = &next.Stats.ActiveFile
+	}
+	if prev.Stats.InactiveAnon != next.Stats.InactiveAnon {
+		delta.InactiveAnon = &next.Stats.InactiveAnon
+	}
+	if prev.Stats.InactiveFile != next.Stats.InactiveFile {
+		delta.InactiveFile = &next.Stats.InactiveFile
+	}
+	if prev.Stats.TotalCache != next.Stats.TotalCache {
+		delta.TotalCache = &next.Stats.TotalCache
+	}
+	if prev.Stats.TotalRss != next.Stats.TotalRss {
+		delta.TotalRss = &next.Stats.TotalRss
+	}
+
+	return &delta
+}
+
+// DockerMemoryStatsDelta represents the difference between two block I/O usage stats
+type DockerBlockIOStatsDelta struct {
+	Read  int `json:"blk_read,omitempty"`
+	Write int `json:"blk_write,omitempty"`
+}
+
+// IsZero returns true if both usage stats are equal
+func (d DockerBlockIOStatsDelta) IsZero() bool {
+	return d.Read == 0 && d.Write == 0
+}
+
+// NewDockerMemoryStatsDelta sums up block I/O reads and writes and calculates the difference between two stat snapshots.
+// It returns nil if aggregated stats are equal.
+func NewDockerBlockIOStatsDelta(prev, next docker.ContainerBlockIOStats) *DockerBlockIOStatsDelta {
+	var delta DockerBlockIOStatsDelta
+
+	for _, stat := range next.ServiceBytes {
+		switch stat.Operation {
+		case docker.BlockIOReadOp:
+			delta.Read += stat.Value
+		case docker.BlockIOWriteOp:
+			delta.Write += stat.Value
+		}
+	}
+
+	for _, stat := range prev.ServiceBytes {
+		switch stat.Operation {
+		case docker.BlockIOReadOp:
+			delta.Read -= stat.Value
+		case docker.BlockIOWriteOp:
+			delta.Write -= stat.Value
+		}
+	}
+
+	if delta.IsZero() {
+		return nil
+	}
+
+	return &delta
+}

--- a/acceptor/docker_stats_test.go
+++ b/acceptor/docker_stats_test.go
@@ -1,0 +1,240 @@
+package acceptor_test
+
+import (
+	"testing"
+
+	"github.com/instana/go-sensor/acceptor"
+	"github.com/instana/go-sensor/docker"
+	"github.com/instana/testify/assert"
+)
+
+func TestNewDockerNetworkAggregatedStatsDelta(t *testing.T) {
+	stats := map[string]docker.ContainerNetworkStats{
+		"eth0": {
+			RxBytes:   1,
+			RxDropped: 10,
+			RxErrors:  100,
+			RxPackets: 1000,
+			TxBytes:   10000,
+			TxDropped: 100000,
+			TxErrors:  1000000,
+			TxPackets: 10000000,
+		},
+		"eth1": {
+			RxBytes:   2,
+			RxDropped: 20,
+			RxErrors:  200,
+			RxPackets: 2000,
+			TxBytes:   20000,
+			TxDropped: 200000,
+			TxErrors:  2000000,
+			TxPackets: 20000000,
+		},
+		"eth2": {
+			RxBytes:   3,
+			RxDropped: 30,
+			RxErrors:  300,
+			RxPackets: 3000,
+			TxBytes:   30000,
+			TxDropped: 300000,
+			TxErrors:  3000000,
+			TxPackets: 30000000,
+		},
+	}
+
+	t.Run("equal", func(t *testing.T) {
+		assert.Nil(t, acceptor.NewDockerNetworkAggregatedStatsDelta(stats, stats))
+	})
+
+	t.Run("increase", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerNetworkAggregatedStatsDelta{
+				Rx: &acceptor.DockerNetworkStatsDelta{
+					Bytes:   6,
+					Dropped: 60,
+					Errors:  600,
+					Packets: 6000,
+				},
+				Tx: &acceptor.DockerNetworkStatsDelta{
+					Bytes:   60000,
+					Dropped: 600000,
+					Errors:  6000000,
+					Packets: 60000000,
+				},
+			},
+			acceptor.NewDockerNetworkAggregatedStatsDelta(nil, stats),
+		)
+	})
+
+	t.Run("decrease", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerNetworkAggregatedStatsDelta{
+				Rx: &acceptor.DockerNetworkStatsDelta{
+					Bytes:   -6,
+					Dropped: -60,
+					Errors:  -600,
+					Packets: -6000,
+				},
+				Tx: &acceptor.DockerNetworkStatsDelta{
+					Bytes:   -60000,
+					Dropped: -600000,
+					Errors:  -6000000,
+					Packets: -60000000,
+				},
+			},
+			acceptor.NewDockerNetworkAggregatedStatsDelta(stats, nil),
+		)
+	})
+}
+
+func TestNewDockerCPUStatsDelta(t *testing.T) {
+	stats := docker.ContainerCPUStats{
+		Usage: docker.CPUUsageStats{
+			Total:  1,
+			User:   10,
+			Kernel: 100,
+		},
+		Throttling: docker.CPUThrottlingStats{
+			Periods: 1000,
+			Time:    10000,
+		},
+		System:     100000,
+		OnlineCPUs: 16,
+	}
+
+	t.Run("equal", func(t *testing.T) {
+		assert.Nil(t, acceptor.NewDockerCPUStatsDelta(stats, stats))
+	})
+
+	t.Run("increase", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerCPUStatsDelta{
+				Total:           0.00016,
+				User:            0.0016,
+				System:          0.016,
+				ThrottlingCount: 1000,
+				ThrottlingTime:  10000,
+			},
+			acceptor.NewDockerCPUStatsDelta(docker.ContainerCPUStats{}, stats),
+		)
+	})
+
+	t.Run("decrease", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerCPUStatsDelta{
+				Total:           0,
+				User:            0,
+				System:          0,
+				ThrottlingCount: -1000,
+				ThrottlingTime:  -10000,
+			},
+			acceptor.NewDockerCPUStatsDelta(stats, docker.ContainerCPUStats{}),
+		)
+	})
+}
+
+func TestNewDockerMemoryStatsDelta(t *testing.T) {
+	stats := docker.ContainerMemoryStats{
+		Stats: docker.MemoryStats{
+			ActiveAnon:   1,
+			ActiveFile:   10,
+			InactiveAnon: 100,
+			InactiveFile: 1000,
+			TotalRss:     10000,
+			TotalCache:   100000,
+		},
+		MaxUsage: 1000000,
+		Usage:    10000000,
+		Limit:    100000000,
+	}
+
+	t.Run("equal", func(t *testing.T) {
+		assert.Nil(t, acceptor.NewDockerMemoryStatsUpdate(stats, stats))
+	})
+
+	t.Run("changed", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerMemoryStatsUpdate{
+				ActiveAnon:   &stats.Stats.ActiveAnon,
+				ActiveFile:   &stats.Stats.ActiveFile,
+				InactiveAnon: &stats.Stats.InactiveAnon,
+				InactiveFile: &stats.Stats.InactiveFile,
+				TotalRss:     &stats.Stats.TotalRss,
+				TotalCache:   &stats.Stats.TotalCache,
+				MaxUsage:     &stats.MaxUsage,
+				Usage:        &stats.Usage,
+				Limit:        &stats.Limit,
+			},
+			acceptor.NewDockerMemoryStatsUpdate(docker.ContainerMemoryStats{}, stats),
+		)
+	})
+
+	t.Run("changed some", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerMemoryStatsUpdate{
+				ActiveFile:   &stats.Stats.ActiveFile,
+				InactiveFile: &stats.Stats.InactiveFile,
+				TotalCache:   &stats.Stats.TotalCache,
+				MaxUsage:     &stats.MaxUsage,
+				Limit:        &stats.Limit,
+			},
+			acceptor.NewDockerMemoryStatsUpdate(docker.ContainerMemoryStats{
+				Stats: docker.MemoryStats{
+					ActiveAnon:   1,
+					ActiveFile:   20,
+					InactiveAnon: 100,
+					InactiveFile: 2000,
+					TotalRss:     10000,
+					TotalCache:   200000,
+				},
+				MaxUsage: 2000000,
+				Usage:    10000000,
+				Limit:    200000000,
+			}, stats),
+		)
+	})
+}
+
+func TestNewDockerBlockIOStatsDelta(t *testing.T) {
+	stats := docker.ContainerBlockIOStats{
+		ServiceBytes: []docker.BlockIOOpStats{
+			{Operation: docker.BlockIOReadOp, Value: 1},
+			{Operation: docker.BlockIOWriteOp, Value: 10},
+			{Operation: docker.BlockIOReadOp, Value: 100},
+		},
+	}
+
+	t.Run("equal", func(t *testing.T) {
+		assert.Nil(t, acceptor.NewDockerBlockIOStatsDelta(stats, stats))
+	})
+
+	t.Run("increase", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerBlockIOStatsDelta{
+				Read:  101,
+				Write: 10,
+			},
+			acceptor.NewDockerBlockIOStatsDelta(docker.ContainerBlockIOStats{}, stats),
+		)
+	})
+
+	t.Run("decrease", func(t *testing.T) {
+		assert.Equal(t,
+			&acceptor.DockerBlockIOStatsDelta{
+				Read:  -101,
+				Write: -10,
+			},
+			acceptor.NewDockerBlockIOStatsDelta(stats, docker.ContainerBlockIOStats{}),
+		)
+	})
+
+	t.Run("equal, shuffled ops", func(t *testing.T) {
+		assert.Nil(t, acceptor.NewDockerBlockIOStatsDelta(stats, docker.ContainerBlockIOStats{
+			ServiceBytes: []docker.BlockIOOpStats{
+				{Operation: docker.BlockIOReadOp, Value: 100},
+				{Operation: docker.BlockIOReadOp, Value: 1},
+				{Operation: docker.BlockIOWriteOp, Value: 10},
+			},
+		}))
+	})
+}

--- a/acceptor/plugins.go
+++ b/acceptor/plugins.go
@@ -81,20 +81,23 @@ func NewECSContainerPluginPayload(entityID string, data ECSContainerData) Plugin
 
 // DockerData is a representation of a Docker container for com.instana.plugin.docker plugin
 type DockerData struct {
-	ID               string              `json:"Id"`
-	Command          string              `json:"Command"`
-	CreatedAt        time.Time           `json:"Created"`
-	StartedAt        time.Time           `json:"Started"`
-	Image            string              `json:"Image"`
-	Labels           aws.ContainerLabels `json:"Labels,omitempty"`
-	Ports            string              `json:"Ports,omitempty"`
-	PortBindings     string              `json:"PortBindings,omitempty"`
-	Names            []string            `json:"Names,omitempty"`
-	NetworkMode      string              `json:"NetworkMode,omitempty"`
-	StorageDriver    string              `json:"StorageDriver,omitempty"`
-	DockerVersion    string              `json:"docker_version,omitempty"`
-	DockerAPIVersion string              `json:"docker_api_version,omitempty"`
-	Memory           int                 `json:"Memory"`
+	ID               string                             `json:"Id"`
+	Command          string                             `json:"Command"`
+	CreatedAt        time.Time                          `json:"Created"`
+	StartedAt        time.Time                          `json:"Started"`
+	Image            string                             `json:"Image"`
+	Labels           aws.ContainerLabels                `json:"Labels,omitempty"`
+	Ports            string                             `json:"Ports,omitempty"`
+	PortBindings     string                             `json:"PortBindings,omitempty"`
+	Names            []string                           `json:"Names,omitempty"`
+	NetworkMode      string                             `json:"NetworkMode,omitempty"`
+	StorageDriver    string                             `json:"StorageDriver,omitempty"`
+	DockerVersion    string                             `json:"docker_version,omitempty"`
+	DockerAPIVersion string                             `json:"docker_api_version,omitempty"`
+	Network          *DockerNetworkAggregatedStatsDelta `json:"network,omitempty"`
+	CPU              *DockerCPUStatsDelta               `json:"cpu,omitempty"`
+	Memory           *DockerMemoryStatsUpdate           `json:"memory,omitempty"`
+	BlockIO          *DockerBlockIOStatsDelta           `json:"blkio,omitempty"`
 }
 
 // NewDockerPluginPayload returns payload for the Docker plugin of Instana acceptor

--- a/aws/testdata/task_stats.json
+++ b/aws/testdata/task_stats.json
@@ -1,0 +1,130 @@
+{
+  "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946": {
+    "read": "2020-09-09T09:54:21.803969293Z",
+    "preread": "2020-09-09T09:54:16.80439292Z",
+    "pids_stats": {
+    },
+    "blkio_stats": {
+      "io_service_bytes_recursive": [
+        {
+          "value": 1,
+          "op": "READ"
+        },
+        {
+          "value": 2,
+          "op": "WRITE"
+        },
+        {
+          "value": 3,
+          "op": "READ"
+        }
+      ],
+      "io_serviced_recursive": [],
+      "io_queue_recursive": [],
+      "io_service_time_recursive": [],
+      "io_wait_time_recursive": [],
+      "io_merged_recursive": [],
+      "io_time_recursive": [],
+      "sectors_recursive": []
+    },
+    "num_procs": 0,
+    "storage_stats": {
+    },
+    "cpu_stats": {
+      "cpu_usage": {
+        "total_usage": 281318382,
+        "percpu_usage": [
+          214203988,
+          67114394,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "usage_in_kernelmode": 20000000,
+        "usage_in_usermode": 180000000
+      },
+      "system_cpu_usage": 360200000000,
+      "online_cpus": 2,
+      "throttling_data": {
+        "periods": 1,
+        "throttled_periods": 2,
+        "throttled_time": 3
+      }
+    },
+    "precpu_stats": {
+      "cpu_usage": {
+        "total_usage": 0,
+        "usage_in_kernelmode": 0,
+        "usage_in_usermode": 0
+      },
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "memory_stats": {
+      "usage": 6148096,
+      "max_usage": 6549504,
+      "stats": {
+        "active_anon": 4681728,
+        "active_file": 12288,
+        "cache": 12288,
+        "dirty": 0,
+        "hierarchical_memory_limit": 536870912,
+        "hierarchical_memsw_limit": 9.223372036854772e+18,
+        "inactive_anon": 100,
+        "inactive_file": 602112,
+        "mapped_file": 0,
+        "pgfault": 3723,
+        "pgmajfault": 0,
+        "pgpgin": 3163,
+        "pgpgout": 1870,
+        "rss": 5283840,
+        "rss_huge": 0,
+        "total_active_anon": 4681728,
+        "total_active_file": 12288,
+        "total_cache": 12290,
+        "total_dirty": 0,
+        "total_inactive_anon": 0,
+        "total_inactive_file": 602112,
+        "total_mapped_file": 0,
+        "total_pgfault": 3723,
+        "total_pgmajfault": 0,
+        "total_pgpgin": 3163,
+        "total_pgpgout": 1870,
+        "total_rss": 5283840,
+        "total_rss_huge": 0,
+        "total_unevictable": 0,
+        "total_writeback": 0,
+        "unevictable": 0,
+        "writeback": 0
+      },
+      "limit": 536870912
+    },
+    "name": "fargate-go-service",
+    "id": "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+    "networks": {
+      "eth1": {
+        "rx_bytes": 4172695,
+        "rx_packets": 3105,
+        "rx_errors": 4,
+        "rx_dropped": 3,
+        "tx_bytes": 106367,
+        "tx_packets": 444,
+        "tx_errors": 2,
+        "tx_dropped": 1
+      }
+    }
+  }
+}

--- a/docker/container_stats.go
+++ b/docker/container_stats.go
@@ -1,0 +1,127 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ContainerNetworkStats represents networking stats for a container.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#network-metrics
+type ContainerNetworkStats struct {
+	RxBytes   int `json:"rx_bytes"`
+	RxDropped int `json:"rx_dropped"`
+	RxErrors  int `json:"rx_errors"`
+	RxPackets int `json:"rx_packets"`
+	TxBytes   int `json:"tx_bytes"`
+	TxDropped int `json:"tx_dropped"`
+	TxErrors  int `json:"tx_errors"`
+	TxPackets int `json:"tx_packets"`
+}
+
+// MemoryStats represents the cgroups memory stats.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
+type MemoryStats struct {
+	ActiveAnon   int `json:"active_anon"`
+	ActiveFile   int `json:"active_file"`
+	InactiveAnon int `json:"inactive_anon"`
+	InactiveFile int `json:"inactive_file"`
+	TotalRss     int `json:"total_rss"`
+	TotalCache   int `json:"total_cache"`
+}
+
+// ContainerMemoryStats represents the memory usage stats for a container.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
+type ContainerMemoryStats struct {
+	Stats    MemoryStats `json:"stats"`
+	MaxUsage int         `json:"max_usage"`
+	Usage    int         `json:"usage"`
+	Limit    int         `json:"limit"`
+}
+
+type blockIOOp uint8
+
+func (biop *blockIOOp) UnmarshalJSON(data []byte) error {
+	switch strings.ToLower(string(data)) {
+	case `"read"`:
+		*biop = BlockIOReadOp
+	case `"write"`:
+		*biop = BlockIOWriteOp
+	default:
+		return fmt.Errorf("unexpected block i/o op %s", string(data))
+	}
+
+	return nil
+}
+
+func (biop blockIOOp) MarshalJSON() ([]byte, error) {
+	switch biop {
+	case BlockIOReadOp:
+		return []byte(`"read"`), nil
+	case BlockIOWriteOp:
+		return []byte(`"write"`), nil
+	default:
+		return []byte(`"unknown"`), nil
+	}
+}
+
+// Valid block I/O operations
+const (
+	BlockIOReadOp = iota + 1
+	BlockIOWriteOp
+)
+
+// BlockIOOpStats represents cgroups stats for a block I/O operation type. The zero-value does not represent
+// a valid value until the Operation is specified.
+type BlockIOOpStats struct {
+	Operation blockIOOp `json:"op"`
+	Value     int       `json:"value"`
+}
+
+// ContainerBlockIOStats represents the block I/O usage stats for a container.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
+type ContainerBlockIOStats struct {
+	ServiceBytes []BlockIOOpStats `json:"io_service_bytes_recursive"`
+}
+
+// CPUThrottlingStats represents the cgroups CPU usage stats.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
+type CPUUsageStats struct {
+	Total  int `json:"total_usage"`
+	Kernel int `json:"usage_in_kernelmode"`
+	User   int `json:"usage_in_usermode"`
+}
+
+// CPUThrottlingStats represents the cgroupd CPU throttling stats.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
+type CPUThrottlingStats struct {
+	Periods int `json:"periods"`
+	Time    int `json:"throttled_time"`
+}
+
+// ContainerCPUStats represents the CPU usage stats for a container.
+//
+// See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
+type ContainerCPUStats struct {
+	Usage      CPUUsageStats      `json:"cpu_usage"`
+	Throttling CPUThrottlingStats `json:"throttling_data"`
+	System     int                `json:"system_cpu_usage"`
+	OnlineCPUs int                `json:"online_cpus"`
+}
+
+// ContainerStats represents the container resource usage stats as returned by Docker Engine.
+//
+// See https://docs.docker.com/engine/api/v1.30/#operation/ContainerExport
+type ContainerStats struct {
+	ReadAt   time.Time                        `json:"read"`
+	Networks map[string]ContainerNetworkStats `json:"networks"`
+	Memory   ContainerMemoryStats             `json:"memory_stats"`
+	BlockIO  ContainerBlockIOStats            `json:"blkio_stats"`
+	CPU      ContainerCPUStats                `json:"cpu_stats"`
+}

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -136,6 +136,7 @@ type fargateAgent struct {
 	snapshot fargateSnapshot
 
 	runtimeSnapshot *SnapshotCollector
+	dockerStats     *ecsDockerStatsCollector
 	client          *http.Client
 	ecs             *aws.ECSMetadataProvider
 	logger          LeveledLogger
@@ -166,6 +167,9 @@ func newFargateAgent(
 			CollectionInterval: snapshotCollectionInterval,
 			ServiceName:        serviceName,
 		},
+		dockerStats: &ecsDockerStatsCollector{
+			ecs: mdProvider,
+		},
 		client: client,
 		ecs:    mdProvider,
 		logger: logger,
@@ -187,6 +191,7 @@ func newFargateAgent(
 			time.Sleep(snapshotCollectionInterval)
 		}
 	}()
+	go agent.dockerStats.Run(context.Background(), time.Second)
 
 	return agent
 }

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -99,7 +99,6 @@ func newDockerContainerPluginPayload(container aws.ECSContainerMetadata) accepto
 		Labels:      container.ContainerLabels,
 		Names:       []string{container.DockerName},
 		NetworkMode: networkMode,
-		Memory:      container.Limits.Memory,
 	})
 }
 

--- a/fargate_agent_test.go
+++ b/fargate_agent_test.go
@@ -129,21 +129,30 @@ func TestFargateAgent_SendMetrics(t *testing.T) {
 	})
 
 	t.Run("Docker plugin payload", func(t *testing.T) {
-		require.Len(t, pluginData["com.instana.plugin.docker"], 1)
-		d := pluginData["com.instana.plugin.docker"][0]
+		require.Len(t, pluginData["com.instana.plugin.docker"], 2)
 
-		assert.NotEmpty(t, d.EntityID)
-		assert.Equal(t, "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946", d.Data["Id"])
-
-		var found bool
-		for _, container := range pluginData["com.instana.plugin.aws.ecs.container"] {
-			if container.Data["containerName"] == "nginx-curl" {
-				found = true
-				assert.Equal(t, container.EntityID, d.EntityID)
-				break
-			}
+		containers := make(map[string]serverlessAgentPluginPayload)
+		for _, container := range pluginData["com.instana.plugin.docker"] {
+			containers[container.EntityID] = container
 		}
-		assert.True(t, found)
+
+		t.Run("instrumented", func(t *testing.T) {
+			d := containers["arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3::nginx-curl"]
+			require.NotEmpty(t, d)
+
+			assert.NotEmpty(t, d.EntityID)
+			assert.Equal(t, "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946", d.Data["Id"])
+
+			var found bool
+			for _, container := range pluginData["com.instana.plugin.aws.ecs.container"] {
+				if container.Data["containerName"] == "nginx-curl" {
+					found = true
+					assert.Equal(t, container.EntityID, d.EntityID)
+					break
+				}
+			}
+			assert.True(t, found)
+		})
 	})
 
 	t.Run("Process plugin payload", func(t *testing.T) {
@@ -207,6 +216,9 @@ func setupMetadataServer() func() {
 	})
 	mux.HandleFunc("/task", func(w http.ResponseWriter, req *http.Request) {
 		http.ServeFile(w, req, "aws/testdata/task_metadata.json")
+	})
+	mux.HandleFunc("/task/stats", func(w http.ResponseWriter, req *http.Request) {
+		http.ServeFile(w, req, "aws/testdata/task_stats.json")
 	})
 
 	srv := httptest.NewServer(mux)

--- a/fargate_agent_test.go
+++ b/fargate_agent_test.go
@@ -142,16 +142,14 @@ func TestFargateAgent_SendMetrics(t *testing.T) {
 
 			assert.NotEmpty(t, d.EntityID)
 			assert.Equal(t, "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946", d.Data["Id"])
+		})
 
-			var found bool
-			for _, container := range pluginData["com.instana.plugin.aws.ecs.container"] {
-				if container.Data["containerName"] == "nginx-curl" {
-					found = true
-					assert.Equal(t, container.EntityID, d.EntityID)
-					break
-				}
-			}
-			assert.True(t, found)
+		t.Run("non-instrumented", func(t *testing.T) {
+			d := containers["arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3::~internal~ecs~pause"]
+			require.NotEmpty(t, d)
+
+			assert.NotEmpty(t, d.EntityID)
+			assert.Equal(t, "731a0d6a3b4210e2448339bc7015aaa79bfe4fa256384f4102db86ef94cbbc4c", d.Data["Id"])
 		})
 	})
 


### PR DESCRIPTION
This PR updates the Fargate agent to send the Docker Engine [container stats](https://docs.docker.com/engine/api/v1.40/#operation/ContainerStats) to the serverless acceptor, so they can be displayed on Instana dashboard.