### PR TITLE
Add support for AWS Lambda spans

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -568,6 +568,8 @@ type AWSLambdaSpanTags struct {
 	Name string `json:"functionName,omitempty"`
 	// Version is either the numeric version or $LATEST
 	Version string `json:"functionVersion,omitempty"`
+	// Trigger is the trigger event type (if any)
+	Trigger string `json:"trigger,omitempty"`
 }
 
 // NewAWSLambdaSpanTags extracts AWS Lambda entry span tags from a tracer span
@@ -584,6 +586,10 @@ func NewAWSLambdaSpanTags(span *spanS) AWSLambdaSpanTags {
 
 	if v, ok := span.Tags["lambda.version"]; ok {
 		readStringTag(&tags.Version, v)
+	}
+
+	if v, ok := span.Tags["lambda.trigger"]; ok {
+		readStringTag(&tags.Trigger, v)
 	}
 
 	return tags

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -1,6 +1,7 @@
 package instana_test
 
 import (
+	"strings"
 	"testing"
 
 	instana "github.com/instana/go-sensor"
@@ -154,6 +155,37 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 					Host:     "example.com",
 					Protocol: "https",
 					Error:    "Not Found",
+				},
+			},
+		},
+		"aws:cloudwatch.events": {
+			Tags: opentracing.Tags{
+				"cloudwatch.events.id": "cw-event-1",
+				"cloudwatch.events.resources": []string{
+					"res1",
+					strings.Repeat("long ", 40) + "res2",
+					"res3",
+					"res4",
+				},
+			},
+			Expected: instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "lambda-arn-1",
+					Runtime: "go",
+					Name:    "test-lambda",
+					Version: "42",
+					Trigger: "aws:cloudwatch.events",
+					CloudWatch: &instana.AWSCloudWatchTags{
+						Events: &instana.AWSCloudWatchEventTags{
+							ID: "cw-event-1",
+							Resources: []string{
+								"res1",
+								strings.Repeat("long ", 40),
+								"res3",
+							},
+							More: true,
+						},
+					},
 				},
 			},
 		},

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -251,6 +251,23 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 				},
 			},
 		},
+		"aws:sqs": {
+			Tags: opentracing.Tags{
+				"sqs.messages": []instana.AWSSQSMessageTags{{Queue: "q1"}, {Queue: "q2"}, {Queue: "q3"}, {Queue: "q4"}},
+			},
+			Expected: instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "lambda-arn-1",
+					Runtime: "go",
+					Name:    "test-lambda",
+					Version: "42",
+					Trigger: "aws:sqs",
+					SQS: &instana.AWSLambdaSQSSpanTags{
+						Messages: []instana.AWSSQSMessageTags{{Queue: "q1"}, {Queue: "q2"}, {Queue: "q3"}},
+					},
+				},
+			},
+		},
 	}
 
 	for trigger, example := range examples {

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -109,6 +109,40 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 					Runtime: "go",
 					Name:    "test-lambda",
 					Version: "42",
+					Trigger: "aws:api.gateway",
+				},
+				HTTP: &instana.HTTPSpanTags{
+					URL:      "https://example.com/lambda",
+					Status:   404,
+					Method:   "GET",
+					Path:     "/lambda",
+					Params:   "q=test&secret=classified",
+					Headers:  map[string]string{"x-custom-header-1": "test"},
+					Host:     "example.com",
+					Protocol: "https",
+					Error:    "Not Found",
+				},
+			},
+		},
+		"aws:application.load.balancer": {
+			Tags: opentracing.Tags{
+				"http.protocol": "https",
+				"http.url":      "https://example.com/lambda",
+				"http.host":     "example.com",
+				"http.method":   "GET",
+				"http.path":     "/lambda",
+				"http.params":   "q=test&secret=classified",
+				"http.header":   map[string]string{"x-custom-header-1": "test"},
+				"http.status":   404,
+				"http.error":    "Not Found",
+			},
+			Expected: instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "lambda-arn-1",
+					Runtime: "go",
+					Name:    "test-lambda",
+					Version: "42",
+					Trigger: "aws:application.load.balancer",
 				},
 				HTTP: &instana.HTTPSpanTags{
 					URL:      "https://example.com/lambda",
@@ -124,9 +158,6 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 			},
 		},
 	}
-
-	// ALB tags set is the same as for API Gateway, so we just copy it over
-	examples["aws:application.load.balancer"] = examples["aws:api.gateway"]
 
 	for trigger, example := range examples {
 		t.Run(trigger, func(t *testing.T) {

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -225,6 +225,32 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 				},
 			},
 		},
+		"aws:s3": {
+			Tags: opentracing.Tags{
+				"s3.events": []instana.AWSS3EventTags{
+					{Name: "event1", Bucket: "bucket1", Object: "object1"},
+					{Name: "event2", Bucket: "bucket2", Object: strings.Repeat("long ", 40) + "object2"},
+					{Name: "event3", Bucket: "bucket3"},
+					{Name: "event4", Bucket: "bucket4"},
+				},
+			},
+			Expected: instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "lambda-arn-1",
+					Runtime: "go",
+					Name:    "test-lambda",
+					Version: "42",
+					Trigger: "aws:s3",
+					S3: &instana.AWSLambdaS3SpanTags{
+						Events: []instana.AWSS3EventTags{
+							{Name: "event1", Bucket: "bucket1", Object: "object1"},
+							{Name: "event2", Bucket: "bucket2", Object: strings.Repeat("long ", 40)},
+							{Name: "event3", Bucket: "bucket3"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for trigger, example := range examples {

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -1,6 +1,7 @@
 package instana_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -175,8 +176,8 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 					Name:    "test-lambda",
 					Version: "42",
 					Trigger: "aws:cloudwatch.events",
-					CloudWatch: &instana.AWSCloudWatchTags{
-						Events: &instana.AWSCloudWatchEventTags{
+					CloudWatch: &instana.AWSLambdaCloudWatchSpanTags{
+						Events: &instana.AWSLambdaCloudWatchEventTags{
 							ID: "cw-event-1",
 							Resources: []string{
 								"res1",
@@ -184,6 +185,41 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 								"res3",
 							},
 							More: true,
+						},
+					},
+				},
+			},
+		},
+		"aws:cloudwatch.logs": {
+			Tags: opentracing.Tags{
+				"cloudwatch.logs.group":  "cw-log-group-1",
+				"cloudwatch.logs.stream": "cw-log-stream-1",
+				"cloudwatch.logs.events": []string{
+					"log1",
+					strings.Repeat("long ", 40) + "log2",
+					"log3",
+					"log4",
+				},
+				"cloudwatch.logs.decodingError": errors.New("none"),
+			},
+			Expected: instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "lambda-arn-1",
+					Runtime: "go",
+					Name:    "test-lambda",
+					Version: "42",
+					Trigger: "aws:cloudwatch.logs",
+					CloudWatch: &instana.AWSLambdaCloudWatchSpanTags{
+						Logs: &instana.AWSLambdaCloudWatchLogsTags{
+							Group:  "cw-log-group-1",
+							Stream: "cw-log-stream-1",
+							Events: []string{
+								"log1",
+								strings.Repeat("long ", 40),
+								"log3",
+							},
+							More:          true,
+							DecodingError: "none",
 						},
 					},
 				},


### PR DESCRIPTION
This PR adds support for AWS Lambda entry span tags. Attributes from following events are supported:
* API Gateway
* Application Load Balancer
* CloudWatch Events
* CloudWatch Logs
* S3
* SQS