### PR TITLE
W3C trace correlation opt-out

### DIFF
--- a/options.go
+++ b/options.go
@@ -20,6 +20,8 @@ type Options struct {
 	MaxBufferedProfiles         int
 	IncludeProfilerFrames       bool
 	Tracer                      TracerOptions
+
+	disableW3CTraceCorrelation bool
 }
 
 // DefaultOptions returns the default set of options to configure Instana sensor.
@@ -77,4 +79,6 @@ func (opts *Options) setDefaults() {
 	if collectableHeaders, ok := os.LookupEnv("INSTANA_EXTRA_HTTP_HEADERS"); ok {
 		opts.Tracer.CollectableHTTPHeaders = parseInstanaExtraHTTPHeaders(collectableHeaders)
 	}
+
+	opts.disableW3CTraceCorrelation = os.Getenv("INSTANA_DISABLE_W3C_TRACE_CORRELATION") != ""
 }

--- a/span_context.go
+++ b/span_context.go
@@ -107,7 +107,7 @@ func NewSpanContext(parent SpanContext) SpanContext {
 }
 
 func restoreFromW3CTraceContext(trCtx w3ctrace.Context) SpanContext {
-	if trCtx.IsZero() {
+	if trCtx.IsZero() || sensor.options.disableW3CTraceCorrelation {
 		return SpanContext{}
 	}
 


### PR DESCRIPTION
Allow to disable W3C trace correlation by setting `INSTANA_DISABLE_W3C_TRACE_CORRELATION` env variable no a non-empty value.