### PR TITLE
Add copyright headers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+STATUS=0
+
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    against=HEAD
+else
+    against=$(git hash-object -t tree /dev/null)
+fi
+
+for f in $(git diff --cached --name-only $against | grep '\.\(go\|sh\)$'); do
+    if ! head -n4 "$f" | grep -q "Copyright (c) IBM Corp\."; then
+        echo "Missing copyright header in $f"
+        STATUS=1
+    fi
+done
+
+exit $STATUS

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 Instana
+Copyright (c) 2021 IBM Corp.
+Copyright (c) 2016 Instana, Inc. https://www.instana.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,7 @@ $(VENDOR_GO):
 	go get golang.org/dl/$(VENDOR_GO_VERSION)
 	$(VENDOR_GO) download
 
+install:
+	cd .git/hooks && ln -fs ../../.githooks/* .
+
 .PHONY: test vendor $(MODULES) $(INTEGRATION_TESTS)

--- a/acceptor/aws.go
+++ b/acceptor/aws.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor
 
 import "time"

--- a/acceptor/aws_test.go
+++ b/acceptor/aws_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor_test
 
 import (

--- a/acceptor/docker.go
+++ b/acceptor/docker.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor
 
 import (

--- a/acceptor/docker_test.go
+++ b/acceptor/docker_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor_test
 
 import (

--- a/acceptor/gcr.go
+++ b/acceptor/gcr.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor
 
 // GCRServiceRevisionInstanceData is a representation of a Google Cloud Run service revision instance

--- a/acceptor/gcr_test.go
+++ b/acceptor/gcr_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor_test
 
 import (

--- a/acceptor/http_client.go
+++ b/acceptor/http_client.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor
 
 import (

--- a/acceptor/plugins.go
+++ b/acceptor/plugins.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Package acceptor provides marshaling structs for Instana serverless acceptor API
 package acceptor
 

--- a/acceptor/process.go
+++ b/acceptor/process.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor
 
 import "github.com/instana/go-sensor/process"

--- a/acceptor/process_test.go
+++ b/acceptor/process_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor_test
 
 import (

--- a/acceptor/runtime.go
+++ b/acceptor/runtime.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor
 
 import "strconv"

--- a/acceptor/runtime_test.go
+++ b/acceptor/runtime_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package acceptor_test
 
 import (

--- a/adapters.go
+++ b/adapters.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2019
+
 package instana
 
 import (

--- a/adapters_test.go
+++ b/adapters_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/agent.go
+++ b/agent.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/autoprofile/auto_profiler.go
+++ b/autoprofile/auto_profiler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package autoprofile
 
 import (

--- a/autoprofile/internal/allocation_sampler.go
+++ b/autoprofile/internal/allocation_sampler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/allocation_sampler_test.go
+++ b/autoprofile/internal/allocation_sampler_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/autoprofile/internal/block_sampler.go
+++ b/autoprofile/internal/block_sampler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/block_sampler_test.go
+++ b/autoprofile/internal/block_sampler_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/autoprofile/internal/cpu_sampler.go
+++ b/autoprofile/internal/cpu_sampler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/cpu_sampler_test.go
+++ b/autoprofile/internal/cpu_sampler_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/autoprofile/internal/flag.go
+++ b/autoprofile/internal/flag.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import "sync/atomic"

--- a/autoprofile/internal/frame_filter.go
+++ b/autoprofile/internal/frame_filter.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/logger/logger.go
+++ b/autoprofile/internal/logger/logger.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package logger
 
 import (

--- a/autoprofile/internal/pprof/profile/encode.go
+++ b/autoprofile/internal/pprof/profile/encode.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/filter.go
+++ b/autoprofile/internal/pprof/profile/filter.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/legacy_profile.go
+++ b/autoprofile/internal/pprof/profile/legacy_profile.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/profile.go
+++ b/autoprofile/internal/pprof/profile/profile.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/profile_test.go
+++ b/autoprofile/internal/pprof/profile/profile_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2015 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/proto.go
+++ b/autoprofile/internal/pprof/profile/proto.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/proto_test.go
+++ b/autoprofile/internal/pprof/profile/proto_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package profile
 
 import (

--- a/autoprofile/internal/pprof/profile/prune.go
+++ b/autoprofile/internal/pprof/profile/prune.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/profile.go
+++ b/autoprofile/internal/profile.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/profile_test.go
+++ b/autoprofile/internal/profile_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/autoprofile/internal/recorder.go
+++ b/autoprofile/internal/recorder.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/recorder_test.go
+++ b/autoprofile/internal/recorder_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/autoprofile/internal/sampler_scheduler.go
+++ b/autoprofile/internal/sampler_scheduler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/symbolizer.go
+++ b/autoprofile/internal/symbolizer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.10
 
 package internal

--- a/autoprofile/internal/symbolizer_1_9.go
+++ b/autoprofile/internal/symbolizer_1_9.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build !go1.10
 
 package internal

--- a/autoprofile/internal/timer.go
+++ b/autoprofile/internal/timer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/timer_test.go
+++ b/autoprofile/internal/timer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/autoprofile/internal/uuid.go
+++ b/autoprofile/internal/uuid.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal
 
 import (

--- a/autoprofile/internal/uuid_test.go
+++ b/autoprofile/internal/uuid_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package internal_test
 
 import (

--- a/aws/ecs_metadata.go
+++ b/aws/ecs_metadata.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package aws
 
 import (

--- a/aws/ecs_metadata_test.go
+++ b/aws/ecs_metadata_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package aws_test
 
 import (

--- a/context.go
+++ b/context.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana
 
 import (

--- a/context_test.go
+++ b/context_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/docker/container_stats.go
+++ b/docker/container_stats.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package docker
 
 import (

--- a/env_config.go
+++ b/env_config.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/env_config_internal_test.go
+++ b/env_config_internal_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/eum.go
+++ b/eum.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2018
+
 package instana
 
 import (

--- a/eum_test.go
+++ b/eum_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2018
+
 package instana_test
 
 import (

--- a/event.go
+++ b/event.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana
 
 import (

--- a/event_internal_test.go
+++ b/event_internal_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana
 
 import (

--- a/example/autoprofile/demo.go
+++ b/example/autoprofile/demo.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package main
 
 import (

--- a/example/event/change/change_event_no_sensor.go
+++ b/example/event/change/change_event_no_sensor.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package main
 
 import (

--- a/example/event/change_event/change_event_no_sensor.go
+++ b/example/event/change_event/change_event_no_sensor.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package main
 
 import (

--- a/example/event/default_service/default_service_event.go
+++ b/example/event/default_service/default_service_event.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package main
 
 import (

--- a/example/event/host/host_event.go
+++ b/example/event/host/host_event.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package main
 
 import (

--- a/example/event/service/service_event.go
+++ b/example/event/service/service_event.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package main
 
 import (

--- a/example/http-database-greeter/main.go
+++ b/example/http-database-greeter/main.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.10
 
 package main

--- a/example/kafka-producer-consumer/main.go
+++ b/example/kafka-producer-consumer/main.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package main
 
 import (

--- a/example/opentracing/main.go
+++ b/example/opentracing/main.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package main
 
 import (

--- a/example_httpclient_test.go
+++ b/example_httpclient_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/example_httpserver_test.go
+++ b/example_httpserver_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/example_instrumentation_go1.10_test.go
+++ b/example_instrumentation_go1.10_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.10
 
 package instana_test

--- a/example_instrumentation_test.go
+++ b/example_instrumentation_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/fargate_agent.go
+++ b/fargate_agent.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/fargate_agent_test.go
+++ b/fargate_agent_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build fargate,integration
 
 package instana_test

--- a/fsm.go
+++ b/fsm.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/gcloud/compute_metadata.go
+++ b/gcloud/compute_metadata.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package gcloud
 
 import (

--- a/gcloud/compute_metadata_test.go
+++ b/gcloud/compute_metadata_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package gcloud_test
 
 import (

--- a/gcr_agent.go
+++ b/gcr_agent.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/gcr_agent_test.go
+++ b/gcr_agent_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build gcr,integration
 
 package instana_test

--- a/instrumentation/cloud.google.com/go/LICENSE.md
+++ b/instrumentation/cloud.google.com/go/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 Instana
+Copyright (c) 2021 IBM Corp.
+Copyright (c) 2020 Instana, Inc. https://www.instana.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/instrumentation/cloud.google.com/go/iam/doc.go
+++ b/instrumentation/cloud.google.com/go/iam/doc.go
@@ -1,2 +1,5 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Package iam provides Instana tracing instrumentation for for Google Cloud IAM clients that use cloud.google.com/go/iam
 package iam

--- a/instrumentation/cloud.google.com/go/iam/iam.go
+++ b/instrumentation/cloud.google.com/go/iam/iam.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package iam

--- a/instrumentation/cloud.google.com/go/internal/trace.go
+++ b/instrumentation/cloud.google.com/go/internal/trace.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package internal

--- a/instrumentation/cloud.google.com/go/pubsub/example_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/example_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub_test

--- a/instrumentation/cloud.google.com/go/pubsub/pubsub.go
+++ b/instrumentation/cloud.google.com/go/pubsub/pubsub.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 // Package pubsub provides Instana tracing instrumentation for

--- a/instrumentation/cloud.google.com/go/pubsub/pubsub_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/pubsub_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub_test

--- a/instrumentation/cloud.google.com/go/pubsub/push.go
+++ b/instrumentation/cloud.google.com/go/pubsub/push.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub

--- a/instrumentation/cloud.google.com/go/pubsub/push_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/push_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub_test

--- a/instrumentation/cloud.google.com/go/pubsub/subscription.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub

--- a/instrumentation/cloud.google.com/go/pubsub/subscription_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub_test

--- a/instrumentation/cloud.google.com/go/pubsub/topic.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub

--- a/instrumentation/cloud.google.com/go/pubsub/topic_test.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package pubsub_test

--- a/instrumentation/cloud.google.com/go/storage/acl.go
+++ b/instrumentation/cloud.google.com/go/storage/acl.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/bucket.go
+++ b/instrumentation/cloud.google.com/go/storage/bucket.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/copy.go
+++ b/instrumentation/cloud.google.com/go/storage/copy.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/doc.go
+++ b/instrumentation/cloud.google.com/go/storage/doc.go
@@ -1,2 +1,5 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Package storage provides Instana tracing instrumentation for Google Cloud Storage clients that use cloud.google.com/go/storage
 package storage

--- a/instrumentation/cloud.google.com/go/storage/hmac.go
+++ b/instrumentation/cloud.google.com/go/storage/hmac.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/iam.go
+++ b/instrumentation/cloud.google.com/go/storage/iam.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/reader.go
+++ b/instrumentation/cloud.google.com/go/storage/reader.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/storage.go
+++ b/instrumentation/cloud.google.com/go/storage/storage.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/cloud.google.com/go/storage/writer.go
+++ b/instrumentation/cloud.google.com/go/storage/writer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.11
 
 package storage

--- a/instrumentation/instagrpc/LICENSE.md
+++ b/instrumentation/instagrpc/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 Instana
+Copyright (c) 2021 IBM Corp.
+Copyright (c) 2020 Instana, Inc. https://www.instana.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/instrumentation/instagrpc/client.go
+++ b/instrumentation/instagrpc/client.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instagrpc

--- a/instrumentation/instagrpc/client_test.go
+++ b/instrumentation/instagrpc/client_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instagrpc_test

--- a/instrumentation/instagrpc/example_test.go
+++ b/instrumentation/instagrpc/example_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instagrpc_test

--- a/instrumentation/instagrpc/instagrpc.go
+++ b/instrumentation/instagrpc/instagrpc.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Package instagrpc provides Instana tracing instrumentation for
 // GRPC servers and clients that use google.golang.org/grpc.
 package instagrpc

--- a/instrumentation/instagrpc/instagrpc_test.go
+++ b/instrumentation/instagrpc/instagrpc_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instagrpc_test
 
 import (

--- a/instrumentation/instagrpc/rpc_error.go
+++ b/instrumentation/instagrpc/rpc_error.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instagrpc
 
 import (

--- a/instrumentation/instagrpc/server.go
+++ b/instrumentation/instagrpc/server.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instagrpc

--- a/instrumentation/instagrpc/server_test.go
+++ b/instrumentation/instagrpc/server_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instagrpc_test

--- a/instrumentation/instalambda/LICENSE.md
+++ b/instrumentation/instalambda/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 Instana
+Copyright (c) 2021 IBM Corp.
+Copyright (c) 2020 Instana, Inc. https://www.instana.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/instrumentation/instalambda/example_test.go
+++ b/instrumentation/instalambda/example_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instalambda_test
 
 import (

--- a/instrumentation/instalambda/handler.go
+++ b/instrumentation/instalambda/handler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Package instalambda provides Instana tracing instrumentation for
 // AWS Lambda functions
 package instalambda

--- a/instrumentation/instalambda/handler_test.go
+++ b/instrumentation/instalambda/handler_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instalambda_test
 
 import (

--- a/instrumentation/instalambda/triggers.go
+++ b/instrumentation/instalambda/triggers.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instalambda
 
 import (

--- a/instrumentation/instasarama/LICENSE.md
+++ b/instrumentation/instasarama/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 Instana
+Copyright (c) 2021 IBM Corp.
+Copyright (c) 2020 Instana, Inc. https://www.instana.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/instrumentation/instasarama/async_producer.go
+++ b/instrumentation/instasarama/async_producer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/async_producer_test.go
+++ b/instrumentation/instasarama/async_producer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/consumer.go
+++ b/instrumentation/instasarama/consumer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/consumer_group_handler.go
+++ b/instrumentation/instasarama/consumer_group_handler.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/consumer_group_handler_test.go
+++ b/instrumentation/instasarama/consumer_group_handler_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/consumer_test.go
+++ b/instrumentation/instasarama/consumer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/example_async_producer_test.go
+++ b/instrumentation/instasarama/example_async_producer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/example_consumer_group_test.go
+++ b/instrumentation/instasarama/example_consumer_group_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/example_consumer_test.go
+++ b/instrumentation/instasarama/example_consumer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/example_sync_producer_test.go
+++ b/instrumentation/instasarama/example_sync_producer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/instasarama.go
+++ b/instrumentation/instasarama/instasarama.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // Package instasarama provides Instana tracing instrumentation for
 // Kafka producers and consumers build on top of github.com/Shopify/sarama.
 package instasarama

--- a/instrumentation/instasarama/instasarama_test.go
+++ b/instrumentation/instasarama/instasarama_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/partition_consumer.go
+++ b/instrumentation/instasarama/partition_consumer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/partition_consumer_test.go
+++ b/instrumentation/instasarama/partition_consumer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/propagation.go
+++ b/instrumentation/instasarama/propagation.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/propagation_test.go
+++ b/instrumentation/instasarama/propagation_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/record_header.go
+++ b/instrumentation/instasarama/record_header.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/record_header_test.go
+++ b/instrumentation/instasarama/record_header_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation/instasarama/span_registry.go
+++ b/instrumentation/instasarama/span_registry.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/sync_producer.go
+++ b/instrumentation/instasarama/sync_producer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama

--- a/instrumentation/instasarama/sync_producer_test.go
+++ b/instrumentation/instasarama/sync_producer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.9
 
 package instasarama_test

--- a/instrumentation_http.go
+++ b/instrumentation_http.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/instrumentation_sql_go1.10.go
+++ b/instrumentation_sql_go1.10.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.10
 
 package instana

--- a/instrumentation_sql_go1.10_test.go
+++ b/instrumentation_sql_go1.10_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build go1.10
 
 package instana_test

--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build integration
 
 package instana_test

--- a/json_span.go
+++ b/json_span.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana
 
 import (

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/lambda_agent.go
+++ b/lambda_agent.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/lambda_agent_test.go
+++ b/lambda_agent_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build lambda,integration
 
 package instana_test

--- a/log.go
+++ b/log.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package logger
 
 import (

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package logger_test
 
 import (

--- a/matcher.go
+++ b/matcher.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/meter.go
+++ b/meter.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/options.go
+++ b/options.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/options_test.go
+++ b/options_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/process/stats.go
+++ b/process/stats.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package process
 
 // MemStats represents memory stats for a process

--- a/process/stats_reader.go
+++ b/process/stats_reader.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build !linux
 
 package process

--- a/process/stats_reader_linux.go
+++ b/process/stats_reader_linux.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build linux
 
 package process

--- a/process/stats_reader_linux_test.go
+++ b/process/stats_reader_linux_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 // +build linux
 
 package process_test

--- a/propagation.go
+++ b/propagation.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/propagation_internal_test.go
+++ b/propagation_internal_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana_test
 
 import (

--- a/recorder.go
+++ b/recorder.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana_test
 
 import (

--- a/secrets/matchers.go
+++ b/secrets/matchers.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package secrets
 
 import (

--- a/secrets/matchers_test.go
+++ b/secrets/matchers_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package secrets_test
 
 import (

--- a/sensor.go
+++ b/sensor.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/serverless_agent.go
+++ b/serverless_agent.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/span.go
+++ b/span.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/span_context.go
+++ b/span_context.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import (

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/span_test.go
+++ b/span_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana_test
 
 import (

--- a/tags.go
+++ b/tags.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana
 
 import ot "github.com/opentracing/opentracing-go"

--- a/tracer.go
+++ b/tracer.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana
 
 // TracerOptions carry the tracer configuration

--- a/tracer_options_test.go
+++ b/tracer_options_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package instana_test
 
 import (

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana_test
 
 import (

--- a/util.go
+++ b/util.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2016
+
 package instana
 
 import (

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2017
+
 package instana
 
 import (

--- a/version.go
+++ b/version.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
 package instana
 
 // Version is the version of Instana sensor

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace
 
 import (

--- a/w3ctrace/context_test.go
+++ b/w3ctrace/context_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace_test
 
 import (

--- a/w3ctrace/middleware.go
+++ b/w3ctrace/middleware.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace
 
 import "net/http"

--- a/w3ctrace/middleware_test.go
+++ b/w3ctrace/middleware_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace_test
 
 import (

--- a/w3ctrace/parent.go
+++ b/w3ctrace/parent.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace
 
 // Flags contains the trace flags as defined by https://www.w3.org/TR/trace-context/#trace-flags

--- a/w3ctrace/parent_test.go
+++ b/w3ctrace/parent_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace_test
 
 import (

--- a/w3ctrace/state.go
+++ b/w3ctrace/state.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace
 
 import (

--- a/w3ctrace/state_test.go
+++ b/w3ctrace/state_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace_test
 
 import (

--- a/w3ctrace/version.go
+++ b/w3ctrace/version.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace
 
 import (

--- a/w3ctrace/version_test.go
+++ b/w3ctrace/version_test.go
@@ -1,3 +1,6 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2020
+
 package w3ctrace_test
 
 import (


### PR DESCRIPTION
This PR adds copyright headers and licenses Go sensor module and its submodules under IBM Corp.