### PR TITLE
Support 128-bit trace IDs in AWS Lambda

### DIFF
--- a/instrumentation/instalambda/go.mod
+++ b/instrumentation/instalambda/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/aws/aws-lambda-go v1.20.0
-	github.com/instana/go-sensor v1.23.0
+	github.com/instana/go-sensor v1.24.0
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/opentracing/opentracing-go v1.1.0
 )

--- a/instrumentation/instalambda/go.sum
+++ b/instrumentation/instalambda/go.sum
@@ -6,8 +6,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/instana/go-sensor v1.23.0 h1:04pGhHXj03hZwIFf1t1JuXfs0Mm0c1E4W16a2LQ66c8=
-github.com/instana/go-sensor v1.23.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
+github.com/instana/go-sensor v1.24.0 h1:l7nbiP5dNetEJzyAVsoNkvx6Qog0Unlj73SLvJy44QA=
+github.com/instana/go-sensor v1.24.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65 h1:T25FL3WEzgmKB0m6XCJNZ65nw09/QIp3T1yXr487D+A=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65/go.mod h1:nYhEREG/B7HUY7P+LKOrqy53TpIqmJ9JyUShcaEKtGw=
 github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=


### PR DESCRIPTION
Support for incoming 128-bit trace IDs has been added in `github.com/instana/go-sensor@v1.24.0`.