### PR TITLE
Collect HTTP headers from AWS Lambda trigger events

### DIFF
--- a/instrumentation/instalambda/testdata/alb_event.json
+++ b/instrumentation/instalambda/testdata/alb_event.json
@@ -29,7 +29,11 @@
         "x-imforwards": "20",
         "X-Instana-T": "0000000000001234",
         "X-Instana-S": "0000000000004567",
-        "X-Instana-L": "1"
+        "X-Instana-L": "1",
+        "x-custom-header-1": "value1"
+    },
+    "multiValueHeaders": {
+        "x-custom-header-2": ["value2", "value3"]
     },
     "body": "",
     "isBase64Encoded": false

--- a/instrumentation/instalambda/testdata/apigw_event.json
+++ b/instrumentation/instalambda/testdata/apigw_event.json
@@ -19,7 +19,8 @@
         "X-Forwarded-Proto": "https",
         "X-Instana-T": "0000000000001234",
         "X-Instana-S": "0000000000004567",
-        "X-Instana-L": "1"
+        "X-Instana-L": "1",
+        "x-custom-header-1": "value1"
     },
     "multiValueHeaders": {
         "accept": [
@@ -63,6 +64,9 @@
         ],
         "X-Forwarded-Proto": [
             "https"
+        ],
+        "x-custom-header-2": [
+            "value2"
         ]
     },
     "queryStringParameters": {

--- a/instrumentation/instalambda/testdata/apigw_v2_event.json
+++ b/instrumentation/instalambda/testdata/apigw_v2_event.json
@@ -12,7 +12,9 @@
       "Header2": "value1,value2",
       "X-Instana-T": "0000000000001234",
       "X-Instana-S": "0000000000004567",
-      "X-Instana-L": "1"
+      "X-Instana-L": "1",
+      "X-Custom-Header-1": "value1",
+      "x-custom-header-2": "value2"
   },
   "queryStringParameters": {
       "secret": "key",


### PR DESCRIPTION
This PR updates Instana AWS Lambda instrumentation to collect and send HTTP headers listed in `INSTANA_EXTRA_HTTP_HEADERS` env variable.