### PR TITLE
Add AWS Lambda agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MODULES = $(filter-out $(EXCLUDE_DIRS), $(shell find . -name go.mod -exec dirnam
 LINTER ?= $(shell go env GOPATH)/bin/golangci-lint
 
 # The list of Go build tags as they are specified in respective integration test files
-INTEGRATION_TESTS = fargate gcr
+INTEGRATION_TESTS = fargate gcr lambda
 
 # the Go version to vendor dependencies listed in go.mod
 VENDOR_GO_VERSION ?= go1.15

--- a/acceptor/aws.go
+++ b/acceptor/aws.go
@@ -66,3 +66,13 @@ func NewECSContainerPluginPayload(entityID string, data ECSContainerData) Plugin
 		Data:     data,
 	}
 }
+
+// NewAWSLambdaPluginPayload returns payload for the AWS Lambda plugin of Instana acceptor
+func NewAWSLambdaPluginPayload(entityID string) PluginPayload {
+	const pluginName = "com.instana.plugin.aws.lambda"
+
+	return PluginPayload{
+		Name:     pluginName,
+		EntityID: entityID,
+	}
+}

--- a/adapters.go
+++ b/adapters.go
@@ -27,6 +27,8 @@ type Tracer interface {
 
 	// Options gets the current tracer options
 	Options() TracerOptions
+	// Flush sends all finished spans to the agent
+	Flush(context.Context) error
 }
 
 // Sensor is used to inject tracing information into requests

--- a/agent.go
+++ b/agent.go
@@ -2,6 +2,7 @@ package instana
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -165,6 +166,9 @@ func (agent *agentS) SendSpans(spans []Span) error {
 
 	return nil
 }
+
+// Flush is a noop for host agent
+func (agent *agentS) Flush(ctx context.Context) error { return nil }
 
 type hostAgentProfile struct {
 	autoprofile.Profile

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -303,6 +303,34 @@ func (a *fargateAgent) SendSpans(spans []Span) error {
 
 func (a *fargateAgent) SendProfiles(profiles []autoprofile.Profile) error { return nil }
 
+func (a *fargateAgent) Flush(ctx context.Context) error {
+	if len(a.spanQueue) == 0 {
+		return nil
+	}
+
+	if !a.Ready() {
+		return ErrAgentNotReady
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(a.spanQueue); err != nil {
+		return fmt.Errorf("failed to marshal traces payload: %s", err)
+	}
+	a.spanQueue = a.spanQueue[:0]
+
+	req, err := http.NewRequest(http.MethodPost, a.Endpoint+"/traces", buf)
+	if err != nil {
+		return fmt.Errorf("failed to prepare send traces request: %s", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return a.sendRequest(req.WithContext(ctx))
+}
+
 func (a *fargateAgent) sendRequest(req *http.Request) error {
 	req.Header.Set("X-Instana-Host", a.snapshot.Service.EntityID)
 	req.Header.Set("X-Instana-Key", a.Key)

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -32,6 +32,10 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 			Operation: "test",
 			Expected:  instana.SDKSpanData{},
 		},
+		"aws lambda": {
+			Operation: "aws.lambda.entry",
+			Expected:  instana.AWSLambdaSpanData{},
+		},
 	}
 
 	for name, example := range examples {

--- a/lambda_agent.go
+++ b/lambda_agent.go
@@ -1,0 +1,56 @@
+package instana
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/instana/go-sensor/acceptor"
+	"github.com/instana/go-sensor/autoprofile"
+)
+
+type lambdaAgent struct {
+	Endpoint string
+	Key      string
+	PID      int
+	Zone     string
+	Tags     map[string]interface{}
+
+	client *http.Client
+	logger LeveledLogger
+}
+
+func newLambdaAgent(
+	serviceName, acceptorEndpoint, agentKey string,
+	client *http.Client,
+	logger LeveledLogger,
+) *lambdaAgent {
+	if logger == nil {
+		logger = defaultLogger
+	}
+
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	logger.Debug("initializing aws lambda agent")
+
+	return &lambdaAgent{
+		Endpoint: acceptorEndpoint,
+		Key:      agentKey,
+		PID:      os.Getpid(),
+		Zone:     os.Getenv("INSTANA_ZONE"),
+		Tags:     parseInstanaTags(os.Getenv("INSTANA_TAGS")),
+		client:   client,
+		logger:   logger,
+	}
+}
+
+func (a *lambdaAgent) Ready() bool { return false }
+
+func (a *lambdaAgent) SendMetrics(data acceptor.Metrics) error { return nil }
+
+func (a *lambdaAgent) SendEvent(event *EventData) error { return nil }
+
+func (a *lambdaAgent) SendSpans(spans []Span) error { return nil }
+
+func (a *lambdaAgent) SendProfiles(profiles []autoprofile.Profile) error { return nil }

--- a/lambda_agent.go
+++ b/lambda_agent.go
@@ -62,7 +62,7 @@ func newLambdaAgent(
 	}
 
 	go func() {
-		t := time.NewTicker(time.Second)
+		t := time.NewTicker(awsLambdaAgentFlushPeriod)
 		defer t.Stop()
 
 		for range t.C {

--- a/lambda_agent.go
+++ b/lambda_agent.go
@@ -1,6 +1,7 @@
 package instana
 
 import (
+	"context"
 	"net/http"
 	"os"
 
@@ -54,3 +55,5 @@ func (a *lambdaAgent) SendEvent(event *EventData) error { return nil }
 func (a *lambdaAgent) SendSpans(spans []Span) error { return nil }
 
 func (a *lambdaAgent) SendProfiles(profiles []autoprofile.Profile) error { return nil }
+
+func (a *lambdaAgent) Flush(ctx context.Context) error { return nil }

--- a/lambda_agent.go
+++ b/lambda_agent.go
@@ -1,13 +1,24 @@
 package instana
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"sync"
+	"time"
 
 	"github.com/instana/go-sensor/acceptor"
 	"github.com/instana/go-sensor/autoprofile"
 )
+
+const awsLambdaAgentFlushPeriod = 2 * time.Second
 
 type lambdaAgent struct {
 	Endpoint string
@@ -15,6 +26,11 @@ type lambdaAgent struct {
 	PID      int
 	Zone     string
 	Tags     map[string]interface{}
+
+	snapshot serverlessSnapshot
+
+	mu        sync.Mutex
+	spanQueue []Span
 
 	client *http.Client
 	logger LeveledLogger
@@ -46,14 +62,133 @@ func newLambdaAgent(
 	}
 }
 
-func (a *lambdaAgent) Ready() bool { return false }
+func (a *lambdaAgent) Ready() bool { return true }
 
 func (a *lambdaAgent) SendMetrics(data acceptor.Metrics) error { return nil }
 
 func (a *lambdaAgent) SendEvent(event *EventData) error { return nil }
 
-func (a *lambdaAgent) SendSpans(spans []Span) error { return nil }
+func (a *lambdaAgent) SendSpans(spans []Span) error {
+	a.enqueueSpans(spans)
+	return nil
+}
 
 func (a *lambdaAgent) SendProfiles(profiles []autoprofile.Profile) error { return nil }
 
-func (a *lambdaAgent) Flush(ctx context.Context) error { return nil }
+func (a *lambdaAgent) Flush(ctx context.Context) error {
+	snapshot := a.collectSnapshot(a.spanQueue)
+
+	if snapshot.EntityID == "" {
+		return ErrAgentNotReady
+	}
+
+	from := newServerlessAgentFromS(snapshot.EntityID, "aws")
+
+	a.mu.Lock()
+	spans := make([]Span, len(a.spanQueue))
+	copy(spans, a.spanQueue)
+	a.spanQueue = a.spanQueue[:0]
+	a.mu.Unlock()
+
+	payload := struct {
+		Metrics metricsPayload `json:"metrics,omitempty"`
+		Spans   []agentSpan    `json:"spans,omitempty"`
+	}{
+		Metrics: metricsPayload{
+			Plugins: []acceptor.PluginPayload{
+				acceptor.NewAWSLambdaPluginPayload(snapshot.EntityID),
+			},
+		},
+		Spans: make([]agentSpan, 0, len(spans)),
+	}
+
+	for _, sp := range spans {
+		payload.Spans = append(payload.Spans, agentSpan{
+			Span: sp,
+			From: from,
+		})
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(payload); err != nil {
+		return fmt.Errorf("failed to marshal traces payload: %s", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, a.Endpoint+"/bundle", buf)
+	if err != nil {
+		a.enqueueSpans(spans)
+		return fmt.Errorf("failed to prepare send traces request: %s", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := a.sendRequest(req.WithContext(ctx)); err != nil {
+		a.enqueueSpans(spans)
+		return fmt.Errorf("failed to send traces, will retry later: %s", err)
+	}
+
+	return nil
+}
+
+func (a *lambdaAgent) enqueueSpans(spans []Span) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.spanQueue = append(a.spanQueue, spans...)
+}
+
+func (a *lambdaAgent) sendRequest(req *http.Request) error {
+	req.Header.Set("X-Instana-Host", a.snapshot.Host)
+	req.Header.Set("X-Instana-Key", a.Key)
+	req.Header.Set("X-Instana-Time", strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10))
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request to the serverless agent: %s", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			a.logger.Debug("failed to read serverless agent response: ", err)
+			return nil
+		}
+
+		a.logger.Info("serverless agent has responded with ", resp.Status, ": ", string(respBody))
+		return nil
+	}
+
+	io.CopyN(ioutil.Discard, resp.Body, 1<<20)
+
+	return nil
+}
+
+func (a *lambdaAgent) collectSnapshot(spans []Span) serverlessSnapshot {
+	if a.snapshot.EntityID != "" {
+		return a.snapshot
+	}
+
+	// searching for the lambda entry span in reverse order, since it's
+	// more likely to be finished last
+	for i := len(spans) - 1; i >= 0; i-- {
+		sp, ok := spans[i].Data.(AWSLambdaSpanData)
+		if !ok {
+			log.Printf("span data type %t", spans[i].Data)
+			continue
+		}
+
+		a.snapshot = serverlessSnapshot{
+			EntityID: sp.Snapshot.ARN,
+			Host:     sp.Snapshot.ARN,
+			Zone:     a.Zone,
+			Tags:     a.Tags,
+		}
+		a.logger.Debug("collected snapshot")
+
+		break
+	}
+
+	return a.snapshot
+}

--- a/lambda_agent_test.go
+++ b/lambda_agent_test.go
@@ -1,0 +1,89 @@
+// +build lambda,integration
+
+package instana_test
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	instana "github.com/instana/go-sensor"
+	"github.com/instana/testify/assert"
+	"github.com/instana/testify/require"
+	"github.com/opentracing/opentracing-go"
+)
+
+var agent *serverlessAgent
+
+func TestMain(m *testing.M) {
+	teardownEnv := setupAWSLambdaEnv()
+	defer teardownEnv()
+
+	defer restoreEnvVarFunc("INSTANA_AGENT_KEY")
+	os.Setenv("INSTANA_AGENT_KEY", "testkey1")
+
+	defer restoreEnvVarFunc("INSTANA_ZONE")
+	os.Setenv("INSTANA_ZONE", "testzone")
+
+	defer restoreEnvVarFunc("INSTANA_TAGS")
+	os.Setenv("INSTANA_TAGS", "key1=value1,key2")
+
+	defer restoreEnvVarFunc("INSTANA_SECRETS")
+	os.Setenv("INSTANA_SECRETS", "contains-ignore-case:key,password,secret,classified")
+
+	defer restoreEnvVarFunc("CLASSIFIED_DATA")
+	os.Setenv("CLASSIFIED_DATA", "classified")
+
+	var err error
+	agent, err = setupServerlessAgent()
+	if err != nil {
+		log.Fatalf("failed to initialize serverless agent: %s", err)
+	}
+
+	instana.InitSensor(instana.DefaultOptions())
+
+	os.Exit(m.Run())
+}
+
+func TestLambdaAgent_SendSpans(t *testing.T) {
+	defer agent.Reset()
+
+	tracer := instana.NewTracer()
+	sensor := instana.NewSensorWithTracer(tracer)
+
+	sp := sensor.Tracer().StartSpan("aws.lambda.entry", opentracing.Tags{
+		"lambda.arn":     "aws::test-lambda::$LATEST",
+		"lambda.name":    "test-lambda",
+		"lambda.version": "$LATEST",
+	})
+	sp.Finish()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	require.NoError(t, tracer.Flush(ctx))
+	require.Len(t, agent.Bundles, 1)
+
+	var spans []map[string]json.RawMessage
+	for _, bundle := range agent.Bundles {
+		var payload struct {
+			Spans []map[string]json.RawMessage `json:"spans"`
+		}
+
+		require.NoError(t, json.Unmarshal(bundle.Body, &payload), "%s", string(bundle.Body))
+		spans = append(spans, payload.Spans...)
+	}
+
+	require.Len(t, spans, 1)
+	assert.JSONEq(t, `{"hl": true, "cp": "aws", "e": "aws::test-lambda::$LATEST"}`, string(spans[0]["f"]))
+}
+
+func setupAWSLambdaEnv() func() {
+	teardown := restoreEnvVarFunc("AWS_EXECUTION_ENV")
+	os.Setenv("AWS_EXECUTION_ENV", "AWS_Lambda_go1.x")
+
+	return teardown
+}

--- a/recorder.go
+++ b/recorder.go
@@ -29,7 +29,7 @@ func NewRecorder() *Recorder {
 	go func() {
 		for range ticker.C {
 			if sensor.agent.Ready() {
-				r.send()
+				go r.send()
 			}
 		}
 	}()
@@ -104,12 +104,12 @@ func (r *Recorder) clearQueuedSpans() {
 	r.spans = r.spans[:0]
 }
 
-// Retrieve the queued spans and post them to the host agent asynchronously.
+// Retrieve the queued spans and post them to the host agent
 func (r *Recorder) send() {
 	spansToSend := r.GetQueuedSpans()
 	if len(spansToSend) == 0 {
 		return
 	}
 
-	go sensor.agent.SendSpans(spansToSend)
+	sensor.agent.SendSpans(spansToSend)
 }

--- a/recorder.go
+++ b/recorder.go
@@ -1,6 +1,8 @@
 package instana
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -11,6 +13,8 @@ import (
 type SpanRecorder interface {
 	// Implementations must determine whether and where to store `span`.
 	RecordSpan(span *spanS)
+	// Flush forces sending any buffered finished spans
+	Flush(context.Context) error
 }
 
 // Recorder accepts spans, processes and queues them
@@ -29,7 +33,7 @@ func NewRecorder() *Recorder {
 	go func() {
 		for range ticker.C {
 			if sensor.agent.Ready() {
-				go r.send()
+				go r.Flush(context.Background())
 			}
 		}
 	}()
@@ -68,8 +72,8 @@ func (r *Recorder) RecordSpan(span *spanS) {
 	}
 
 	if len(r.spans) >= sensor.options.ForceTransmissionStartingAt {
-		sensor.logger.Debug("Forcing spans to agent. Count:", len(r.spans))
-		go r.send()
+		sensor.logger.Debug("forcing ", len(r.spans), "span(s) to the agent")
+		go r.Flush(context.Background())
 	}
 }
 
@@ -95,6 +99,21 @@ func (r *Recorder) GetQueuedSpans() []Span {
 	return queuedSpans
 }
 
+// Flush sends queued spans to the agent
+func (r *Recorder) Flush(ctx context.Context) error {
+	spansToSend := r.GetQueuedSpans()
+	if len(spansToSend) == 0 {
+		return nil
+	}
+
+	if err := sensor.agent.SendSpans(spansToSend); err != nil {
+		r.spans = append(r.spans, spansToSend...)
+		return fmt.Errorf("failed to send collected spans to the agent: %s", err)
+	}
+
+	return nil
+}
+
 // clearQueuedSpans brings the span queue to empty/0/nada
 //   This function doesn't take the Lock so make sure to have
 //   the write lock before calling.
@@ -102,14 +121,4 @@ func (r *Recorder) GetQueuedSpans() []Span {
 //   locking.
 func (r *Recorder) clearQueuedSpans() {
 	r.spans = r.spans[:0]
-}
-
-// Retrieve the queued spans and post them to the host agent
-func (r *Recorder) send() {
-	spansToSend := r.GetQueuedSpans()
-	if len(spansToSend) == 0 {
-		return
-	}
-
-	sensor.agent.SendSpans(spansToSend)
 }

--- a/sensor.go
+++ b/sensor.go
@@ -1,6 +1,7 @@
 package instana
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -29,6 +30,7 @@ type agentClient interface {
 	SendEvent(event *EventData) error
 	SendSpans(spans []Span) error
 	SendProfiles(profiles []autoprofile.Profile) error
+	Flush(context.Context) error
 }
 
 type sensorS struct {

--- a/serverless_agent.go
+++ b/serverless_agent.go
@@ -2,6 +2,7 @@ package instana
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/user"
 	"strconv"
@@ -11,6 +12,8 @@ import (
 	"github.com/instana/go-sensor/acceptor"
 	"github.com/instana/go-sensor/process"
 )
+
+var ErrAgentNotReady = errors.New("agent not ready")
 
 type containerSnapshot struct {
 	ID    string


### PR DESCRIPTION
This PR adds basic support for tracing AWS Lambda functions by using a dedicated agent. To ensure that gathered data has been submitted upon function exit, there is now `(instana.Tracer).Flush()` method that forces sending collected spans to the agent.