### PR TITLE
Add GCS ACL entity to the span tags

### DIFF
--- a/instrumentation/cloud.google.com/go/storage/acl.go
+++ b/instrumentation/cloud.google.com/go/storage/acl.go
@@ -29,6 +29,7 @@ func (a *ACLHandle) Delete(ctx context.Context, entity storage.ACLEntity) (err e
 		"gcs.op":     aclOpPrefix(a) + ".delete",
 		"gcs.bucket": a.Bucket,
 		"gcs.object": a.Object,
+		"gcs.entity": string(entity),
 	})
 
 	defer func() { internal.FinishSpan(ctx, err) }()
@@ -44,6 +45,7 @@ func (a *ACLHandle) Set(ctx context.Context, entity storage.ACLEntity, role stor
 		"gcs.op":     aclOpPrefix(a) + ".update",
 		"gcs.bucket": a.Bucket,
 		"gcs.object": a.Object,
+		"gcs.entity": string(entity),
 	})
 
 	defer func() { internal.FinishSpan(ctx, err) }()


### PR DESCRIPTION
This PR updates the Google Cloud Storage client instrumentation by including the ACL entity into span tags.