### PR TITLE
Fix autoprofile linter issues

### DIFF
--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -14,6 +14,8 @@ import (
 // Ideally this type should've been defined in the same package with instana.agentS, however
 // due to the way we activate profiling, this would introduce a circular dependency.
 type Profile internal.AgentProfile
+
+// SendProfilesFunc is a function that submits profiles to the host agent
 type SendProfilesFunc func(profiles []Profile) error
 
 var (

--- a/autoprofile/internal/allocation_sampler.go
+++ b/autoprofile/internal/allocation_sampler.go
@@ -8,23 +8,24 @@ import (
 	profile "github.com/instana/go-sensor/autoprofile/internal/pprof/profile"
 )
 
+// AllocationSampler collects information about the number of memory allocations
 type AllocationSampler struct{}
 
+// NewAllocationSampler initializes a new allocation sampler
 func NewAllocationSampler() *AllocationSampler {
 	return &AllocationSampler{}
 }
 
-func (as *AllocationSampler) Reset() {
-}
+// Reset is a no-op for allocation sampler
+func (as *AllocationSampler) Reset() {}
 
-func (as *AllocationSampler) Start() error {
-	return nil
-}
+// Start is a no-op for allocation sampler
+func (as *AllocationSampler) Start() error { return nil }
 
-func (as *AllocationSampler) Stop() error {
-	return nil
-}
+// Stop is a no-op for allocation sampler
+func (as *AllocationSampler) Stop() error { return nil }
 
+// Profile retrieves the head profile and converts it to the profile.Profile
 func (as *AllocationSampler) Profile(duration int64, timespan int64) (*Profile, error) {
 	hp, err := as.readHeapProfile()
 	if err != nil {

--- a/autoprofile/internal/block_sampler.go
+++ b/autoprofile/internal/block_sampler.go
@@ -48,10 +48,13 @@ func (bs *BlockSampler) Start() error {
 }
 
 func (bs *BlockSampler) Stop() error {
-	p, err := bs.stopBlockSampler()
+	runtime.SetBlockProfileRate(0)
+
+	p, err := bs.collectProfile()
 	if err != nil {
 		return err
 	}
+
 	if p == nil {
 		return errors.New("no profile returned")
 	}
@@ -146,9 +149,7 @@ func (bs *BlockSampler) getValueChange(key string, delay float64, contentions in
 	}
 }
 
-func (bs *BlockSampler) stopBlockSampler() (*profile.Profile, error) {
-	runtime.SetBlockProfileRate(0)
-
+func (bs *BlockSampler) collectProfile() (*profile.Profile, error) {
 	var buf bytes.Buffer
 
 	w := bufio.NewWriter(&buf)

--- a/autoprofile/internal/block_sampler.go
+++ b/autoprofile/internal/block_sampler.go
@@ -37,10 +37,12 @@ func (bs *BlockSampler) Reset() {
 }
 
 func (bs *BlockSampler) Start() error {
-	err := bs.startBlockSampler()
-	if err != nil {
-		return err
+	bs.partialProfile = pprof.Lookup("block")
+	if bs.partialProfile == nil {
+		return errors.New("No block profile found")
 	}
+
+	runtime.SetBlockProfileRate(1e6)
 
 	return nil
 }
@@ -142,17 +144,6 @@ func (bs *BlockSampler) getValueChange(key string, delay float64, contentions in
 
 		return delay, contentions
 	}
-}
-
-func (bs *BlockSampler) startBlockSampler() error {
-	bs.partialProfile = pprof.Lookup("block")
-	if bs.partialProfile == nil {
-		return errors.New("No block profile found")
-	}
-
-	runtime.SetBlockProfileRate(1e6)
-
-	return nil
 }
 
 func (bs *BlockSampler) stopBlockSampler() (*profile.Profile, error) {

--- a/autoprofile/internal/block_sampler.go
+++ b/autoprofile/internal/block_sampler.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -150,17 +149,13 @@ func (bs *BlockSampler) getValueChange(key string, delay float64, contentions in
 }
 
 func (bs *BlockSampler) collectProfile() (*profile.Profile, error) {
-	var buf bytes.Buffer
+	buf := bytes.NewBuffer(nil)
 
-	w := bufio.NewWriter(&buf)
-	if err := bs.partialProfile.WriteTo(w, 0); err != nil {
+	if err := bs.partialProfile.WriteTo(buf, 0); err != nil {
 		return nil, err
 	}
 
-	w.Flush()
-
-	r := bufio.NewReader(&buf)
-	p, err := profile.Parse(r)
+	p, err := profile.Parse(buf)
 	if err != nil {
 		return nil, err
 	}

--- a/autoprofile/internal/cpu_sampler.go
+++ b/autoprofile/internal/cpu_sampler.go
@@ -9,20 +9,25 @@ import (
 	"github.com/instana/go-sensor/autoprofile/internal/pprof/profile"
 )
 
+// CPUSampler collects information about CPU usage
 type CPUSampler struct {
 	top       *CallSite
 	buf       *bytes.Buffer
 	startNano int64
 }
 
+// NewCPUSampler initializes a new CPI sampler
 func NewCPUSampler() *CPUSampler {
 	return &CPUSampler{}
 }
 
+// Reset resets the state of a CPUProfiler, starting a new call tree. It does not
+// terminate the profiling, so the gathered profile will make up a new call tree.
 func (cs *CPUSampler) Reset() {
 	cs.top = NewCallSite("", "", 0)
 }
 
+// Start enables the collection of CPU usage data
 func (cs *CPUSampler) Start() error {
 	if cs.buf != nil {
 		return nil
@@ -38,6 +43,7 @@ func (cs *CPUSampler) Start() error {
 	return nil
 }
 
+// Stop terminates the collection of CPU usage data and records the collected profile
 func (cs *CPUSampler) Stop() error {
 	if cs.buf == nil {
 		return nil
@@ -61,6 +67,7 @@ func (cs *CPUSampler) Stop() error {
 	return nil
 }
 
+// Profile returns the recorder profile
 func (cs *CPUSampler) Profile(duration int64, timespan int64) (*Profile, error) {
 	roots := make([]*CallSite, 0)
 	for _, child := range cs.top.children {

--- a/autoprofile/internal/cpu_sampler.go
+++ b/autoprofile/internal/cpu_sampler.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"runtime/pprof"
@@ -11,9 +10,9 @@ import (
 )
 
 type CPUSampler struct {
-	top        *CallSite
-	profBuffer *bytes.Buffer
-	startNano  int64
+	top       *CallSite
+	buf       *bytes.Buffer
+	startNano int64
 }
 
 func NewCPUSampler() *CPUSampler {
@@ -25,8 +24,14 @@ func (cs *CPUSampler) Reset() {
 }
 
 func (cs *CPUSampler) Start() error {
-	err := cs.startCPUSampler()
-	if err != nil {
+	if cs.buf != nil {
+		return nil
+	}
+
+	cs.buf = bytes.NewBuffer(nil)
+	cs.startNano = time.Now().UnixNano()
+
+	if err := pprof.StartCPUProfile(cs.buf); err != nil {
 		return err
 	}
 
@@ -34,10 +39,17 @@ func (cs *CPUSampler) Start() error {
 }
 
 func (cs *CPUSampler) Stop() error {
-	p, err := cs.stopCPUSampler()
+	if cs.buf == nil {
+		return nil
+	}
+
+	pprof.StopCPUProfile()
+
+	p, err := cs.collectProfile()
 	if err != nil {
 		return err
 	}
+
 	if p == nil {
 		return errors.New("no profile returned")
 	}
@@ -55,6 +67,7 @@ func (cs *CPUSampler) Profile(duration int64, timespan int64) (*Profile, error) 
 		roots = append(roots, child)
 	}
 	p := NewProfile(CategoryCPU, TypeCPUUsage, UnitMillisecond, roots, duration, timespan)
+
 	return p, nil
 }
 
@@ -96,47 +109,33 @@ func (cs *CPUSampler) updateCPUProfile(p *profile.Profile) error {
 	return nil
 }
 
-func (cs *CPUSampler) startCPUSampler() error {
-	cs.profBuffer = bytes.NewBuffer(nil)
-	cs.startNano = time.Now().UnixNano()
+func (cs *CPUSampler) collectProfile() (*profile.Profile, error) {
+	defer func() {
+		cs.buf = nil
+	}()
 
-	err := pprof.StartCPUProfile(cs.profBuffer)
+	p, err := profile.Parse(cs.buf)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
-}
-
-func (cs *CPUSampler) stopCPUSampler() (*profile.Profile, error) {
-	pprof.StopCPUProfile()
-
-	r := bufio.NewReader(cs.profBuffer)
-
-	if p, perr := profile.Parse(r); perr == nil {
-		cs.profBuffer = nil
-
-		if p.TimeNanos == 0 {
-			p.TimeNanos = cs.startNano
-		}
-		if p.DurationNanos == 0 {
-			p.DurationNanos = time.Now().UnixNano() - cs.startNano
-		}
-
-		if serr := symbolizeProfile(p); serr != nil {
-			return nil, serr
-		}
-
-		if verr := p.CheckValid(); verr != nil {
-			return nil, verr
-		}
-
-		return p, nil
-	} else {
-		cs.profBuffer = nil
-
-		return nil, perr
+	if p.TimeNanos == 0 {
+		p.TimeNanos = cs.startNano
 	}
+
+	if p.DurationNanos == 0 {
+		p.DurationNanos = time.Now().UnixNano() - cs.startNano
+	}
+
+	if err := symbolizeProfile(p); err != nil {
+		return nil, err
+	}
+
+	if err := p.CheckValid(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 func readFuncInfo(l *profile.Location) (funcName string, fileName string, fileLine int64) {

--- a/autoprofile/internal/flag.go
+++ b/autoprofile/internal/flag.go
@@ -2,26 +2,34 @@ package internal
 
 import "sync/atomic"
 
+// Flag is a boolean value that can be set and unset atomically
 type Flag struct {
 	value int32
 }
 
+// SetIfUnset sets the Flag to true if it's false and returns whether
+// the value has been changed
 func (f *Flag) SetIfUnset() bool {
 	return atomic.CompareAndSwapInt32(&f.value, 0, 1)
 }
 
+// UnsetIfSet sets the Flag to false if it's true and returns whether
+// the value has been changed
 func (f *Flag) UnsetIfSet() bool {
 	return atomic.CompareAndSwapInt32(&f.value, 1, 0)
 }
 
+// Set sets the Flag to true
 func (f *Flag) Set() {
 	atomic.StoreInt32(&f.value, 1)
 }
 
+// Unset sets the Flag to false
 func (f *Flag) Unset() {
 	atomic.StoreInt32(&f.value, 0)
 }
 
+// IsSet returns whether the Flag is set to true
 func (f *Flag) IsSet() bool {
 	return atomic.LoadInt32(&f.value) == 1
 }

--- a/autoprofile/internal/frame_filter.go
+++ b/autoprofile/internal/frame_filter.go
@@ -8,6 +8,8 @@ import (
 )
 
 var (
+	// IncludeProfilerFrames is a setting for the frame filter whether or not to include the profiler
+	// frames into the profile
 	IncludeProfilerFrames = false
 	autoprofilePath       = filepath.Join("github.com", "instana", "go-sensor", "autoprofile")
 )

--- a/autoprofile/internal/recorder.go
+++ b/autoprofile/internal/recorder.go
@@ -7,9 +7,8 @@ import (
 	"github.com/instana/go-sensor/autoprofile/internal/logger"
 )
 
-const (
-	DefaultMaxBufferedProfiles = 100
-)
+// DefaultMaxBufferedProfiles is the default number of profiles to keep in recorder buffer
+const DefaultMaxBufferedProfiles = 100
 
 // SendProfilesFunc is a callback to emit collected profiles from recorder
 type SendProfilesFunc func([]AgentProfile) error
@@ -24,6 +23,7 @@ func NoopSendProfiles([]AgentProfile) error {
 	return nil
 }
 
+// Recorder collects and stores recorded profiles
 type Recorder struct {
 	FlushInterval       int64
 	MaxBufferedProfiles int
@@ -37,6 +37,7 @@ type Recorder struct {
 	backoffSeconds     int64
 }
 
+// NewRecorder initializes and returns a new profile recorder
 func NewRecorder() *Recorder {
 	mq := &Recorder{
 		FlushInterval:       5,
@@ -50,6 +51,7 @@ func NewRecorder() *Recorder {
 	return mq
 }
 
+// Start initiates profile recorder flush loop
 func (pr *Recorder) Start() {
 	if !pr.started.SetIfUnset() {
 		return
@@ -60,6 +62,7 @@ func (pr *Recorder) Start() {
 	})
 }
 
+// Stop terminates profile recorder flush loop
 func (pr *Recorder) Stop() {
 	if !pr.started.UnsetIfSet() {
 		return
@@ -70,6 +73,7 @@ func (pr *Recorder) Stop() {
 	}
 }
 
+// Size returns the number of profiles enqueued for submission
 func (pr *Recorder) Size() int {
 	pr.queueLock.Lock()
 	defer pr.queueLock.Unlock()
@@ -77,6 +81,7 @@ func (pr *Recorder) Size() int {
 	return len(pr.queue)
 }
 
+// Record stores collected AgentProfile and enqueues it for submission
 func (pr *Recorder) Record(record AgentProfile) {
 	if pr.MaxBufferedProfiles < 1 {
 		return
@@ -92,6 +97,7 @@ func (pr *Recorder) Record(record AgentProfile) {
 	logger.Debug("Added record to the queue", record)
 }
 
+// Flush forces the recorder to submit collected profiles
 func (pr *Recorder) Flush() {
 	if pr.Size() == 0 {
 		return

--- a/autoprofile/internal/sampler_scheduler.go
+++ b/autoprofile/internal/sampler_scheduler.go
@@ -10,6 +10,7 @@ import (
 
 var samplerActive Flag
 
+// SamplerConfig holds profile sampler setting
 type SamplerConfig struct {
 	LogPrefix          string
 	ReportOnly         bool
@@ -20,6 +21,7 @@ type SamplerConfig struct {
 	ReportInterval     int64
 }
 
+// Sampler gathers continuous profile samples over a period of time
 type Sampler interface {
 	Profile(duration int64, timespan int64) (*Profile, error)
 	Start() error
@@ -27,6 +29,7 @@ type Sampler interface {
 	Reset()
 }
 
+// SamplerScheduler periodically runs the sampler for a time period
 type SamplerScheduler struct {
 	profileRecorder  *Recorder
 	sampler          Sampler
@@ -41,6 +44,7 @@ type SamplerScheduler struct {
 	samplerTimeout   *Timer
 }
 
+// NewSamplerScheduler initializes a new SamplerScheduler for a sampler
 func NewSamplerScheduler(profileRecorder *Recorder, samp Sampler, config SamplerConfig) *SamplerScheduler {
 	pr := &SamplerScheduler{
 		profileRecorder: profileRecorder,
@@ -52,6 +56,7 @@ func NewSamplerScheduler(profileRecorder *Recorder, samp Sampler, config Sampler
 	return pr
 }
 
+// Start runs the SampleScheduler
 func (ss *SamplerScheduler) Start() {
 	if !ss.started.SetIfUnset() {
 		return
@@ -74,6 +79,7 @@ func (ss *SamplerScheduler) Start() {
 	})
 }
 
+// Stop prevents the SamplerScheduler from running the sampler
 func (ss *SamplerScheduler) Stop() {
 	if !ss.started.UnsetIfSet() {
 		return
@@ -88,12 +94,14 @@ func (ss *SamplerScheduler) Stop() {
 	}
 }
 
+// Reset resets the sampler and clears the internal state of the scheduler
 func (ss *SamplerScheduler) Reset() {
 	ss.sampler.Reset()
 	ss.profileStart = time.Now().Unix()
 	ss.samplingDuration = 0
 }
 
+// Report retrieves the collected profile from the sampler and enqueues it for submission
 func (ss *SamplerScheduler) Report() {
 	if !ss.started.IsSet() {
 		return

--- a/autoprofile/internal/timer.go
+++ b/autoprofile/internal/timer.go
@@ -17,6 +17,7 @@ type Timer struct {
 	ticker     *time.Ticker
 }
 
+// NewTimer initializes a new Timer
 func NewTimer(delay, interval time.Duration, job func()) *Timer {
 	t := &Timer{
 		done: make(chan bool),

--- a/autoprofile/internal/uuid.go
+++ b/autoprofile/internal/uuid.go
@@ -16,6 +16,7 @@ var (
 	nextID     int64
 )
 
+// GenerateUUID generates a new UUID string
 func GenerateUUID() string {
 	n := atomic.AddInt64(&nextID, 1)
 


### PR DESCRIPTION
This PR addresses some of `golint`-discovered issues:

* Added missing godoc strings to the methods/contants/types exported by the `autoprofile` package
* Removed double-buffering when writing and reading inside of CPU and block samplers