### PR TITLE
AWS Fargate: configure extra HTTP headers

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -312,7 +312,6 @@ func NewHTTPSpanTags(span *spanS) HTTPSpanTags {
 			if m, ok := v.(map[string]string); ok {
 				tags.Headers = m
 			}
-			tags.Headers = v.(map[string]string)
 		case "http.path_tpl":
 			readStringTag(&tags.PathTemplate, v)
 		case "http.host":

--- a/options.go
+++ b/options.go
@@ -70,4 +70,8 @@ func (opts *Options) setDefaults() {
 	}
 
 	opts.Tracer.Secrets = secretsMatcher
+
+	if collectableHeaders, ok := os.LookupEnv("INSTANA_EXTRA_HTTP_HEADERS"); ok {
+		opts.Tracer.CollectableHTTPHeaders = parseInstanaExtraHTTPHeaders(collectableHeaders)
+	}
 }

--- a/util.go
+++ b/util.go
@@ -239,3 +239,23 @@ func parseInstanaSecrets(matcherStr string) (Matcher, error) {
 
 	return NamedMatcher(matcher, config)
 }
+
+// parseInstanaExtraHTTPHeaders parses the tags string passed via INSTANA_EXTRA_HTTP_HEADERS.
+// The header names are expected to come in a semicolon-separated list:
+//
+//     INSTANA_EXTRA_HTTP_HEADERS := header1[;header2;...]
+//
+// Any leading and trailing whitespace characters will be trimmed from header names.
+func parseInstanaExtraHTTPHeaders(headersStr string) []string {
+	var headers []string
+	for _, h := range strings.Split(headersStr, ";") {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+
+		headers = append(headers, h)
+	}
+
+	return headers
+}

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -261,3 +261,20 @@ func TestParseInstanaSecrets_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestParseInstanaExtraHTTPHeaders(t *testing.T) {
+	examples := map[string]struct {
+		Value    string
+		Expected []string
+	}{
+		"empty":    {"", nil},
+		"one":      {"a", []string{"a"}},
+		"multiple": {"a; ;  b  ;c;", []string{"a", "b", "c"}},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, example.Expected, parseInstanaExtraHTTPHeaders(example.Value))
+		})
+	}
+}


### PR DESCRIPTION
This PR allows to provide a list of HTTP headers to collect from incoming requests by setting the [`INSTANA_EXTRA_HTTP_HEADERS`](https://www.instana.com/docs/reference/environment_variables/#serverless-monitoring) env variable. The value is expected to be a semicolon-separated list of header names.