### PR TITLE
Send tracer version

### DIFF
--- a/acceptor/runtime.go
+++ b/acceptor/runtime.go
@@ -4,12 +4,13 @@ import "strconv"
 
 // RuntimeInfo represents Go runtime info to be sent to com.insana.plugin.golang
 type RuntimeInfo struct {
-	Name     string `json:"name"`
-	Version  string `json:"version"`
-	Root     string `json:"goroot"`
-	MaxProcs int    `json:"maxprocs"`
-	Compiler string `json:"compiler"`
-	NumCPU   int    `json:"cpu"`
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	Root          string `json:"goroot"`
+	MaxProcs      int    `json:"maxprocs"`
+	Compiler      string `json:"compiler"`
+	NumCPU        int    `json:"cpu"`
+	SensorVersion string `json:"iv,omitempty"`
 }
 
 // MemoryStats represents Go runtime memory stats to be sent to com.insana.plugin.golang

--- a/sensor.go
+++ b/sensor.go
@@ -151,7 +151,7 @@ func InitSensor(options *Options) {
 		autoprofile.Enable()
 	}
 
-	sensor.logger.Debug("initialized sensor")
+	sensor.logger.Debug("initialized Instana sensor v", Version)
 }
 
 func newServerlessAgent(serviceName, agentEndpoint, agentKey string, client *http.Client, logger LeveledLogger) agentClient {

--- a/snapshot.go
+++ b/snapshot.go
@@ -34,11 +34,12 @@ func (sc *SnapshotCollector) Collect() *acceptor.RuntimeInfo {
 	sc.lastCollectionTime = time.Now()
 
 	return &acceptor.RuntimeInfo{
-		Name:     sc.ServiceName,
-		Version:  runtime.Version(),
-		Root:     runtime.GOROOT(),
-		MaxProcs: runtime.GOMAXPROCS(0),
-		Compiler: runtime.Compiler,
-		NumCPU:   runtime.NumCPU(),
+		Name:          sc.ServiceName,
+		Version:       runtime.Version(),
+		Root:          runtime.GOROOT(),
+		MaxProcs:      runtime.GOMAXPROCS(0),
+		Compiler:      runtime.Compiler,
+		NumCPU:        runtime.NumCPU(),
+		SensorVersion: Version,
 	}
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -17,12 +17,13 @@ func TestSnapshotCollector_Collect(t *testing.T) {
 	}
 
 	assert.Equal(t, &acceptor.RuntimeInfo{
-		Name:     sc.ServiceName,
-		Version:  runtime.Version(),
-		Root:     runtime.GOROOT(),
-		MaxProcs: runtime.GOMAXPROCS(0),
-		Compiler: runtime.Compiler,
-		NumCPU:   runtime.NumCPU(),
+		Name:          sc.ServiceName,
+		Version:       runtime.Version(),
+		Root:          runtime.GOROOT(),
+		MaxProcs:      runtime.GOMAXPROCS(0),
+		Compiler:      runtime.Compiler,
+		NumCPU:        runtime.NumCPU(),
+		SensorVersion: instana.Version,
 	}, sc.Collect())
 
 	t.Run("second call before collection interval", func(t *testing.T) {
@@ -37,12 +38,13 @@ func TestSnapshotCollector_Collect(t *testing.T) {
 		runtime.GOMAXPROCS(oldNumProcs + 1)
 
 		assert.Equal(t, &acceptor.RuntimeInfo{
-			Name:     sc.ServiceName,
-			Version:  runtime.Version(),
-			Root:     runtime.GOROOT(),
-			MaxProcs: oldNumProcs + 1,
-			Compiler: runtime.Compiler,
-			NumCPU:   runtime.NumCPU(),
+			Name:          sc.ServiceName,
+			Version:       runtime.Version(),
+			Root:          runtime.GOROOT(),
+			MaxProcs:      oldNumProcs + 1,
+			Compiler:      runtime.Compiler,
+			NumCPU:        runtime.NumCPU(),
+			SensorVersion: instana.Version,
 		}, sc.Collect())
 	})
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package instana
+
+// Version is the version of Instana sensor
+const Version = "1.24.0"


### PR DESCRIPTION
This PR introduces a new constant `instana.Version` containing the package version string. This value will also be sent to the agent as a part of process snapshot to be displayed in the process info UI pane.