### PR TITLE
AWS Fargate: send custom Instana zone name specified in INSTANA_ZONE env var

### DIFF
--- a/acceptor/plugins.go
+++ b/acceptor/plugins.go
@@ -27,6 +27,7 @@ type ECSTaskData struct {
 	TaskARN               string             `json:"taskArn"`
 	ClusterARN            string             `json:"clusterArn"`
 	AvailabilityZone      string             `json:"availabilityZone,omitempty"`
+	InstanaZone           string             `json:"instanaZone,omitempty"`
 	TaskDefinition        string             `json:"taskDefinition"`
 	TaskDefinitionVersion string             `json:"taskDefinitionVersion"`
 	DesiredStatus         string             `json:"desiredStatus"`

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -42,6 +42,7 @@ func newECSTaskPluginPayload(snapshot fargateSnapshot) acceptor.PluginPayload {
 		TaskARN:               snapshot.Task.TaskARN,
 		ClusterARN:            snapshot.Container.Cluster,
 		AvailabilityZone:      snapshot.Task.AvailabilityZone,
+		InstanaZone:           os.Getenv("INSTANA_ZONE"),
 		TaskDefinition:        snapshot.Task.Family,
 		TaskDefinitionVersion: snapshot.Task.Revision,
 		DesiredStatus:         snapshot.Task.DesiredStatus,


### PR DESCRIPTION
This PR adds support for providing a custom Instana zone name in AWS Fargate by setting the `INSTANA_ZONE` environment variable.