### PR TITLE
Add 128-bit trace ID support

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -124,7 +124,8 @@ func newW3CForeignParent(trCtx w3ctrace.Context) *ForeignParent {
 
 // Span represents the OpenTracing span document to be sent to the agent
 type Span struct {
-	TraceID         int64          `json:"t"`
+	TraceID         int64          `json:"-"`
+	TraceID128      string         `json:"t"`
 	ParentID        int64          `json:"p,omitempty"`
 	SpanID          int64          `json:"s"`
 	Timestamp       uint64         `json:"ts"`
@@ -145,6 +146,7 @@ func newSpan(span *spanS) Span {
 	data := RegisteredSpanType(span.Operation).ExtractData(span)
 	sp := Span{
 		TraceID:         span.context.TraceID,
+		TraceID128:      FormatLongID(span.context.TraceIDHi, span.context.TraceID),
 		ParentID:        span.context.ParentID,
 		SpanID:          span.context.SpanID,
 		Timestamp:       uint64(span.Start.UnixNano()) / uint64(time.Millisecond),

--- a/propagation.go
+++ b/propagation.go
@@ -150,7 +150,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		return spanContext, nil
 	}
 
-	spanContext.TraceID, err = ParseID(traceID)
+	spanContext.TraceIDHi, spanContext.TraceID, err = ParseLongID(traceID)
 	if err != nil {
 		return spanContext, ot.ErrSpanContextCorrupted
 	}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -19,8 +19,9 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 	}{
 		"no trace context": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x1,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 				Baggage: map[string]string{
 					"foo": "bar",
 				},
@@ -41,8 +42,9 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 		},
 		"with instana trace": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x1,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 				Baggage: map[string]string{
 					"foo": "bar",
 				},
@@ -67,6 +69,7 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 		},
 		"with instana trace suppressed": {
 			SpanContext: instana.SpanContext{
+				TraceIDHi:  0x1,
 				TraceID:    0x2435,
 				SpanID:     0x3546,
 				Suppressed: true,
@@ -104,6 +107,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 	}{
 		"instana trace suppressed, no w3c trace": {
 			SpanContext: instana.SpanContext{
+				TraceIDHi:  0x01,
 				TraceID:    0x2435,
 				SpanID:     0x3546,
 				Suppressed: true,
@@ -119,8 +123,9 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		},
 		"instana trace suppressed, w3c trace not sampled": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x01,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -138,8 +143,9 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		},
 		"instana trace suppressed, w3c trace sampled": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x01,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -157,8 +163,9 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		},
 		"instana trace, no w3c trace": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x01,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 			},
 			Expected: http.Header{
 				"X-Instana-T":   {"2435"},
@@ -171,8 +178,9 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		},
 		"instana trace, w3c trace not sampled": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x01,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -189,8 +197,9 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		},
 		"instana trace, w3c trace": {
 			SpanContext: instana.SpanContext{
-				TraceID: 0x2435,
-				SpanID:  0x3546,
+				TraceIDHi: 0x01,
+				TraceID:   0x2435,
+				SpanID:    0x3546,
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -231,6 +240,7 @@ func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 	}
 
 	sc := instana.SpanContext{
+		TraceIDHi:  0x1,
 		TraceID:    0x2435,
 		SpanID:     0x3546,
 		Suppressed: true,
@@ -274,14 +284,15 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"tracing enabled": {
 			Headers: map[string]string{
 				"Authorization":   "Basic 123",
-				"x-instana-t":     "1314",
+				"x-instana-t":     "10000000000001314",
 				"X-INSTANA-S":     "2435",
 				"X-Instana-L":     "1",
 				"X-Instana-B-Foo": "bar",
 			},
 			Expected: instana.SpanContext{
-				TraceID: 0x1314,
-				SpanID:  0x2435,
+				TraceIDHi: 0x1,
+				TraceID:   0x1314,
+				SpanID:    0x2435,
 				Baggage: map[string]string{
 					"Foo": "bar",
 				},
@@ -290,11 +301,12 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"tracing disabled": {
 			Headers: map[string]string{
 				"Authorization": "Basic 123",
-				"x-instana-t":   "1314",
+				"x-instana-t":   "10000000000001314",
 				"X-INSTANA-S":   "2435",
 				"X-Instana-L":   "0",
 			},
 			Expected: instana.SpanContext{
+				TraceIDHi:  0x1,
 				TraceID:    0x1314,
 				SpanID:     0x2435,
 				Suppressed: true,
@@ -304,11 +316,12 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"tracing disabled, with correlation data": {
 			Headers: map[string]string{
 				"Authorization": "Basic 123",
-				"x-instana-t":   "1314",
+				"x-instana-t":   "10000000000001314",
 				"X-INSTANA-S":   "2435",
 				"X-Instana-L":   "0,correlationType=web;correlationId=1234",
 			},
 			Expected: instana.SpanContext{
+				TraceIDHi:  0x1,
 				TraceID:    0x1314,
 				SpanID:     0x2435,
 				Suppressed: true,
@@ -317,34 +330,36 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		},
 		"w3c trace context, last vendor is instana": {
 			Headers: map[string]string{
-				"x-instana-t": "1314",
+				"x-instana-t": "10000000000001314",
 				"X-INSTANA-S": "2435",
 				"X-Instana-L": "1",
 				"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000002435-01",
-				"tracestate":  "in=1314;2435,rojo=00f067aa0ba902b7",
+				"tracestate":  "in=10000000000001314;2435,rojo=00f067aa0ba902b7",
 			},
 			Expected: instana.SpanContext{
-				TraceID: 0x1314,
-				SpanID:  0x2435,
-				Baggage: map[string]string{},
+				TraceIDHi: 0x1,
+				TraceID:   0x1314,
+				SpanID:    0x2435,
+				Baggage:   map[string]string{},
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000002435-01",
-					RawState:  "in=1314;2435,rojo=00f067aa0ba902b7",
+					RawState:  "in=10000000000001314;2435,rojo=00f067aa0ba902b7",
 				},
 			},
 		},
 		"w3c trace context, last vendor not instana": {
 			Headers: map[string]string{
-				"x-instana-t": "1314",
+				"x-instana-t": "10000000000001314",
 				"X-INSTANA-S": "2435",
 				"X-Instana-L": "1",
 				"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 				"tracestate":  "rojo=00f067aa0ba902b7",
 			},
 			Expected: instana.SpanContext{
-				TraceID: 0x1314,
-				SpanID:  0x2435,
-				Baggage: map[string]string{},
+				TraceIDHi: 0x1,
+				TraceID:   0x1314,
+				SpanID:    0x2435,
+				Baggage:   map[string]string{},
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					RawState:  "rojo=00f067aa0ba902b7",
@@ -354,13 +369,13 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"w3c trace context, no instana headers": {
 			Headers: map[string]string{
 				"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-				"tracestate":  "in=1314;2435,rojo=00f067aa0ba902b7",
+				"tracestate":  "in=10000000000001314;2435,rojo=00f067aa0ba902b7",
 			},
 			Expected: instana.SpanContext{
 				Baggage: map[string]string{},
 				W3CContext: w3ctrace.Context{
 					RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-					RawState:  "in=1314;2435,rojo=00f067aa0ba902b7",
+					RawState:  "in=10000000000001314;2435,rojo=00f067aa0ba902b7",
 				},
 			},
 		},
@@ -492,8 +507,9 @@ func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
 	sc := instana.SpanContext{
-		TraceID: 0x2435,
-		SpanID:  0x3546,
+		TraceIDHi: 0x1,
+		TraceID:   0x2435,
+		SpanID:    0x3546,
 		Baggage: map[string]string{
 			"foo": "bar",
 		},
@@ -519,8 +535,9 @@ func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
 	sc := instana.SpanContext{
-		TraceID: 0x2435,
-		SpanID:  0x3546,
+		TraceIDHi: 0x1,
+		TraceID:   0x2435,
+		SpanID:    0x3546,
 		Baggage: map[string]string{
 			"foo": "bar",
 		},
@@ -550,6 +567,7 @@ func TestTracer_Inject_TextMap_SuppressedTracing(t *testing.T) {
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
 	sc := instana.SpanContext{
+		TraceIDHi:  0x1,
 		TraceID:    0x2435,
 		SpanID:     0x3546,
 		Suppressed: true,
@@ -580,14 +598,15 @@ func TestTracer_Extract_TextMap(t *testing.T) {
 		"tracing enabled": {
 			Carrier: map[string]string{
 				"Authorization":   "Basic 123",
-				"x-instana-t":     "1314",
+				"x-instana-t":     "10000000000001314",
 				"X-INSTANA-S":     "2435",
 				"X-Instana-L":     "1",
 				"X-Instana-B-Foo": "bar",
 			},
 			Expected: instana.SpanContext{
-				TraceID: 0x1314,
-				SpanID:  0x2435,
+				TraceIDHi: 0x1,
+				TraceID:   0x1314,
+				SpanID:    0x2435,
 				Baggage: map[string]string{
 					"Foo": "bar",
 				},
@@ -596,11 +615,12 @@ func TestTracer_Extract_TextMap(t *testing.T) {
 		"tracing disabled": {
 			Carrier: map[string]string{
 				"Authorization": "Basic 123",
-				"x-instana-t":   "1314",
+				"x-instana-t":   "10000000000001314",
 				"X-INSTANA-S":   "2435",
 				"X-Instana-L":   "0",
 			},
 			Expected: instana.SpanContext{
+				TraceIDHi:  0x1,
 				TraceID:    0x1314,
 				SpanID:     0x2435,
 				Suppressed: true,

--- a/span_context.go
+++ b/span_context.go
@@ -96,7 +96,7 @@ func (c *SpanContext) restoreFromForeignTraceContext(trCtx w3ctrace.Context) boo
 		return true
 	}
 
-	traceID, err := ParseID(vd[:i])
+	traceIDHi, traceIDLo, err := ParseLongID(vd[:i])
 	if err != nil {
 		return true
 	}
@@ -106,7 +106,7 @@ func (c *SpanContext) restoreFromForeignTraceContext(trCtx w3ctrace.Context) boo
 		return true
 	}
 
-	c.TraceID, c.SpanID = traceID, spanID
+	c.TraceIDHi, c.TraceID, c.SpanID = traceIDHi, traceIDLo, spanID
 
 	return true
 }

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestNewRootSpanContext(t *testing.T) {
 	c := instana.NewRootSpanContext()
+
 	assert.NotEmpty(t, c.TraceID)
 	assert.Equal(t, c.SpanID, c.TraceID)
 	assert.False(t, c.Sampled)
@@ -21,6 +22,7 @@ func TestNewRootSpanContext(t *testing.T) {
 func TestNewSpanContext(t *testing.T) {
 	examples := map[string]instana.SpanContext{
 		"no w3c trace": {
+			TraceIDHi:  10,
 			TraceID:    1,
 			SpanID:     2,
 			ParentID:   3,
@@ -32,24 +34,27 @@ func TestNewSpanContext(t *testing.T) {
 			},
 		},
 		"with w3c trace, no instana state": {
-			TraceID: 1,
-			SpanID:  2,
+			TraceIDHi: 10,
+			TraceID:   1,
+			SpanID:    2,
 			W3CContext: w3ctrace.Context{
 				RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 				RawState:  "vendor1=data",
 			},
 		},
 		"with w3c trace, last state from instana": {
-			TraceID: 1,
-			SpanID:  2,
+			TraceIDHi: 10,
+			TraceID:   1,
+			SpanID:    2,
 			W3CContext: w3ctrace.Context{
 				RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 				RawState:  "in=1234;5678,vendor1=data",
 			},
 		},
 		"with correlation data": {
-			TraceID: 1,
-			SpanID:  2,
+			TraceIDHi: 10,
+			TraceID:   1,
+			SpanID:    2,
 			Correlation: instana.EUMCorrelationData{
 				Type: "web",
 				ID:   "1",
@@ -60,6 +65,8 @@ func TestNewSpanContext(t *testing.T) {
 	for name, parent := range examples {
 		t.Run(name, func(t *testing.T) {
 			c := instana.NewSpanContext(parent)
+
+			assert.Equal(t, parent.TraceIDHi, c.TraceIDHi)
 			assert.Equal(t, parent.TraceID, c.TraceID)
 			assert.Equal(t, parent.SpanID, c.ParentID)
 			assert.Equal(t, parent.Sampled, c.Sampled)
@@ -78,6 +85,7 @@ func TestNewSpanContext(t *testing.T) {
 
 func TestNewSpanContext_EmptyParent(t *testing.T) {
 	c := instana.NewSpanContext(instana.SpanContext{})
+
 	assert.NotEmpty(t, c.TraceID)
 	assert.Equal(t, c.SpanID, c.TraceID)
 	assert.False(t, c.Sampled)
@@ -134,10 +142,11 @@ func TestNewSpanContext_ForeignParent(t *testing.T) {
 
 func TestSpanContext_WithBaggageItem(t *testing.T) {
 	c := instana.SpanContext{
-		TraceID:  1,
-		SpanID:   2,
-		ParentID: 3,
-		Sampled:  true,
+		TraceIDHi: 10,
+		TraceID:   1,
+		SpanID:    2,
+		ParentID:  3,
+		Sampled:   true,
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
@@ -146,10 +155,11 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 
 	updated := c.WithBaggageItem("key3", "value3")
 	assert.Equal(t, instana.SpanContext{
-		TraceID:  1,
-		SpanID:   2,
-		ParentID: 3,
-		Sampled:  true,
+		TraceIDHi: 10,
+		TraceID:   1,
+		SpanID:    2,
+		ParentID:  3,
+		Sampled:   true,
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
@@ -158,10 +168,11 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 	}, updated)
 
 	assert.Equal(t, instana.SpanContext{
-		TraceID:  1,
-		SpanID:   2,
-		ParentID: 3,
-		Sampled:  true,
+		TraceIDHi: 10,
+		TraceID:   1,
+		SpanID:    2,
+		ParentID:  3,
+		Sampled:   true,
 		Baggage: map[string]string{
 			"key1": "value1",
 			"key2": "value2",
@@ -171,6 +182,7 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 
 func TestSpanContext_Clone(t *testing.T) {
 	c := instana.SpanContext{
+		TraceIDHi:     10,
 		TraceID:       1,
 		SpanID:        2,
 		ParentID:      3,
@@ -195,10 +207,11 @@ func TestSpanContext_Clone(t *testing.T) {
 
 func TestSpanContext_Clone_NoBaggage(t *testing.T) {
 	c := instana.SpanContext{
-		TraceID:  1,
-		SpanID:   2,
-		ParentID: 3,
-		Sampled:  true,
+		TraceIDHi: 10,
+		TraceID:   1,
+		SpanID:    2,
+		ParentID:  3,
+		Sampled:   true,
 	}
 
 	cloned := c.Clone()

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -102,6 +102,61 @@ func TestIDConversion(t *testing.T) {
 	}
 }
 
+func TestParseLongID(t *testing.T) {
+	examples := map[string]struct {
+		Value                  string
+		ExpectedHi, ExpectedLo int64
+	}{
+		"64-bit short":             {"1234ab", 0x0, 0x1234ab},
+		"64-bit padded":            {"00000000001234ab", 0x0, 0x1234ab},
+		"64-bit padded to 128-bit": {"000000000000000000000000001234ab", 0x0, 0x1234ab},
+		"128-bit short":            {"1c00000000001234ab", 0x1c, 0x1234ab},
+		"128-bit padded":           {"000000000000001c00000000001234ab", 0x1c, 0x1234ab},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			hi, lo, err := ParseLongID(example.Value)
+			require.NoError(t, err)
+
+			assert.Equal(t, example.ExpectedHi, hi)
+			assert.Equal(t, example.ExpectedLo, lo)
+		})
+	}
+}
+
+func TestFormatLongID(t *testing.T) {
+	examples := map[string]struct {
+		Hi, Lo   int64
+		Expected string
+	}{
+		"64-bit":  {0x0, 0x1234ab, "1234ab"},
+		"128-bit": {0x1c, 0x1234ab, "1c00000000001234ab"},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, example.Expected, FormatLongID(example.Hi, example.Lo))
+		})
+	}
+}
+
+func TestParseFormatLongID(t *testing.T) {
+	examples := map[string]string{
+		"64-bit":  "1234abcd1234abcd",
+		"128-bit": "5678defa5678defa1234abcd1234abcd",
+	}
+
+	for name, id := range examples {
+		t.Run(name, func(t *testing.T) {
+			hi, lo, err := ParseLongID(id)
+			require.NoError(t, err)
+
+			assert.Equal(t, id, FormatLongID(hi, lo))
+		})
+	}
+}
+
 func TestBogusValues(t *testing.T) {
 	var id int64
 


### PR DESCRIPTION
This PR updates the Go sensor to accept 128-bit trace IDs sent by the upstream. The high 64 bits are not sent downstream  to ensure compatibility with the older versions of Instana sensors.