### PR TITLE
Send trace and span IDs as strings of fixed length

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -31,13 +31,13 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 			},
 			Expected: http.Header{
 				"Authorization":   {"Basic 123"},
-				"X-Instana-T":     {"2435"},
-				"X-Instana-S":     {"3546"},
+				"X-Instana-T":     {"0000000000002435"},
+				"X-Instana-S":     {"0000000000003546"},
 				"X-Instana-L":     {"1"},
 				"X-Instana-B-Foo": {"bar"},
 				"Traceparent":     {"00-00000000000000000000000000002435-0000000000003546-01"},
-				"Tracestate":      {"in=2435;3546"},
-				"Server-Timing":   {"intid;desc=2435"},
+				"Tracestate":      {"in=0000000000002435;0000000000003546"},
+				"Server-Timing":   {"intid;desc=0000000000002435"},
 			},
 		},
 		"with instana trace": {
@@ -51,20 +51,20 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 			},
 			Headers: http.Header{
 				"Authorization":   {"Basic 123"},
-				"x-instana-t":     {"1314"},
-				"X-INSTANA-S":     {"1314"},
+				"x-instana-t":     {"0000000000001314"},
+				"X-INSTANA-S":     {"0000000000001314"},
 				"X-Instana-L":     {"1"},
 				"X-Instana-B-foo": {"hello"},
 			},
 			Expected: http.Header{
 				"Authorization":   {"Basic 123"},
-				"X-Instana-T":     {"2435"},
-				"X-Instana-S":     {"3546"},
+				"X-Instana-T":     {"0000000000002435"},
+				"X-Instana-S":     {"0000000000003546"},
 				"X-Instana-L":     {"1"},
 				"X-Instana-B-Foo": {"bar"},
 				"Traceparent":     {"00-00000000000000000000000000002435-0000000000003546-01"},
-				"Tracestate":      {"in=2435;3546"},
-				"Server-Timing":   {"intid;desc=2435"},
+				"Tracestate":      {"in=0000000000002435;0000000000003546"},
+				"Server-Timing":   {"intid;desc=0000000000002435"},
 			},
 		},
 		"with instana trace suppressed": {
@@ -79,12 +79,12 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 			},
 			Expected: http.Header{
 				"Authorization": {"Basic 123"},
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"0"},
 				"Traceparent":   {"00-00000000000000000000000000002435-0000000000003546-00"},
 				"Tracestate":    {""},
-				"Server-Timing": {"intid;desc=2435"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 	}
@@ -113,12 +113,12 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 				Suppressed: true,
 			},
 			Expected: http.Header{
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"0"},
 				"Traceparent":   {"00-00000000000000000000000000002435-0000000000003546-00"},
 				"Tracestate":    {""},
-				"Server-Timing": {"intid;desc=2435"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 		"instana trace suppressed, w3c trace not sampled": {
@@ -133,12 +133,12 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 				Suppressed: true,
 			},
 			Expected: http.Header{
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"0"},
 				"Traceparent":   {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"},
 				"Tracestate":    {"rojo=00f067aa0ba902b7"},
-				"Server-Timing": {"intid;desc=2435"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 		"instana trace suppressed, w3c trace sampled": {
@@ -153,12 +153,12 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 				Suppressed: true,
 			},
 			Expected: http.Header{
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"0"},
 				"Traceparent":   {"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000003546-00"},
 				"Tracestate":    {"rojo=00f067aa0ba902b7"},
-				"Server-Timing": {"intid;desc=2435"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 		"instana trace, no w3c trace": {
@@ -168,12 +168,12 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 				SpanID:    0x3546,
 			},
 			Expected: http.Header{
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"1"},
 				"Traceparent":   {"00-00000000000000000000000000002435-0000000000003546-01"},
-				"Tracestate":    {"in=2435;3546"},
-				"Server-Timing": {"intid;desc=2435"},
+				"Tracestate":    {"in=0000000000002435;0000000000003546"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 		"instana trace, w3c trace not sampled": {
@@ -187,12 +187,12 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 				},
 			},
 			Expected: http.Header{
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"1"},
 				"Traceparent":   {"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000003546-01"},
-				"Tracestate":    {"in=2435;3546,rojo=00f067aa0ba902b7"},
-				"Server-Timing": {"intid;desc=2435"},
+				"Tracestate":    {"in=0000000000002435;0000000000003546,rojo=00f067aa0ba902b7"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 		"instana trace, w3c trace": {
@@ -206,12 +206,12 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 				},
 			},
 			Expected: http.Header{
-				"X-Instana-T":   {"2435"},
-				"X-Instana-S":   {"3546"},
+				"X-Instana-T":   {"0000000000002435"},
+				"X-Instana-S":   {"0000000000003546"},
 				"X-Instana-L":   {"1"},
 				"Traceparent":   {"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000003546-01"},
-				"Tracestate":    {"in=2435;3546,rojo=00f067aa0ba902b7"},
-				"Server-Timing": {"intid;desc=2435"},
+				"Tracestate":    {"in=0000000000002435;0000000000003546,rojo=00f067aa0ba902b7"},
+				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
 	}
@@ -234,8 +234,8 @@ func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 
 	headers := http.Header{
 		"Authorization": {"Basic 123"},
-		"x-instana-t":   {"1314"},
-		"X-INSTANA-S":   {"1314"},
+		"x-instana-t":   {"0000000000001314"},
+		"X-INSTANA-S":   {"0000000000001314"},
 		"X-Instana-L":   {"1"},
 	}
 
@@ -248,11 +248,11 @@ func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 
 	require.NoError(t, tracer.Inject(sc, ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
 
-	assert.Equal(t, "2435", headers.Get("X-Instana-T"))
-	assert.Equal(t, "3546", headers.Get("X-Instana-S"))
+	assert.Equal(t, "0000000000002435", headers.Get("X-Instana-T"))
+	assert.Equal(t, "0000000000003546", headers.Get("X-Instana-S"))
 	assert.Equal(t, "0", headers.Get("X-Instana-L"))
 	assert.Equal(t, "Basic 123", headers.Get("Authorization"))
-	assert.Equal(t, "intid;desc=2435", headers.Get("Server-Timing"))
+	assert.Equal(t, "intid;desc=0000000000002435", headers.Get("Server-Timing"))
 }
 
 func TestTracer_Inject_HTTPHeaders_WithExistingServerTiming(t *testing.T) {
@@ -260,8 +260,8 @@ func TestTracer_Inject_HTTPHeaders_WithExistingServerTiming(t *testing.T) {
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
 	headers := http.Header{
-		"x-instana-t":   {"1314"},
-		"X-INSTANA-S":   {"1314"},
+		"x-instana-t":   {"0000000000001314"},
+		"X-INSTANA-S":   {"0000000000001314"},
 		"X-Instana-L":   {"1"},
 		"Server-Timing": {"db;dur=53, app;dur=47.2", `cache;desc="Cache Read";dur=23.2`},
 	}
@@ -273,7 +273,7 @@ func TestTracer_Inject_HTTPHeaders_WithExistingServerTiming(t *testing.T) {
 	}
 
 	require.NoError(t, tracer.Inject(sc, ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
-	assert.Equal(t, `db;dur=53, app;dur=47.2, cache;desc="Cache Read";dur=23.2, intid;desc=2435`, headers.Get("Server-Timing"))
+	assert.Equal(t, `db;dur=53, app;dur=47.2, cache;desc="Cache Read";dur=23.2, intid;desc=0000000000002435`, headers.Get("Server-Timing"))
 }
 
 func TestTracer_Extract_HTTPHeaders(t *testing.T) {
@@ -284,8 +284,8 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"tracing enabled": {
 			Headers: map[string]string{
 				"Authorization":   "Basic 123",
-				"x-instana-t":     "10000000000001314",
-				"X-INSTANA-S":     "2435",
+				"x-instana-t":     "0000000000000000000000010000000000001314",
+				"X-INSTANA-S":     "0000000000002435",
 				"X-Instana-L":     "1",
 				"X-Instana-B-Foo": "bar",
 			},
@@ -301,8 +301,8 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		"tracing disabled": {
 			Headers: map[string]string{
 				"Authorization": "Basic 123",
-				"x-instana-t":   "10000000000001314",
-				"X-INSTANA-S":   "2435",
+				"x-instana-t":   "0000000000000000000000010000000000001314",
+				"X-INSTANA-S":   "0000000000002435",
 				"X-Instana-L":   "0",
 			},
 			Expected: instana.SpanContext{
@@ -522,8 +522,8 @@ func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
 	require.NoError(t, tracer.Inject(sc, ot.TextMap, ot.TextMapCarrier(carrier)))
 
 	assert.Equal(t, map[string]string{
-		"x-instana-t":     "2435",
-		"x-instana-s":     "3546",
+		"x-instana-t":     "0000000000002435",
+		"x-instana-s":     "0000000000003546",
 		"x-instana-l":     "1",
 		"x-instana-b-foo": "bar",
 		"key1":            "value1",
@@ -545,8 +545,8 @@ func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 
 	carrier := map[string]string{
 		"key1":            "value1",
-		"x-instana-t":     "1314",
-		"X-INSTANA-S":     "1314",
+		"x-instana-t":     "0000000000001314",
+		"X-INSTANA-S":     "0000000000001314",
 		"X-Instana-L":     "1",
 		"X-INSTANA-b-foo": "hello",
 	}
@@ -554,8 +554,8 @@ func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 	require.NoError(t, tracer.Inject(sc, ot.TextMap, ot.TextMapCarrier(carrier)))
 
 	assert.Equal(t, map[string]string{
-		"x-instana-t":     "2435",
-		"X-INSTANA-S":     "3546",
+		"x-instana-t":     "0000000000002435",
+		"X-INSTANA-S":     "0000000000003546",
 		"X-Instana-L":     "1",
 		"X-INSTANA-b-foo": "bar",
 		"key1":            "value1",
@@ -575,16 +575,16 @@ func TestTracer_Inject_TextMap_SuppressedTracing(t *testing.T) {
 
 	carrier := map[string]string{
 		"key1":        "value1",
-		"x-instana-t": "1314",
-		"X-INSTANA-S": "1314",
+		"x-instana-t": "0000000000001314",
+		"X-INSTANA-S": "0000000000001314",
 		"X-Instana-L": "1",
 	}
 
 	require.NoError(t, tracer.Inject(sc, ot.TextMap, ot.TextMapCarrier(carrier)))
 
 	assert.Equal(t, map[string]string{
-		"x-instana-t": "2435",
-		"X-INSTANA-S": "3546",
+		"x-instana-t": "0000000000002435",
+		"X-INSTANA-S": "0000000000003546",
 		"X-Instana-L": "0",
 		"key1":        "value1",
 	}, carrier)

--- a/util.go
+++ b/util.go
@@ -29,6 +29,7 @@ func randomID() int64 {
 // FormatID converts an Instana ID to a value that can be used in
 // context propagation (such as HTTP headers). More specifically,
 // this converts a signed 64 bit integer into an unsigned hex string.
+// The resulting string is always padded with 0 to be 16 characters long.
 func FormatID(id int64) string {
 	// FIXME: We're assuming LittleEndian here
 
@@ -43,17 +44,18 @@ func FormatID(id int64) string {
 	binary.Read(buf, binary.LittleEndian, &unsigned)
 
 	// Convert uint64 to hex string equivalent and return that
-	return strconv.FormatUint(unsigned, 16)
+	return padHexString(strconv.FormatUint(unsigned, 16), 64)
 }
 
 // FormatLongID converts a 128-bit Instana ID passed in two quad words to an
 // unsigned hex string suitable for context propagation.
 func FormatLongID(hi, lo int64) string {
+	loStr := FormatID(lo)
 	if hi == 0 {
-		return FormatID(lo)
+		return loStr
 	}
 
-	return FormatID(hi) + padHexString(FormatID(lo), 64)
+	return FormatID(hi) + loStr
 }
 
 func padHexString(s string, bitSize int) string {

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -49,59 +49,6 @@ func TestFormatID(t *testing.T) {
 	assert.Equal(t, minHex, header)
 }
 
-func TestIDConversion(t *testing.T) {
-	// Place holders
-	var header string
-	var id int64
-
-	header = FormatID(-7815363404733516491)
-	assert.Equal(t, "938a406416457535", header, "FormatID incorrect result.")
-
-	id, err := ParseID("938a406416457535")
-	require.NoError(t, err)
-	assert.Equal(t, int64(-7815363404733516491), id, "ParseID incorrect result")
-
-	header = FormatID(307170163380978816)
-	assert.Equal(t, "44349a2d9ec0480", header, "FormatID incorrect result.")
-
-	id, err = ParseID("44349a2d9ec0480") // Without a leading zero
-	require.NoError(t, err)
-	assert.Equal(t, int64(307170163380978816), id, "ParseID incorrect result")
-
-	id, err = ParseID("044349a2d9ec0480") // Try with a leading zero
-	require.NoError(t, err)
-	assert.Equal(t, int64(307170163380978816), id, "ParseID incorrect result")
-
-	header = FormatID(2920004540187184976)
-	assert.Equal(t, "2885f0a890628f50", header, "FormatID incorrect result.")
-
-	id, err = ParseID("2885f0a890628f50")
-	require.NoError(t, err)
-	assert.Equal(t, int64(2920004540187184976), id, "ParseID incorrect result")
-
-	header = FormatID(16)
-	assert.Equal(t, "10", header, "FormatID should drop leading zeros")
-
-	id, err = ParseID("0000000000000010")
-	require.NoError(t, err)
-	assert.Equal(t, int64(16), id, "ParseID should stll work with leading zeros")
-
-	id, err = ParseID("10")
-	require.NoError(t, err)
-	assert.Equal(t, int64(16), id, "ParseID should convert <16 char strings")
-
-	count := 10000
-	for index := 0; index < count; index++ {
-		generatedID := randomID()
-
-		header := FormatID(generatedID)
-
-		id, err := ParseID(header)
-		require.NoError(t, err)
-		assert.Equal(t, generatedID, id, "Original ID does not match converted back ID")
-	}
-}
-
 func TestParseLongID(t *testing.T) {
 	examples := map[string]struct {
 		Value                  string
@@ -130,8 +77,8 @@ func TestFormatLongID(t *testing.T) {
 		Hi, Lo   int64
 		Expected string
 	}{
-		"64-bit":  {0x0, 0x1234ab, "1234ab"},
-		"128-bit": {0x1c, 0x1234ab, "1c00000000001234ab"},
+		"64-bit":  {0x0, 0x1234ab, "00000000001234ab"},
+		"128-bit": {0x1c, 0x1234ab, "000000000000001c00000000001234ab"},
 	}
 
 	for name, example := range examples {


### PR DESCRIPTION
Trace and span IDs are hex strings representing 64-bit integer values. To make it easier to differentiate between the upcoming 128-bit identifiers and 64-bit ones the hex representation needs to be aligned to either 16 or 32 characters by left padding it with zeroes.