### PR TITLE
Send GCP Pub/Sub operations in upper case

### DIFF
--- a/instrumentation/cloud.google.com/go/go.mod
+++ b/instrumentation/cloud.google.com/go/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/storage v1.7.0
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.1 // indirect
-	github.com/instana/go-sensor v1.21.0
+	github.com/instana/go-sensor v1.22.0
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/opentracing/opentracing-go v1.2.0
 	go.opencensus.io v0.22.4 // indirect

--- a/instrumentation/cloud.google.com/go/go.sum
+++ b/instrumentation/cloud.google.com/go/go.sum
@@ -105,8 +105,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/instana/go-sensor v1.21.0 h1:vP7UYEcvii/+lAUU2gRq3kaGOrZgTjTD4BBueSyyQxc=
-github.com/instana/go-sensor v1.21.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
+github.com/instana/go-sensor v1.22.0 h1:GxmiLBHNqnKigYq/S5zQ6/R8iUcTVYmKZzjPS+vkhDs=
+github.com/instana/go-sensor v1.22.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65 h1:T25FL3WEzgmKB0m6XCJNZ65nw09/QIp3T1yXr487D+A=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65/go.mod h1:nYhEREG/B7HUY7P+LKOrqy53TpIqmJ9JyUShcaEKtGw=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/instrumentation/cloud.google.com/go/pubsub/push.go
+++ b/instrumentation/cloud.google.com/go/pubsub/push.go
@@ -70,7 +70,7 @@ func startConsumePushSpan(body []byte, sensor *instana.Sensor) (opentracing.Span
 	opts := []opentracing.StartSpanOption{
 		ext.SpanKindConsumer,
 		opentracing.Tags{
-			"gcps.op":     "consume",
+			"gcps.op":     "CONSUME",
 			"gcps.projid": projectID,
 			"gcps.sub":    subscription,
 		},

--- a/instrumentation/cloud.google.com/go/pubsub/push_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/push_test.go
@@ -73,7 +73,7 @@ func TestTracingHandler(t *testing.T) {
 
 	data := gcpsSpan.Data.(instana.GCPPubSubSpanData)
 	assert.Equal(t, instana.GCPPubSubSpanTags{
-		Operation:    "consume",
+		Operation:    "CONSUME",
 		ProjectID:    "myproject",
 		Subscription: "mysubscription",
 	}, data.Tags)
@@ -129,7 +129,7 @@ func TestTracingHandlerFunc_TracePropagation(t *testing.T) {
 
 	data := gcpsSpan.Data.(instana.GCPPubSubSpanData)
 	assert.Equal(t, instana.GCPPubSubSpanTags{
-		Operation:    "consume",
+		Operation:    "CONSUME",
 		ProjectID:    "myproject",
 		Subscription: "mysubscription",
 	}, data.Tags)

--- a/instrumentation/cloud.google.com/go/pubsub/subscription.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription.go
@@ -32,7 +32,7 @@ func (sub *Subscription) Receive(ctx context.Context, f func(context.Context, *p
 		opts := []opentracing.StartSpanOption{
 			ext.SpanKindConsumer,
 			opentracing.Tags{
-				"gcps.op":     "consume",
+				"gcps.op":     "CONSUME",
 				"gcps.projid": sub.projectID,
 				"gcps.sub":    sub.ID(),
 			},

--- a/instrumentation/cloud.google.com/go/pubsub/subscription_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription_test.go
@@ -83,7 +83,7 @@ func TestSubscription_Receive(t *testing.T) {
 
 	data := gcpsSpan.Data.(instana.GCPPubSubSpanData)
 	assert.Equal(t, instana.GCPPubSubSpanTags{
-		Operation:    "consume",
+		Operation:    "CONSUME",
 		ProjectID:    "test-project",
 		Subscription: "test-subscription",
 	}, data.Tags)
@@ -152,7 +152,7 @@ func TestSubscription_Receive_NoTrace(t *testing.T) {
 
 	data := gcpsSpan.Data.(instana.GCPPubSubSpanData)
 	assert.Equal(t, instana.GCPPubSubSpanTags{
-		Operation:    "consume",
+		Operation:    "CONSUME",
 		ProjectID:    "test-project",
 		Subscription: "test-subscription",
 	}, data.Tags)

--- a/instrumentation/cloud.google.com/go/pubsub/topic.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic.go
@@ -39,7 +39,7 @@ func (top *Topic) Publish(ctx context.Context, msg *pubsub.Message) *pubsub.Publ
 		ext.SpanKindProducer,
 		opentracing.ChildOf(parent.Context()),
 		opentracing.Tags{
-			"gcps.op":     "publish",
+			"gcps.op":     "PUBLISH",
 			"gcps.projid": top.projectID,
 			"gcps.top":    top.ID(),
 		},

--- a/instrumentation/cloud.google.com/go/pubsub/topic_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic_test.go
@@ -82,7 +82,7 @@ func TestTopic_Publish(t *testing.T) {
 
 	data := gcpsSpan.Data.(instana.GCPPubSubSpanData)
 	assert.Equal(t, instana.GCPPubSubSpanTags{
-		Operation: "publish",
+		Operation: "PUBLISH",
 		ProjectID: "test-project",
 		Topic:     "test-topic",
 	}, data.Tags)


### PR DESCRIPTION
This PR improves readability of GCP Sub/Sub labels displayed in Instana dashboard by using the upper case to highlight the operation name.