### PR TITLE
Send GCP Pub/Sub message ID as a span attribute

### DIFF
--- a/instrumentation/cloud.google.com/go/pubsub/push.go
+++ b/instrumentation/cloud.google.com/go/pubsub/push.go
@@ -54,6 +54,7 @@ func startConsumePushSpan(body []byte, sensor *instana.Sensor) (opentracing.Span
 	var delivery struct {
 		Message struct {
 			Attributes map[string]string `json:"attributes"`
+			ID         string            `json:"messageId"`
 		} `json:"message"`
 		Subscription string `json:"subscription"`
 	}
@@ -73,6 +74,7 @@ func startConsumePushSpan(body []byte, sensor *instana.Sensor) (opentracing.Span
 			"gcps.op":     "CONSUME",
 			"gcps.projid": projectID,
 			"gcps.sub":    subscription,
+			"gcps.msgid":  delivery.Message.ID,
 		},
 	}
 

--- a/instrumentation/cloud.google.com/go/pubsub/push_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/push_test.go
@@ -76,6 +76,7 @@ func TestTracingHandler(t *testing.T) {
 		Operation:    "CONSUME",
 		ProjectID:    "myproject",
 		Subscription: "mysubscription",
+		MessageID:    "136969346945",
 	}, data.Tags)
 }
 
@@ -132,6 +133,7 @@ func TestTracingHandlerFunc_TracePropagation(t *testing.T) {
 		Operation:    "CONSUME",
 		ProjectID:    "myproject",
 		Subscription: "mysubscription",
+		MessageID:    "136969346945",
 	}, data.Tags)
 }
 

--- a/instrumentation/cloud.google.com/go/pubsub/subscription.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription.go
@@ -35,6 +35,7 @@ func (sub *Subscription) Receive(ctx context.Context, f func(context.Context, *p
 				"gcps.op":     "CONSUME",
 				"gcps.projid": sub.projectID,
 				"gcps.sub":    sub.ID(),
+				"gcps.msgid":  msg.ID,
 			},
 		}
 		if spCtx, err := sub.sensor.Tracer().Extract(opentracing.TextMap, opentracing.TextMapCarrier(msg.Attributes)); err == nil {

--- a/instrumentation/cloud.google.com/go/pubsub/subscription_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription_test.go
@@ -86,6 +86,7 @@ func TestSubscription_Receive(t *testing.T) {
 		Operation:    "CONSUME",
 		ProjectID:    "test-project",
 		Subscription: "test-subscription",
+		MessageID:    msgID,
 	}, data.Tags)
 }
 
@@ -155,5 +156,6 @@ func TestSubscription_Receive_NoTrace(t *testing.T) {
 		Operation:    "CONSUME",
 		ProjectID:    "test-project",
 		Subscription: "test-subscription",
+		MessageID:    msgID,
 	}, data.Tags)
 }

--- a/instrumentation/cloud.google.com/go/pubsub/topic.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic.go
@@ -52,9 +52,11 @@ func (top *Topic) Publish(ctx context.Context, msg *pubsub.Message) *pubsub.Publ
 
 	res := top.Topic.Publish(ctx, msg)
 	go func() {
-		_, err := res.Get(context.Background())
+		id, err := res.Get(context.Background())
 		if err != nil {
 			sp.LogFields(otlog.Error(err))
+		} else {
+			sp.SetTag("gcps.msgid", id)
 		}
 
 		sp.Finish()

--- a/instrumentation/cloud.google.com/go/pubsub/topic_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic_test.go
@@ -85,6 +85,7 @@ func TestTopic_Publish(t *testing.T) {
 		Operation: "PUBLISH",
 		ProjectID: "test-project",
 		Topic:     "test-topic",
+		MessageID: msgID,
 	}, data.Tags)
 
 	// trace context propagation


### PR DESCRIPTION
This is a follow-up PR for https://github.com/instana/go-sensor/pull/167 that updates the GCP Pub/Sub instrumentation to include message IDs into span attributes.