### PR TITLE
Send "GET OBJECT METADATA" GCS operation as `objects.attrs`

### DIFF
--- a/instrumentation/cloud.google.com/go/storage/storage.go
+++ b/instrumentation/cloud.google.com/go/storage/storage.go
@@ -89,7 +89,7 @@ func (o *ObjectHandle) Key(encryptionKey []byte) *ObjectHandle {
 // See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Attrs for furter details on wrapped method.
 func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *storage.ObjectAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
-		"gcs.op":     "objects.get",
+		"gcs.op":     "objects.attrs",
 		"gcs.bucket": o.Bucket,
 		"gcs.object": o.Name,
 	})


### PR DESCRIPTION
Currently GCS instrumentation sends the same operation for both object metadata and object content reads. As a results these requests are aggregated when shown in Instana dashboard, which may lead to skewed timing percentiles.

This PR sets the operation name for object metadata reads to `object.attrs`, allowing to distinguish between these calls.