### PR TITLE
AWS Fargate: send Instana tags

### DIFF
--- a/acceptor/plugins.go
+++ b/acceptor/plugins.go
@@ -24,17 +24,18 @@ type AWSContainerLimits struct {
 
 // ECSTaskData is a representation of an ECS task for com.instana.plugin.aws.ecs.task plugin
 type ECSTaskData struct {
-	TaskARN               string             `json:"taskArn"`
-	ClusterARN            string             `json:"clusterArn"`
-	AvailabilityZone      string             `json:"availabilityZone,omitempty"`
-	InstanaZone           string             `json:"instanaZone,omitempty"`
-	TaskDefinition        string             `json:"taskDefinition"`
-	TaskDefinitionVersion string             `json:"taskDefinitionVersion"`
-	DesiredStatus         string             `json:"desiredStatus"`
-	KnownStatus           string             `json:"knownStatus"`
-	Limits                AWSContainerLimits `json:"limits"`
-	PullStartedAt         time.Time          `json:"pullStartedAt"`
-	PullStoppedAt         time.Time          `json:"pullStoppedAt"`
+	TaskARN               string                 `json:"taskArn"`
+	ClusterARN            string                 `json:"clusterArn"`
+	AvailabilityZone      string                 `json:"availabilityZone,omitempty"`
+	InstanaZone           string                 `json:"instanaZone,omitempty"`
+	TaskDefinition        string                 `json:"taskDefinition"`
+	TaskDefinitionVersion string                 `json:"taskDefinitionVersion"`
+	DesiredStatus         string                 `json:"desiredStatus"`
+	KnownStatus           string                 `json:"knownStatus"`
+	Limits                AWSContainerLimits     `json:"limits"`
+	PullStartedAt         time.Time              `json:"pullStartedAt"`
+	PullStoppedAt         time.Time              `json:"pullStoppedAt"`
+	Tags                  map[string]interface{} `json:"tags,omitempty"`
 }
 
 // NewECSTaskPluginPayload returns payload for the ECS task plugin of Instana acceptor

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -25,6 +25,7 @@ type fargateSnapshot struct {
 	EntityID  string
 	PID       int
 	Zone      string
+	Tags      map[string]interface{}
 	Task      aws.ECSTaskMetadata
 	Container aws.ECSContainerMetadata
 }
@@ -154,6 +155,7 @@ type fargateAgent struct {
 	Key      string
 	PID      int
 	Zone     string
+	Tags     map[string]interface{}
 
 	snapshot         fargateSnapshot
 	lastDockerStats  map[string]docker.ContainerStats
@@ -189,6 +191,7 @@ func newFargateAgent(
 		Key:      agentKey,
 		PID:      os.Getpid(),
 		Zone:     os.Getenv("INSTANA_ZONE"),
+		Tags:     parseInstanaTags(os.Getenv("INSTANA_TAGS")),
 		runtimeSnapshot: &SnapshotCollector{
 			CollectionInterval: snapshotCollectionInterval,
 			ServiceName:        serviceName,
@@ -379,6 +382,7 @@ func (a *fargateAgent) collectSnapshot(ctx context.Context) (fargateSnapshot, bo
 
 	snapshot := newFargateSnapshot(a.PID, taskMD, containerMD)
 	snapshot.Zone = a.Zone
+	snapshot.Tags = a.Tags
 
 	a.logger.Debug("collected snapshot")
 

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -55,6 +55,7 @@ func newECSTaskPluginPayload(snapshot fargateSnapshot) acceptor.PluginPayload {
 		},
 		PullStartedAt: snapshot.Task.PullStartedAt,
 		PullStoppedAt: snapshot.Task.PullStoppedAt,
+		Tags:          snapshot.Tags,
 	})
 }
 

--- a/fargate_agent_test.go
+++ b/fargate_agent_test.go
@@ -34,6 +34,9 @@ func TestMain(m *testing.M) {
 	defer restoreEnvVarFunc("INSTANA_ZONE")
 	os.Setenv("INSTANA_ZONE", "testzone")
 
+	defer restoreEnvVarFunc("INSTANA_TAGS")
+	os.Setenv("INSTANA_TAGS", "key1=value1,key2")
+
 	var err error
 	agent, err = setupServerlessAgent()
 	if err != nil {
@@ -78,6 +81,7 @@ func TestFargateAgent_SendMetrics(t *testing.T) {
 		assert.Equal(t, d.Data["taskArn"], d.EntityID)
 
 		assert.Equal(t, "testzone", d.Data["instanaZone"])
+		assert.Equal(t, map[string]interface{}{"key1": "value1", "key2": nil}, d.Data["tags"])
 		assert.Equal(t, "default", d.Data["clusterArn"])
 		assert.Equal(t, "nginx", d.Data["taskDefinition"])
 		assert.Equal(t, "5", d.Data["taskDefinitionVersion"])

--- a/fargate_agent_test.go
+++ b/fargate_agent_test.go
@@ -31,6 +31,9 @@ func TestMain(m *testing.M) {
 	defer restoreEnvVarFunc("INSTANA_AGENT_KEY")
 	os.Setenv("INSTANA_AGENT_KEY", "testkey1")
 
+	defer restoreEnvVarFunc("INSTANA_ZONE")
+	os.Setenv("INSTANA_ZONE", "testzone")
+
 	var err error
 	agent, err = setupServerlessAgent()
 	if err != nil {
@@ -74,6 +77,7 @@ func TestFargateAgent_SendMetrics(t *testing.T) {
 		assert.NotEmpty(t, d.EntityID)
 		assert.Equal(t, d.Data["taskArn"], d.EntityID)
 
+		assert.Equal(t, "testzone", d.Data["instanaZone"])
 		assert.Equal(t, "default", d.Data["clusterArn"])
 		assert.Equal(t, "nginx", d.Data["taskDefinition"])
 		assert.Equal(t, "5", d.Data["taskDefinitionVersion"])

--- a/util.go
+++ b/util.go
@@ -178,3 +178,36 @@ func hexGatewayToAddr(gateway []rune) (string, error) {
 
 	return fmt.Sprintf("%v.%v.%v.%v", octets[0], octets[1], octets[2], octets[3]), nil
 }
+
+// parseInstanaTags parses the tags string passed via INSTANA_TAGS.
+// The tag string is a comma-separated list of keys optionally followed by an '=' character and a string value:
+//
+//     INSTANA_TAGS := key1[=value1][,key2[=value2],...]
+//
+// The leading and trailing space is truncated from key names, values are used as-is. If a key does not have
+// value associated, it's considered to be nil.
+func parseInstanaTags(tagStr string) map[string]interface{} {
+	tags := make(map[string]interface{})
+
+	for _, s := range strings.Split(tagStr, ",") {
+		kv := strings.SplitN(s, "=", 2)
+
+		k := strings.TrimSpace(kv[0])
+		if k == "" {
+			continue
+		}
+
+		var v interface{}
+		if len(kv) > 1 {
+			v = kv[1]
+		}
+
+		tags[k] = v
+	}
+
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return tags
+}

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -192,3 +192,31 @@ eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0
 		}()
 	}
 }
+
+func TestParseInstanaTags(t *testing.T) {
+	examples := map[string]struct {
+		Value    string
+		Expected map[string]interface{}
+	}{
+		"empty":                   {"", nil},
+		"single tag, empty key":   {"=value", nil},
+		"single tag, no value":    {"key", map[string]interface{}{"key": nil}},
+		"single tag, empty value": {"key=", map[string]interface{}{"key": ""}},
+		"single tag, with value":  {"key=value", map[string]interface{}{"key": "value"}},
+		"multiple tags, mixed": {
+			`key1,  key2=  , key3   ="",key4=42`,
+			map[string]interface{}{
+				"key1": nil,
+				"key2": "  ",
+				"key3": `""`,
+				"key4": "42",
+			},
+		},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, example.Expected, parseInstanaTags(example.Value))
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the AWS Fargate agent to parse and send the value of `INSTANA_TAGS` env variable with each metrics payload.