### PR TITLE
Address linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Instana Go sensor consists of three parts:
 [![Build Status](https://circleci.com/gh/instana/go-sensor/tree/master.svg?style=svg)](https://circleci.com/gh/instana/go-sensor/tree/master)
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)][pkg.go.dev]
 [![OpenTracing](https://img.shields.io/badge/OpenTracing-enabled-blue.svg)](http://opentracing.io)
+[![Go Report Card](https://goreportcard.com/badge/github.com/instana/go-sensor)](https://goreportcard.com/report/github.com/instana/go-sensor)
 
 ## Table of Contents
 

--- a/acceptor/docker.go
+++ b/acceptor/docker.go
@@ -52,7 +52,7 @@ func (d DockerNetworkStatsDelta) IsZero() bool {
 	return d.Bytes == 0 && d.Packets == 0 && d.Dropped == 0 && d.Errors == 0
 }
 
-// DockerNetworkStatsDelta represents the difference between two network interface stats
+// DockerNetworkAggregatedStatsDelta represents the difference between two network interface stats
 type DockerNetworkAggregatedStatsDelta struct {
 	Rx *DockerNetworkStatsDelta `json:"rx,omitempty"`
 	Tx *DockerNetworkStatsDelta `json:"tx,omitempty"`
@@ -194,7 +194,7 @@ func NewDockerMemoryStatsUpdate(prev, next docker.ContainerMemoryStats) *DockerM
 	return &delta
 }
 
-// DockerMemoryStatsDelta represents the difference between two block I/O usage stats
+// DockerBlockIOStatsDelta represents the difference between two block I/O usage stats
 type DockerBlockIOStatsDelta struct {
 	Read  int `json:"blk_read,omitempty"`
 	Write int `json:"blk_write,omitempty"`
@@ -205,7 +205,7 @@ func (d DockerBlockIOStatsDelta) IsZero() bool {
 	return d.Read == 0 && d.Write == 0
 }
 
-// NewDockerMemoryStatsDelta sums up block I/O reads and writes and calculates the difference between two stat snapshots.
+// NewDockerBlockIOStatsDelta sums up block I/O reads and writes and calculates the difference between two stat snapshots.
 // It returns nil if aggregated stats are equal.
 func NewDockerBlockIOStatsDelta(prev, next docker.ContainerBlockIOStats) *DockerBlockIOStatsDelta {
 	var delta DockerBlockIOStatsDelta

--- a/acceptor/process.go
+++ b/acceptor/process.go
@@ -32,13 +32,13 @@ func NewProcessPluginPayload(entityID string, data ProcessData) PluginPayload {
 	}
 }
 
-// ProcessCPUStatsUpdate represents the CPU stats that have changed since the last measurement
+// ProcessCPUStatsDelta represents the CPU stats that have changed since the last measurement
 type ProcessCPUStatsDelta struct {
 	User   float64 `json:"user,omitempty"`
 	System float64 `json:"sys,omitempty"`
 }
 
-// NewDockerCPUStatsDelta calculates the difference between two CPU usage stats.
+// NewProcessCPUStatsDelta calculates the difference between two CPU usage stats.
 // It returns nil if stats are equal or if the stats were taken at the same time (ticks).
 // The stats are considered to be equal if the change is less then 1%.
 func NewProcessCPUStatsDelta(prev, next process.CPUStats, ticksElapsed int) *ProcessCPUStatsDelta {

--- a/adapters.go
+++ b/adapters.go
@@ -11,7 +11,14 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
+// SpanSensitiveFunc is a function executed within a span context
+//
+// Deprecated: use instana.ContextWithSpan() and instana.SpanFromContext() to inject and retrieve spans
 type SpanSensitiveFunc func(span ot.Span)
+
+// ContextSensitiveFunc is a SpanSensitiveFunc that also takes context.Context
+//
+// Deprecated: use instana.ContextWithSpan() and instana.SpanFromContext() to inject and retrieve spans
 type ContextSensitiveFunc func(span ot.Span, ctx context.Context)
 
 // Tracer extends the opentracing.Tracer interface
@@ -147,7 +154,7 @@ func (s *Sensor) WithTracingSpan(operationName string, w http.ResponseWriter, re
 	f(span)
 }
 
-// Executes the given ContextSensitiveFunc and executes it under the scope of a newly created context.Context,
+// WithTracingContext executes the given ContextSensitiveFunc and executes it under the scope of a newly created context.Context,
 // that provides access to the parent span as 'parentSpan'.
 //
 // Deprecated: please use instana.TracingHandlerFunc() to instrument an HTTP handler

--- a/adapters_test.go
+++ b/adapters_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
-	ot "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/instana/testify/assert"
 	"github.com/instana/testify/require"
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 )
 
 func TestWithTracingSpan(t *testing.T) {

--- a/agent.go
+++ b/agent.go
@@ -189,46 +189,46 @@ func (agent *agentS) SendProfiles(profiles []autoprofile.Profile) error {
 	return nil
 }
 
-func (r *agentS) setLogger(l LeveledLogger) {
-	r.logger = l
+func (agent *agentS) setLogger(l LeveledLogger) {
+	agent.logger = l
 }
 
-func (r *agentS) makeURL(prefix string) string {
-	return r.makeHostURL(r.host, prefix)
+func (agent *agentS) makeURL(prefix string) string {
+	return agent.makeHostURL(agent.host, prefix)
 }
 
-func (r *agentS) makeHostURL(host string, prefix string) string {
+func (agent *agentS) makeHostURL(host string, prefix string) string {
 	var buffer bytes.Buffer
 
 	buffer.WriteString("http://")
 	buffer.WriteString(host)
 	buffer.WriteString(":")
-	buffer.WriteString(r.port)
+	buffer.WriteString(agent.port)
 	buffer.WriteString(prefix)
-	if prefix[len(prefix)-1:] == "." && r.from.EntityID != "" {
-		buffer.WriteString(r.from.EntityID)
+	if prefix[len(prefix)-1:] == "." && agent.from.EntityID != "" {
+		buffer.WriteString(agent.from.EntityID)
 	}
 
 	return buffer.String()
 }
 
-func (r *agentS) head(url string) (string, error) {
-	return r.request(url, "HEAD", nil)
+func (agent *agentS) head(url string) (string, error) {
+	return agent.request(url, "HEAD", nil)
 }
 
-func (r *agentS) request(url string, method string, data interface{}) (string, error) {
-	return r.fullRequestResponse(url, method, data, nil, "")
+func (agent *agentS) request(url string, method string, data interface{}) (string, error) {
+	return agent.fullRequestResponse(url, method, data, nil, "")
 }
 
-func (r *agentS) requestResponse(url string, method string, data interface{}, ret interface{}) (string, error) {
-	return r.fullRequestResponse(url, method, data, ret, "")
+func (agent *agentS) requestResponse(url string, method string, data interface{}, ret interface{}) (string, error) {
+	return agent.fullRequestResponse(url, method, data, ret, "")
 }
 
-func (r *agentS) requestHeader(url string, method string, header string) (string, error) {
-	return r.fullRequestResponse(url, method, nil, nil, header)
+func (agent *agentS) requestHeader(url string, method string, header string) (string, error) {
+	return agent.fullRequestResponse(url, method, nil, nil, header)
 }
 
-func (r *agentS) fullRequestResponse(url string, method string, data interface{}, body interface{}, header string) (string, error) {
+func (agent *agentS) fullRequestResponse(url string, method string, data interface{}, body interface{}, header string) (string, error) {
 	var j []byte
 	var ret string
 	var err error
@@ -250,7 +250,7 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 
 		if err == nil {
 			req.Header.Set("Content-Type", "application/json")
-			resp, err = r.client.Do(req)
+			resp, err = agent.client.Do(req)
 			if err == nil {
 				defer resp.Body.Close()
 
@@ -275,21 +275,21 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 		// Ignore errors while in announced stated (before ready) as
 		// this is the time where the entity is registering in the Instana
 		// backend and it will return 404 until it's done.
-		if !r.fsm.fsm.Is("announced") {
-			r.logger.Info(err, url)
+		if !agent.fsm.fsm.Is("announced") {
+			agent.logger.Info(err, url)
 		}
 	}
 
 	return ret, err
 }
 
-func (r *agentS) applyHostAgentSettings(resp agentResponse) {
-	r.from = newHostAgentFromS(int(resp.Pid), resp.HostID)
+func (agent *agentS) applyHostAgentSettings(resp agentResponse) {
+	agent.from = newHostAgentFromS(int(resp.Pid), resp.HostID)
 
 	if resp.Secrets.Matcher != "" {
 		m, err := NamedMatcher(resp.Secrets.Matcher, resp.Secrets.List)
 		if err != nil {
-			r.logger.Warn("failed to apply secrets matcher configuration: ", err)
+			agent.logger.Warn("failed to apply secrets matcher configuration: ", err)
 		} else {
 			sensor.options.Tracer.Secrets = m
 		}
@@ -298,10 +298,10 @@ func (r *agentS) applyHostAgentSettings(resp agentResponse) {
 	sensor.options.Tracer.CollectableHTTPHeaders = resp.ExtraHTTPHeaders
 }
 
-func (r *agentS) setHost(host string) {
-	r.host = host
+func (agent *agentS) setHost(host string) {
+	agent.host = host
 }
 
-func (r *agentS) reset() {
-	r.fsm.reset()
+func (agent *agentS) reset() {
+	agent.fsm.reset()
 }

--- a/autoprofile/internal/pprof/profile/encode.go
+++ b/autoprofile/internal/pprof/profile/encode.go
@@ -278,7 +278,10 @@ func (p *Profile) postDecode() error {
 		pt.Type, err = getString(p.stringTable, &pt.typeX, err)
 		pt.Unit, err = getString(p.stringTable, &pt.unitX, err)
 	}
+
 	p.stringTable = nil
+	_ = err
+
 	return nil
 }
 

--- a/aws/ecs_metadata.go
+++ b/aws/ecs_metadata.go
@@ -17,6 +17,7 @@ type ContainerLimits struct {
 	Memory int `json:"Memory"`
 }
 
+// ContainerLabels represents AWS container labels
 type ContainerLabels struct {
 	Cluster               string `json:"com.amazonaws.ecs.cluster"`
 	TaskARN               string `json:"com.amazonaws.ecs.task-arn"`
@@ -24,12 +25,13 @@ type ContainerLabels struct {
 	TaskDefinitionVersion string `json:"com.amazonaws.ecs.task-definition-version"`
 }
 
+// ContainerNetwork represents AWS container network configuration
 type ContainerNetwork struct {
 	Mode          string   `json:"NetworkMode"`
 	IPv4Addresses []string `json:"IPv4Addresses"`
 }
 
-// ECSContainerV3Metadata represents the ECS container metadata as described in
+// ECSContainerMetadata represents the ECS container metadata as described in
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html#metadata-file-format
 type ECSContainerMetadata struct {
 	DockerID        string             `json:"DockerId"`

--- a/docker/container_stats.go
+++ b/docker/container_stats.go
@@ -88,7 +88,7 @@ type ContainerBlockIOStats struct {
 	ServiceBytes []BlockIOOpStats `json:"io_service_bytes_recursive"`
 }
 
-// CPUThrottlingStats represents the cgroups CPU usage stats.
+// CPUUsageStats represents the cgroups CPU usage stats.
 //
 // See https://docs.docker.com/config/containers/runmetrics/#metrics-from-cgroups-memory-cpu-block-io
 type CPUUsageStats struct {

--- a/example/database/elasticsearch.go
+++ b/example/database/elasticsearch.go
@@ -19,7 +19,7 @@ func fetchResults(parentSpan ot.Span) {
 	// Making an ElasticSearch query
 	childSpan := ot.StartSpan("elasticsearch", ot.ChildOf(parentSpan.Context()))
 
-	// Set the apropriate tags for the span
+	// Set the appropriate tags for the span
 	//
 	// Client Span
 	childSpan.SetTag(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum))

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -293,7 +293,7 @@ func (a *fargateAgent) SendSpans(spans []Span) error {
 		agentSpans = append(agentSpans, agentSpan{sp, from})
 	}
 
-	// enqueue the spans to send them in a bundle with metrics instead of sending immidiately
+	// enqueue the spans to send them in a bundle with metrics instead of sending immediately
 	a.mu.Lock()
 	a.spanQueue = append(a.spanQueue, agentSpans...)
 	a.mu.Unlock()
@@ -415,7 +415,7 @@ func (c *ecsDockerStatsCollector) fetchStats(ctx context.Context) {
 	if err != nil {
 		if ctx.Err() != nil {
 			// request either timed out or had been cancelled, keep the old value
-			c.logger.Debug("failed to retireve Docker container stats (timed out), skipping")
+			c.logger.Debug("failed to retrieve Docker container stats (timed out), skipping")
 			return
 		}
 

--- a/gcr_agent.go
+++ b/gcr_agent.go
@@ -213,7 +213,7 @@ func (a *gcrAgent) SendSpans(spans []Span) error {
 		agentSpans = append(agentSpans, agentSpan{sp, from})
 	}
 
-	// enqueue the spans to send them in a bundle with metrics instead of sending immidiately
+	// enqueue the spans to send them in a bundle with metrics instead of sending immediately
 	a.mu.Lock()
 	a.spanQueue = append(a.spanQueue, agentSpans...)
 	a.mu.Unlock()

--- a/instrumentation/cloud.google.com/go/iam/doc.go
+++ b/instrumentation/cloud.google.com/go/iam/doc.go
@@ -1,3 +1,2 @@
 // Package iam provides Instana tracing instrumentation for for Google Cloud IAM clients that use cloud.google.com/go/iam
-
 package iam

--- a/instrumentation/cloud.google.com/go/internal/trace.go
+++ b/instrumentation/cloud.google.com/go/internal/trace.go
@@ -10,6 +10,8 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
+// StartExitSpan starts a new span and injects in into returned context. If provided context already
+// contains an active span, it will be used as a parent.
 func StartExitSpan(ctx context.Context, op string, opts ...ot.StartSpanOption) context.Context {
 	sp, ok := instana.SpanFromContext(ctx)
 	if !ok {
@@ -21,6 +23,8 @@ func StartExitSpan(ctx context.Context, op string, opts ...ot.StartSpanOption) c
 	return instana.ContextWithSpan(ctx, sp.Tracer().StartSpan(op, opts...))
 }
 
+// FinishSpan finishes an active span found in context, optionally logging an error if it's not nil.
+// This function is a noop if provided context does not contain an active span.
 func FinishSpan(ctx context.Context, err error) {
 	sp, ok := instana.SpanFromContext(ctx)
 	if !ok {

--- a/instrumentation/cloud.google.com/go/pubsub/topic.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic.go
@@ -65,6 +65,9 @@ func (top *Topic) Publish(ctx context.Context, msg *pubsub.Message) *pubsub.Publ
 	return res
 }
 
+// Subscriptions calls Subscriptions() of underlying Topic and wraps the returned subscription iterator.
+//
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic.Subscriptions for furter details on wrapped method.
 func (top *Topic) Subscriptions(ctx context.Context) *SubscriptionIterator {
 	return &SubscriptionIterator{top.Topic.Subscriptions(ctx), top.projectID, top.sensor}
 }

--- a/instrumentation/cloud.google.com/go/storage/doc.go
+++ b/instrumentation/cloud.google.com/go/storage/doc.go
@@ -1,3 +1,2 @@
 // Package storage provides Instana tracing instrumentation for Google Cloud Storage clients that use cloud.google.com/go/storage
-
 package storage

--- a/instrumentation/cloud.google.com/go/storage/hmac.go
+++ b/instrumentation/cloud.google.com/go/storage/hmac.go
@@ -79,16 +79,16 @@ func (c *Client) CreateHMACKey(ctx context.Context, projectID, serviceAccountEma
 // Update calls and traces the Update() method of the wrapped cloud.google.com/go/storage.HMACKeyHandle.
 //
 // See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Update for furter details on wrapped method.
-func (h *HMACKeyHandle) Update(ctx context.Context, au storage.HMACKeyAttrsToUpdate, opts ...storage.HMACKeyOption) (hk *storage.HMACKey, err error) {
+func (hkh *HMACKeyHandle) Update(ctx context.Context, au storage.HMACKeyAttrsToUpdate, opts ...storage.HMACKeyOption) (hk *storage.HMACKey, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "hmacKeys.update",
-		"gcs.projectId": h.ProjectID,
-		"gcs.accessId":  h.AccessID,
+		"gcs.projectId": hkh.ProjectID,
+		"gcs.accessId":  hkh.AccessID,
 	})
 
 	defer func() { internal.FinishSpan(ctx, err) }()
 
-	return h.HMACKeyHandle.Update(ctx, au, opts...)
+	return hkh.HMACKeyHandle.Update(ctx, au, opts...)
 }
 
 // HMACKeysIterator is an instrumented wrapper for cloud.google.com/go/storage.HMACKeysIterator

--- a/instrumentation/instagrpc/instagrpc_test.go
+++ b/instrumentation/instagrpc/instagrpc_test.go
@@ -16,9 +16,9 @@ type agentSpan struct {
 		PID    string `json:"e"`
 		HostID string `json:"h"`
 	} `json:"f"`
-	Kind  int    `json:"k"`
-	Ec    int    `json:"ec,omitempty"`
-	Data  struct {
+	Kind int `json:"k"`
+	Ec   int `json:"ec,omitempty"`
+	Data struct {
 		Service string           `json:"service"`
 		RPC     agentRPCSpanData `json:"rpc"`
 	} `json:"data"`

--- a/instrumentation/instasarama/consumer.go
+++ b/instrumentation/instasarama/consumer.go
@@ -25,7 +25,7 @@ func NewConsumer(addrs []string, config *sarama.Config, sensor *instana.Sensor) 
 	return WrapConsumer(c, sensor), nil
 }
 
-// NewConsumerFromClient creates a new consumer using the given client and intruments its calls
+// NewConsumerFromClient creates a new consumer using the given client and instruments its calls
 func NewConsumerFromClient(client sarama.Client, sensor *instana.Sensor) (sarama.Consumer, error) {
 	c, err := sarama.NewConsumerFromClient(client)
 	if err != nil {

--- a/instrumentation/instasarama/consumer_group_handler.go
+++ b/instrumentation/instasarama/consumer_group_handler.go
@@ -16,7 +16,7 @@ type ConsumerGroupHandler struct {
 	sensor  *instana.Sensor
 }
 
-// WrapConsumerGroupHandler wraps the existing group handler and intruments its calls
+// WrapConsumerGroupHandler wraps the existing group handler and instruments its calls
 func WrapConsumerGroupHandler(h sarama.ConsumerGroupHandler, sensor *instana.Sensor) *ConsumerGroupHandler {
 	return &ConsumerGroupHandler{
 		handler: h,

--- a/instrumentation/instasarama/consumer_test.go
+++ b/instrumentation/instasarama/consumer_test.go
@@ -21,7 +21,7 @@ func TestConsumer_ConsumePartition(t *testing.T) {
 	messages := make(chan *sarama.ConsumerMessage, 1)
 	c := &testConsumer{
 		consumers: map[string]*testPartitionConsumer{
-			"topic-1": &testPartitionConsumer{
+			"topic-1": {
 				messages: messages,
 			},
 		},
@@ -70,7 +70,7 @@ func TestConsumer_ConsumePartition_Error(t *testing.T) {
 	c := &testConsumer{
 		Error: errors.New("something went wrong"),
 		consumers: map[string]*testPartitionConsumer{
-			"topic-1": &testPartitionConsumer{},
+			"topic-1": {},
 		},
 	}
 
@@ -112,7 +112,7 @@ func TestConsumer_Topics_Error(t *testing.T) {
 func TestConsumer_Partitions(t *testing.T) {
 	c := &testConsumer{
 		partitions: map[string][]int32{
-			"topic-1": []int32{1, 2, 3},
+			"topic-1": {1, 2, 3},
 		},
 	}
 
@@ -150,7 +150,7 @@ func TestConsumer_Partitions_Error(t *testing.T) {
 	c := &testConsumer{
 		Error: errors.New("something went wrong"),
 		partitions: map[string][]int32{
-			"topic-1": []int32{1, 2, 3},
+			"topic-1": {1, 2, 3},
 		},
 	}
 

--- a/instrumentation/instasarama/propagation.go
+++ b/instrumentation/instasarama/propagation.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	// The trace context header key
+	// FieldC is the trace context header key
 	FieldC = "X_INSTANA_C"
-	// The trace level header key
+	// FieldL is the trace level header key
 	FieldL = "X_INSTANA_L"
 )
 

--- a/instrumentation/instasarama/propagation_test.go
+++ b/instrumentation/instasarama/propagation_test.go
@@ -310,10 +310,10 @@ func TestProducerMessageCarrier_Update_FieldS(t *testing.T) {
 
 func TestProducerMessageCarrier_Set_FieldL(t *testing.T) {
 	examples := map[string][]sarama.RecordHeader{
-		"0": []sarama.RecordHeader{
+		"0": {
 			{Key: []byte(instasarama.FieldL), Value: []byte{0x00}},
 		},
-		"1": []sarama.RecordHeader{
+		"1": {
 			{Key: []byte(instasarama.FieldL), Value: []byte{0x01}},
 		},
 	}
@@ -787,10 +787,10 @@ func TestConsumerMessageCarrier_Update_FieldS(t *testing.T) {
 
 func TestConsumerMessageCarrier_Set_FieldL(t *testing.T) {
 	examples := map[string][]*sarama.RecordHeader{
-		"0": []*sarama.RecordHeader{
+		"0": {
 			{Key: []byte(instasarama.FieldL), Value: []byte{0x00}},
 		},
-		"1": []*sarama.RecordHeader{
+		"1": {
 			{Key: []byte(instasarama.FieldL), Value: []byte{0x01}},
 		},
 	}

--- a/instrumentation/instasarama/record_header_test.go
+++ b/instrumentation/instasarama/record_header_test.go
@@ -107,8 +107,8 @@ func TestUnpackTraceContextHeader_WrongBufferSize(t *testing.T) {
 func TestPackUnpackTraceLevelHeader(t *testing.T) {
 	// using fixed len arrays here to avoid typos in examples
 	examples := map[string][1]byte{
-		"0": [1]byte{0x00},
-		"1": [1]byte{0x01},
+		"0": {0x00},
+		"1": {0x01},
 	}
 
 	for level, expected := range examples {

--- a/instrumentation_sql_go1.10_test.go
+++ b/instrumentation_sql_go1.10_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
-	ot "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/instana/testify/assert"
 	"github.com/instana/testify/require"
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 )
 
 func TestWrapSQLConnector_Exec(t *testing.T) {

--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
-	ot "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/instana/testify/assert"
 	"github.com/instana/testify/require"
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 )
 
 func TestOpenSQLDB(t *testing.T) {

--- a/json_span.go
+++ b/json_span.go
@@ -190,7 +190,7 @@ func NewSpanData(span *spanS, st RegisteredSpanType) SpanData {
 	}
 }
 
-// Name returns the registered name for the span type suitable for use as the value of `n` field.
+// Type returns the registered span type suitable for use as the value of `n` field.
 func (d SpanData) Type() RegisteredSpanType {
 	return d.st
 }
@@ -426,11 +426,13 @@ func NewKafkaSpanTags(span *spanS) KafkaSpanTags {
 	return tags
 }
 
+// GCPStorageSpanData represents the `data` section of a Google Cloud Storage span sent within an OT span document
 type GCPStorageSpanData struct {
 	SpanData
 	Tags GCPStorageSpanTags `json:"gcs"`
 }
 
+// NewGCPStorageSpanData initializes a new Google Cloud Storage span data from tracer span
 func NewGCPStorageSpanData(span *spanS) GCPStorageSpanData {
 	data := GCPStorageSpanData{
 		SpanData: NewSpanData(span, GCPStorageSpanType),
@@ -440,10 +442,12 @@ func NewGCPStorageSpanData(span *spanS) GCPStorageSpanData {
 	return data
 }
 
+// Kind returns the span kind for a Google Cloud Storage span
 func (d GCPStorageSpanData) Kind() SpanKind {
 	return ExitSpanKind
 }
 
+// GCPStorageSpanTags contains fields within the `data.gcs` section of an OT span document
 type GCPStorageSpanTags struct {
 	Operation          string `json:"op,omitempty"`
 	Bucket             string `json:"bucket,omitempty"`
@@ -459,6 +463,7 @@ type GCPStorageSpanTags struct {
 	AccessID           string `json:"accessId,omitempty"`
 }
 
+// NewGCPStorageSpanTags extracts Google Cloud Storage span tags from a tracer span
 func NewGCPStorageSpanTags(span *spanS) GCPStorageSpanTags {
 	var tags GCPStorageSpanTags
 	for k, v := range span.Tags {
@@ -493,11 +498,13 @@ func NewGCPStorageSpanTags(span *spanS) GCPStorageSpanTags {
 	return tags
 }
 
+// GCPPubSubSpanData represents the `data` section of a Google Cloud Pub/Sub span sent within an OT span document
 type GCPPubSubSpanData struct {
 	SpanData
 	Tags GCPPubSubSpanTags `json:"gcps"`
 }
 
+// NewGCPPubSubSpanData initializes a new Google Cloud Pub/Span span data from tracer span
 func NewGCPPubSubSpanData(span *spanS) GCPPubSubSpanData {
 	data := GCPPubSubSpanData{
 		SpanData: NewSpanData(span, GCPPubSubSpanType),
@@ -507,6 +514,7 @@ func NewGCPPubSubSpanData(span *spanS) GCPPubSubSpanData {
 	return data
 }
 
+// Kind returns the span kind for a Google Cloud Pub/Sub span
 func (d GCPPubSubSpanData) Kind() SpanKind {
 	switch strings.ToLower(d.Tags.Operation) {
 	case "consume":
@@ -516,6 +524,7 @@ func (d GCPPubSubSpanData) Kind() SpanKind {
 	}
 }
 
+// GCPPubSubSpanTags contains fields within the `data.gcps` section of an OT span document
 type GCPPubSubSpanTags struct {
 	ProjectID    string `json:"projid"`
 	Operation    string `json:"op"`
@@ -524,6 +533,7 @@ type GCPPubSubSpanTags struct {
 	MessageID    string `json:"msgid,omitempty"`
 }
 
+// NewGCPPubSubSpanTags extracts Google Cloud Pub/Sub span tags from a tracer span
 func NewGCPPubSubSpanTags(span *spanS) GCPPubSubSpanTags {
 	var tags GCPPubSubSpanTags
 	for k, v := range span.Tags {

--- a/json_span.go
+++ b/json_span.go
@@ -295,7 +295,7 @@ type HTTPSpanTags struct {
 	Host string `json:"host,omitempty"`
 	// The name of the protocol used for request ("http" or "https")
 	Protocol string `json:"protocol,omitempty"`
-	// The message describing an error occured during the request handling
+	// The message describing an error occurred during the request handling
 	Error string `json:"error,omitempty"`
 }
 
@@ -360,7 +360,7 @@ type RPCSpanTags struct {
 	CallType string `json:"call_type,omitempty"`
 	// The RPC flavor used for this call, e.g. "grpc" for GRPC requests
 	Flavor string `json:"flavor,omitempty"`
-	// The message describing an error occured during the request handling
+	// The message describing an error occurred during the request handling
 	Error string `json:"error,omitempty"`
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,16 +7,16 @@ import (
 	"sync"
 )
 
+// Valid log levels to be used with (*logger.Logger).SetLevel()
 const (
-	// Valid log levels to be used with (*logger.Logger).SetLevel()
 	ErrorLevel Level = iota
 	WarnLevel
 	InfoLevel
 	DebugLevel
-
-	// Default log prefix
-	DefaultPrefix = "instana: "
 )
+
+// DefaultPrefix is the default log prefix used by Logger
+const DefaultPrefix = "instana: "
 
 // Level defines the minimum logging level for logger.Log
 type Level uint8

--- a/matcher.go
+++ b/matcher.go
@@ -13,7 +13,7 @@ const (
 	EqualsMatcher = "equals"
 	// EqualsIgnoreCaseMatcher matches the string exactly ignoring the case
 	EqualsIgnoreCaseMatcher = "equals-ignore-case"
-	// Contains matches the substring in a string
+	// ContainsMatcher matches the substring in a string
 	ContainsMatcher = "contains"
 	// ContainsIgnoreCaseMatcher matches the substring in a string ignoring the case
 	ContainsIgnoreCaseMatcher = "contains-ignore-case"

--- a/meter.go
+++ b/meter.go
@@ -61,7 +61,7 @@ func (m *meterS) setLogger(l LeveledLogger) {
 	m.logger = l
 }
 
-func (r *meterS) collectMemoryMetrics() acceptor.MemoryStats {
+func (m *meterS) collectMemoryMetrics() acceptor.MemoryStats {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 	ret := acceptor.MemoryStats{
@@ -81,18 +81,18 @@ func (r *meterS) collectMemoryMetrics() acceptor.MemoryStats {
 		NumGC:         memStats.NumGC,
 		GCCPUFraction: memStats.GCCPUFraction}
 
-	if r.numGC < memStats.NumGC {
+	if m.numGC < memStats.NumGC {
 		ret.PauseNs = memStats.PauseNs[(memStats.NumGC+255)%256]
-		r.numGC = memStats.NumGC
+		m.numGC = memStats.NumGC
 	}
 
 	return ret
 }
 
-func (r *meterS) collectMetrics() acceptor.Metrics {
+func (m *meterS) collectMetrics() acceptor.Metrics {
 	return acceptor.Metrics{
 		CgoCall:     runtime.NumCgoCall(),
 		Goroutine:   runtime.NumGoroutine(),
-		MemoryStats: r.collectMemoryMetrics(),
+		MemoryStats: m.collectMemoryMetrics(),
 	}
 }

--- a/propagation.go
+++ b/propagation.go
@@ -61,7 +61,7 @@ func injectTraceContext(sc SpanContext, opaqueCarrier interface{}) error {
 		// Even though the godoc claims that the key passed to (*http.Header).Set()
 		// is case-insensitive, it actually normalizes it using textproto.CanonicalMIMEHeaderKey()
 		// before populating the value. As a result headers with non-canonical will not be
-		// overwritted with a new value. This is only the case if header names were set while
+		// overwritten with a new value. This is only the case if header names were set while
 		// initializing the http.Header instance, i.e.
 		//     h := http.Headers{"X-InStAnA-T": {"abc123"}}
 		// and does not apply to a common case when requests are being created using http.NewRequest()

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -6,9 +6,9 @@ import (
 
 	instana "github.com/instana/go-sensor"
 	"github.com/instana/go-sensor/w3ctrace"
-	ot "github.com/opentracing/opentracing-go"
 	"github.com/instana/testify/assert"
 	"github.com/instana/testify/require"
+	ot "github.com/opentracing/opentracing-go"
 )
 
 func TestTracer_Inject_HTTPHeaders(t *testing.T) {

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	instana "github.com/instana/go-sensor"
-	ext "github.com/opentracing/opentracing-go/ext"
 	"github.com/instana/testify/assert"
 	"github.com/instana/testify/require"
+	ext "github.com/opentracing/opentracing-go/ext"
 )
 
 func TestRecorderBasics(t *testing.T) {

--- a/secrets/matchers_test.go
+++ b/secrets/matchers_test.go
@@ -12,16 +12,16 @@ import (
 func TestEqualsMatcher(t *testing.T) {
 	m := secrets.NewEqualsMatcher("one", "two")
 	examples := map[string]bool{
-		"":           false,
-		"one":        true,
-		"two":        true,
-		"ONE":        false,
-		"tWo":        false,
-		"onetwo":     false,
-		"two ":       false,
-		" one":       false,
-		"fourty-two": false,
-		"hello!":     false,
+		"":          false,
+		"one":       true,
+		"two":       true,
+		"ONE":       false,
+		"tWo":       false,
+		"onetwo":    false,
+		"two ":      false,
+		" one":      false,
+		"forty-two": false,
+		"hello!":    false,
 	}
 
 	for s, expected := range examples {
@@ -34,16 +34,16 @@ func TestEqualsMatcher(t *testing.T) {
 func TestEqualsIgnoreCaseMatcher(t *testing.T) {
 	m := secrets.NewEqualsIgnoreCaseMatcher("One", "TWO")
 	examples := map[string]bool{
-		"":           false,
-		"one":        true,
-		"two":        true,
-		"ONE":        true,
-		"tWo":        true,
-		"onetwo":     false,
-		"two ":       false,
-		" one":       false,
-		"fourty-two": false,
-		"hello!":     false,
+		"":          false,
+		"one":       true,
+		"two":       true,
+		"ONE":       true,
+		"tWo":       true,
+		"onetwo":    false,
+		"two ":      false,
+		" one":      false,
+		"forty-two": false,
+		"hello!":    false,
 	}
 
 	for s, expected := range examples {
@@ -56,16 +56,16 @@ func TestEqualsIgnoreCaseMatcher(t *testing.T) {
 func TestContainsMatcher(t *testing.T) {
 	m := secrets.NewContainsMatcher("one", "two")
 	examples := map[string]bool{
-		"":           false,
-		"one":        true,
-		"two":        true,
-		"ONE":        false,
-		"tWo":        false,
-		"onetwo":     true,
-		"two ":       true,
-		" one":       true,
-		"fourty-two": true,
-		"hello!":     false,
+		"":          false,
+		"one":       true,
+		"two":       true,
+		"ONE":       false,
+		"tWo":       false,
+		"onetwo":    true,
+		"two ":      true,
+		" one":      true,
+		"forty-two": true,
+		"hello!":    false,
 	}
 
 	for s, expected := range examples {
@@ -78,16 +78,16 @@ func TestContainsMatcher(t *testing.T) {
 func TestContainsIgnoreCaseMatcher(t *testing.T) {
 	m := secrets.NewContainsIgnoreCaseMatcher("one", "two")
 	examples := map[string]bool{
-		"":           false,
-		"one":        true,
-		"two":        true,
-		"ONE":        true,
-		"tWo":        true,
-		"onetwo":     true,
-		"two ":       true,
-		" one":       true,
-		"fourty-TWO": true,
-		"hello!":     false,
+		"":          false,
+		"one":       true,
+		"two":       true,
+		"ONE":       true,
+		"tWo":       true,
+		"onetwo":    true,
+		"two ":      true,
+		" one":      true,
+		"forty-TWO": true,
+		"hello!":    false,
 	}
 
 	for s, expected := range examples {
@@ -102,16 +102,16 @@ func TestRegexpMatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	examples := map[string]bool{
-		"":           false,
-		"one":        true,
-		"two":        true,
-		"ONE":        true,
-		"tWo":        false,
-		"onetwo":     false,
-		"two ":       false,
-		" one":       false,
-		"fourty-TWO": false,
-		"hello!":     false,
+		"":          false,
+		"one":       true,
+		"two":       true,
+		"ONE":       true,
+		"tWo":       false,
+		"onetwo":    false,
+		"two ":      false,
+		" one":      false,
+		"forty-TWO": false,
+		"hello!":    false,
 	}
 
 	for s, expected := range examples {

--- a/sensor.go
+++ b/sensor.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
+	// DefaultMaxBufferedSpans is the default span buffer size
 	DefaultMaxBufferedSpans = 1000
-	DefaultForceSpanSendAt  = 500
+	// DefaultForceSpanSendAt is the default max number of spans to buffer before force sending them to the agent
+	DefaultForceSpanSendAt = 500
 
 	defaultServerlessTimeout = 500 * time.Millisecond
 )

--- a/util.go
+++ b/util.go
@@ -46,7 +46,7 @@ func FormatID(id int64) string {
 	return strconv.FormatUint(unsigned, 16)
 }
 
-// Header2ID converts an header context value into an Instana ID.  More
+// ParseID converts an header context value into an Instana ID.  More
 // specifically, this converts an unsigned 64 bit hex value into a signed
 // 64bit integer.
 func ParseID(header string) (int64, error) {

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -7,17 +7,22 @@ import (
 )
 
 const (
-	// The max number of items in `tracestate` as defined by https://www.w3.org/TR/trace-context/#tracestate-header-field-values
+	// MaxStateEntries is the maximum number of items in `tracestate` as defined by
+	// https://www.w3.org/TR/trace-context/#tracestate-header-field-values
 	MaxStateEntries = 32
 
-	// W3C trace context header names as defined by https://www.w3.org/TR/trace-context/
+	// TraceParentHeader is the W3C trace parent header name as defined by https://www.w3.org/TR/trace-context/
 	TraceParentHeader = "traceparent"
-	TraceStateHeader  = "tracestate"
+	// TraceStateHeader is the W3C trace state header name as defined by https://www.w3.org/TR/trace-context/
+	TraceStateHeader = "tracestate"
 )
 
 var (
-	ErrContextNotFound    = errors.New("no w3c context")
-	ErrContextCorrupted   = errors.New("corrupted w3c context")
+	// ErrContextNotFound is an error retuned by w3ctrace.Extract() if provided HTTP headers does not contain W3C trace context
+	ErrContextNotFound = errors.New("no w3c context")
+	// ErrContextCorrupted is an error retuned by w3ctrace.Extract() if provided HTTP headers contain W3C trace context in unexpected format
+	ErrContextCorrupted = errors.New("corrupted w3c context")
+	// ErrUnsupportedVersion is an error retuned by w3ctrace.Extract() if the version of provided W3C trace context is not supported
 	ErrUnsupportedVersion = errors.New("unsupported w3c context version")
 )
 

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -79,8 +79,8 @@ func Inject(trCtx Context, headers http.Header) {
 
 // State parses RawState and returns the corresponding list.
 // It silently discards malformed state. To check errors use ParseState().
-func (trCtx Context) State() State {
-	st, err := ParseState(trCtx.RawState)
+func (c Context) State() State {
+	st, err := ParseState(c.RawState)
 	if err != nil {
 		return State{}
 	}
@@ -90,8 +90,8 @@ func (trCtx Context) State() State {
 
 // Parent parses RawParent and returns the corresponding list.
 // It silently discards malformed value. To check errors use ParseParent().
-func (trCtx Context) Parent() Parent {
-	st, err := ParseParent(trCtx.RawParent)
+func (c Context) Parent() Parent {
+	st, err := ParseParent(c.RawParent)
 	if err != nil {
 		return Parent{}
 	}

--- a/w3ctrace/state.go
+++ b/w3ctrace/state.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// Instana vendor key in the `tracestate` list
+// VendorInstana is the Instana vendor key in the `tracestate` list
 const VendorInstana = "in"
 
 // State is list of key=value pairs representing vendor-specific data in the trace context
@@ -28,7 +28,7 @@ func ParseState(traceStateValue string) (State, error) {
 	return state, nil
 }
 
-// Put returns a new state prepended with provided vendor-specific data. It removes any existing
+// Add returns a new state prepended with provided vendor-specific data. It removes any existing
 // entries for this vendor and returns the same state if vendor is empty. If the number of entries
 // in a state reaches the MaxStateEntries, rest of the items will be truncated
 func (st State) Add(vendor, data string) State {


### PR DESCRIPTION
This PR addresses following linter warnings found with Go Report Card:
* Malformed or missing godoc strings
* Inconsistent receiver names
* Typos and misspelled words