### PR TITLE
Add support 128-bit trace IDs to instrumented to GCP Pub/Sub and Storage clients

### DIFF
--- a/instrumentation/cloud.google.com/go/go.mod
+++ b/instrumentation/cloud.google.com/go/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/storage v1.7.0
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.1 // indirect
-	github.com/instana/go-sensor v1.22.0
+	github.com/instana/go-sensor v1.24.0
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/opentracing/opentracing-go v1.2.0
 	go.opencensus.io v0.22.4 // indirect

--- a/instrumentation/cloud.google.com/go/go.sum
+++ b/instrumentation/cloud.google.com/go/go.sum
@@ -107,6 +107,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/instana/go-sensor v1.22.0 h1:GxmiLBHNqnKigYq/S5zQ6/R8iUcTVYmKZzjPS+vkhDs=
 github.com/instana/go-sensor v1.22.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
+github.com/instana/go-sensor v1.24.0 h1:l7nbiP5dNetEJzyAVsoNkvx6Qog0Unlj73SLvJy44QA=
+github.com/instana/go-sensor v1.24.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65 h1:T25FL3WEzgmKB0m6XCJNZ65nw09/QIp3T1yXr487D+A=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65/go.mod h1:nYhEREG/B7HUY7P+LKOrqy53TpIqmJ9JyUShcaEKtGw=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
Support for incoming 128-bit trace IDs has been added in `github.com/instana/go-sensor@v1.24.0`.