### PR TITLE
Always send trace IDs as strings

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -144,19 +144,13 @@ func (agent *agentS) SendEvent(event *EventData) error {
 	return nil
 }
 
-type agentSpan struct {
-	Span
-	From *fromS `json:"f"` // override the `f` fields with agent-specific type
-}
-
 // SendSpans sends collected spans to the host agent
 func (agent *agentS) SendSpans(spans []Span) error {
-	agentSpans := make([]agentSpan, 0, len(spans))
-	for _, sp := range spans {
-		agentSpans = append(agentSpans, agentSpan{sp, agent.from})
+	for i := range spans {
+		spans[i].From = agent.from
 	}
 
-	_, err := agent.request(agent.makeURL(agentTracesURL), "POST", agentSpans)
+	_, err := agent.request(agent.makeURL(agentTracesURL), "POST", spans)
 	if err != nil {
 		agent.logger.Error("failed to send spans to the host agent: ", err)
 		agent.reset()

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -143,7 +143,7 @@ type fargateAgent struct {
 	lastProcessStats processStats
 
 	mu        sync.Mutex
-	spanQueue []agentSpan
+	spanQueue []Span
 
 	runtimeSnapshot *SnapshotCollector
 	dockerStats     *ecsDockerStatsCollector
@@ -231,7 +231,7 @@ func (a *fargateAgent) SendMetrics(data acceptor.Metrics) (err error) {
 
 	payload := struct {
 		Metrics metricsPayload `json:"metrics,omitempty"`
-		Spans   []agentSpan    `json:"spans,omitempty"`
+		Spans   []Span         `json:"spans,omitempty"`
 	}{
 		Metrics: metricsPayload{
 			Plugins: []acceptor.PluginPayload{
@@ -262,7 +262,7 @@ func (a *fargateAgent) SendMetrics(data acceptor.Metrics) (err error) {
 
 	a.mu.Lock()
 	if len(a.spanQueue) > 0 {
-		payload.Spans = make([]agentSpan, len(a.spanQueue))
+		payload.Spans = make([]Span, len(a.spanQueue))
 		copy(payload.Spans, a.spanQueue)
 		a.spanQueue = a.spanQueue[:0]
 	}
@@ -287,15 +287,13 @@ func (a *fargateAgent) SendEvent(event *EventData) error { return nil }
 
 func (a *fargateAgent) SendSpans(spans []Span) error {
 	from := newServerlessAgentFromS(a.snapshot.Service.EntityID, "aws")
-
-	agentSpans := make([]agentSpan, 0, len(spans))
-	for _, sp := range spans {
-		agentSpans = append(agentSpans, agentSpan{sp, from})
+	for i := range spans {
+		spans[i].From = from
 	}
 
 	// enqueue the spans to send them in a bundle with metrics instead of sending immediately
 	a.mu.Lock()
-	a.spanQueue = append(a.spanQueue, agentSpans...)
+	a.spanQueue = append(a.spanQueue, spans...)
 	a.mu.Unlock()
 
 	return nil


### PR DESCRIPTION
This PR unifies the way trace context IDs are being sent. The span and trace IDs as well as `X-Instana-{T,S}` header values and corresponding values within the `Server-Timing` and `tracestate` headers are now sent as zero-padded 16-character strings.