### PR TITLE
AWS Fargate: redact sensitive information using the INSTANA_SECRETS matcher config

### DIFF
--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -133,11 +133,22 @@ func newProcessPluginPayload(snapshot fargateSnapshot, prevStats, currentStats p
 		}
 	}
 
+	env := getProcessEnv()
+	for k := range env {
+		if k == "INSTANA_AGENT_KEY" {
+			continue
+		}
+
+		if sensor.options.Tracer.Secrets.Match(k) {
+			env[k] = "<redacted>"
+		}
+	}
+
 	return acceptor.NewProcessPluginPayload(strconv.Itoa(snapshot.PID), acceptor.ProcessData{
 		PID:           snapshot.PID,
 		Exec:          os.Args[0],
 		Args:          os.Args[1:],
-		Env:           getProcessEnv(),
+		Env:           env,
 		User:          currUser,
 		Group:         currGroup,
 		ContainerID:   snapshot.Container.DockerID,

--- a/options.go
+++ b/options.go
@@ -59,7 +59,15 @@ func (opts *Options) setDefaults() {
 		}
 	}
 
-	if opts.Tracer.Secrets == nil {
-		opts.Tracer.Secrets = DefaultSecretsMatcher()
+	secretsMatcher, err := parseInstanaSecrets(os.Getenv("INSTANA_SECRETS"))
+	if err != nil {
+		defaultLogger.Warn("invalid INSTANA_SECRETS= env variable value: ", err, ", ignoring")
+		secretsMatcher = opts.Tracer.Secrets
 	}
+
+	if secretsMatcher == nil {
+		secretsMatcher = DefaultSecretsMatcher()
+	}
+
+	opts.Tracer.Secrets = secretsMatcher
 }

--- a/util.go
+++ b/util.go
@@ -211,3 +211,31 @@ func parseInstanaTags(tagStr string) map[string]interface{} {
 
 	return tags
 }
+
+// parseInstanaSecrets parses the tags string passed via INSTANA_SECRETS.
+// The secrets matcher configuration string is expected to have the following format:
+//
+//     INSTANA_SECRETS := <matcher>:<secret>[,<secret>]
+//
+// Where `matcher` is one of:
+// * `equals` - matches a string if it's contained in the secrets list
+// * `equals-ignore-case` is a case-insensitive version of `equals`
+// * `contains` matches a string if it contains any of the secrets list values
+// * `contains-ignore-case` is a case-insensitive version of `contains`
+// * `regex` matches a string if it fully matches any of the regular expressions provided in the secrets list
+//
+// This function returns DefaultSecretsMatcher() if there is no matcher configuration provided.
+func parseInstanaSecrets(matcherStr string) (Matcher, error) {
+	if matcherStr == "" {
+		return DefaultSecretsMatcher(), nil
+	}
+
+	ind := strings.Index(matcherStr, ":")
+	if ind < 0 {
+		return nil, fmt.Errorf("malformed INSTANA_SECRETS configuration: %q", matcherStr)
+	}
+
+	matcher, config := strings.TrimSpace(matcherStr[:ind]), strings.Split(matcherStr[ind+1:], ",")
+
+	return NamedMatcher(matcher, config)
+}


### PR DESCRIPTION
This PR updates the AWS Fargate agent to redact sensitive information from process env vars and HTTP query string parameters before sending them to Instana. The configuration can be provided via [`INSTANA_SECRETS`](https://www.instana.com/docs/ecosystem/aws-fargate/#secrets) env variable.