### PR TITLE
Truncate 128bit ids

### DIFF
--- a/instrumentation/instaawssdk/sqs.go
+++ b/instrumentation/instaawssdk/sqs.go
@@ -16,16 +16,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
-var sqsInstrumentedOps = map[string]string{
-	"ReceiveMessage":     "",
-	"SendMessage":        "single.sync",
-	"SendMessageBatch":   "batch.sync",
-	"GetQueueUrl":        "get.queue",
-	"CreateQueue":        "create.queue",
-	"DeleteMessage":      "delete.single.sync",
-	"DeleteMessageBatch": "delete.batch.sync",
-}
-
 // StartSQSSpan initiates a new span from an AWS SQS request and injects it into the
 // request.Request context
 func StartSQSSpan(req *request.Request, sensor *instana.Sensor) {

--- a/json_span.go
+++ b/json_span.go
@@ -219,7 +219,7 @@ func (sp Span) MarshalJSON() ([]byte, error) {
 		CorrelationType string         `json:"crtp,omitempty"`
 		CorrelationID   string         `json:"crid,omitempty"`
 	}{
-		FormatLongID(sp.TraceIDHi, sp.TraceID),
+		FormatID(sp.TraceID),
 		parentID,
 		FormatID(sp.SpanID),
 		sp.Timestamp,


### PR DESCRIPTION
This PR addresses potential compatibility issue when using 128-bit trace IDs in systems where services instrumented with older versions of Instana tracers are present. Whenever an upstream service initiates a trace with a 128-bit trace ID with non-zero higher 8 bytes, this may result in a broken trace, if the downstream service does not support sending long trace IDs.