### PR TITLE
Lookup and send the indirect Instana trace parent

### DIFF
--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -50,7 +50,6 @@ func TestTracingHandlerFunc_Write(t *testing.T) {
 	assert.Empty(t, span.CorrelationType)
 	assert.Empty(t, span.CorrelationID)
 	assert.False(t, span.ForeignTrace)
-	assert.Empty(t, span.W3CTraceID)
 	assert.Empty(t, span.Ancestor)
 
 	require.IsType(t, instana.HTTPSpanData{}, span.Data)
@@ -108,7 +107,6 @@ func TestTracingHandlerFunc_WriteHeaders(t *testing.T) {
 	assert.Empty(t, span.CorrelationType)
 	assert.Empty(t, span.CorrelationID)
 	assert.False(t, span.ForeignTrace)
-	assert.Empty(t, span.W3CTraceID)
 	assert.Empty(t, span.Ancestor)
 
 	require.IsType(t, instana.HTTPSpanData{}, span.Data)
@@ -171,7 +169,6 @@ func TestTracingHandlerFunc_W3CTraceContext(t *testing.T) {
 	assert.Empty(t, span.CorrelationType)
 	assert.Empty(t, span.CorrelationID)
 	assert.True(t, span.ForeignTrace)
-	assert.Equal(t, "00000000000000010000000000000002", span.W3CTraceID)
 	assert.Equal(t, &instana.TraceReference{
 		TraceID:  "1234",
 		ParentID: "5678",

--- a/json_span.go
+++ b/json_span.go
@@ -185,7 +185,7 @@ func (sp Span) MarshalJSON() ([]byte, error) {
 	}
 
 	var longTraceID string
-	if sp.TraceIDHi != 0 {
+	if sp.TraceIDHi != 0 && sp.Kind == int(EntrySpanKind) {
 		longTraceID = FormatLongID(sp.TraceIDHi, sp.TraceID)
 	}
 

--- a/span_context.go
+++ b/span_context.go
@@ -94,7 +94,7 @@ func NewSpanContext(parent SpanContext) SpanContext {
 
 	// check if there is Instana state stored in the W3C tracestate header
 	w3cState := c.W3CContext.State()
-	if ancestor, ok := w3cState.Fetch(w3ctrace.VendorInstana); ok {
+	if ancestor, ok := w3cState.Fetch(w3ctrace.VendorInstana); ok && foreignTrace {
 		if ind := strings.IndexByte(ancestor, ';'); ind > -1 {
 			c.Links = append(c.Links, SpanReference{
 				TraceID: ancestor[:ind],

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -122,6 +122,9 @@ func TestNewSpanContext_FromW3CTraceContext(t *testing.T) {
 			RawState:  "in=1234;5678,vendor1=data",
 		},
 		ForeignTrace: true,
+		Links: []instana.SpanReference{
+			{TraceID: "1234", SpanID: "5678"},
+		},
 	}, c)
 }
 


### PR DESCRIPTION
This PR updates the tracer to look for an Instana trace parent stored within the W3C `tracestate` header.