### PR TITLE
Send GCP Pub/Sub message ID

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -520,6 +520,7 @@ type GCPPubSubSpanTags struct {
 	Operation    string `json:"op"`
 	Topic        string `json:"top,omitempty"`
 	Subscription string `json:"sub,omitempty"`
+	MessageID    string `json:"msgid,omitempty"`
 }
 
 func NewGCPPubSubSpanTags(span *spanS) GCPPubSubSpanTags {
@@ -534,6 +535,8 @@ func NewGCPPubSubSpanTags(span *spanS) GCPPubSubSpanTags {
 			readStringTag(&tags.Topic, v)
 		case "gcps.sub":
 			readStringTag(&tags.Subscription, v)
+		case "gcps.msgid":
+			readStringTag(&tags.MessageID, v)
 		}
 	}
 

--- a/json_span.go
+++ b/json_span.go
@@ -518,7 +518,7 @@ func (d GCPPubSubSpanData) Kind() SpanKind {
 type GCPPubSubSpanTags struct {
 	ProjectID    string `json:"projid"`
 	Operation    string `json:"op"`
-	Topic        string `json:"top"`
+	Topic        string `json:"top,omitempty"`
 	Subscription string `json:"sub,omitempty"`
 }
 


### PR DESCRIPTION
This PR updates the list of GCP Pub/Sub span attributes to include the message ID to allow correlation log lines to the Instana trace.