### PR TITLE
Do not propagate suppressed trace

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -109,13 +109,20 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		pickupW3CTraceContext(http.Header(c), &spanContext)
 	}
 
-	var traceID, spanID string
 	err := carrier.ForeachKey(func(k, v string) error {
+		var err error
+
 		switch strings.ToLower(k) {
 		case FieldT:
-			traceID = v
+			spanContext.TraceIDHi, spanContext.TraceID, err = ParseLongID(v)
+			if err != nil {
+				return ot.ErrSpanContextCorrupted
+			}
 		case FieldS:
-			spanID = v
+			spanContext.SpanID, err = ParseID(v)
+			if err != nil {
+				return ot.ErrSpanContextCorrupted
+			}
 		case FieldL:
 			suppressed, corrData, err := parseLevel(v)
 			if err != nil {
@@ -123,6 +130,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 				// use defaults
 				suppressed, corrData = false, EUMCorrelationData{}
 			}
+
 			spanContext.Suppressed = suppressed
 			if !spanContext.Suppressed {
 				spanContext.Correlation = corrData
@@ -140,26 +148,18 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		return spanContext, err
 	}
 
-	// For compatibility reasons X-Instana-{T,S} values if EUM has provided correlation ID
+	// reset the trace if a correlation ID has been provided
 	if spanContext.Correlation.ID != "" {
-		return spanContext, nil
-	}
-
-	if traceID == "" && spanID == "" {
-		if spanContext.W3CContext.IsZero() {
-			return spanContext, ot.ErrSpanContextNotFound
-		}
+		spanContext.TraceIDHi, spanContext.TraceID, spanContext.SpanID = 0, 0, 0
 
 		return spanContext, nil
 	}
 
-	spanContext.TraceIDHi, spanContext.TraceID, err = ParseLongID(traceID)
-	if err != nil {
-		return spanContext, ot.ErrSpanContextCorrupted
+	if spanContext.IsZero() {
+		return spanContext, ot.ErrSpanContextNotFound
 	}
 
-	spanContext.SpanID, err = ParseID(spanID)
-	if err != nil {
+	if !spanContext.Suppressed && (spanContext.SpanID == 0 != (spanContext.TraceIDHi == 0 && spanContext.TraceID == 0)) {
 		return spanContext, ot.ErrSpanContextCorrupted
 	}
 

--- a/span_context.go
+++ b/span_context.go
@@ -112,6 +112,10 @@ func NewSpanContext(parent SpanContext) SpanContext {
 	return c
 }
 
+func (sc SpanContext) IsZero() bool {
+	return sc.TraceIDHi == 0 && sc.TraceID == 0 && sc.SpanID == 0 && sc.W3CContext.IsZero() && !sc.Suppressed
+}
+
 func restoreFromW3CTraceContext(trCtx w3ctrace.Context) SpanContext {
 	if trCtx.IsZero() {
 		return SpanContext{}

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -168,6 +168,34 @@ func TestSpanContext_WithBaggageItem(t *testing.T) {
 	}, c)
 }
 
+func TestSpanContext_IsZero(t *testing.T) {
+	examples := map[string]instana.SpanContext{
+		"with 64-bit trace ID":  {TraceID: 0x1},
+		"with 128-bit trace ID": {TraceIDHi: 0x1},
+		"with span ID":          {SpanID: 0x1},
+		"with w3c context": {
+			W3CContext: w3ctrace.New(w3ctrace.Parent{
+				Version:  w3ctrace.Version_Max,
+				TraceID:  "abcd",
+				ParentID: "1234",
+			}),
+		},
+		"with suppressed option": {
+			Suppressed: true,
+		},
+	}
+
+	for name, sc := range examples {
+		t.Run(name, func(t *testing.T) {
+			assert.False(t, sc.IsZero())
+		})
+	}
+
+	t.Run("zero value", func(t *testing.T) {
+		assert.True(t, instana.SpanContext{}.IsZero())
+	})
+}
+
 func TestSpanContext_Clone(t *testing.T) {
 	c := instana.SpanContext{
 		TraceIDHi:  10,

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -50,24 +50,6 @@ func TestNewSpanContext(t *testing.T) {
 				RawState:  "vendor1=data",
 			},
 		},
-		"with w3c trace, last state from instana": {
-			TraceIDHi: 10,
-			TraceID:   1,
-			SpanID:    2,
-			W3CContext: w3ctrace.Context{
-				RawParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-				RawState:  "in=1234;5678,vendor1=data",
-			},
-		},
-		"with correlation data": {
-			TraceIDHi: 10,
-			TraceID:   1,
-			SpanID:    2,
-			Correlation: instana.EUMCorrelationData{
-				Type: "web",
-				ID:   "1",
-			},
-		},
 	}
 
 	for name, parent := range examples {
@@ -81,6 +63,7 @@ func TestNewSpanContext(t *testing.T) {
 			assert.Equal(t, parent.Suppressed, c.Suppressed)
 			assert.Equal(t, instana.FormatID(c.SpanID), c.W3CContext.Parent().ParentID)
 			assert.Equal(t, instana.EUMCorrelationData{}, c.Correlation)
+			assert.False(t, c.W3CContext.IsZero())
 			assert.Equal(t, parent.Baggage, c.Baggage)
 
 			assert.NotEqual(t, parent.SpanID, c.SpanID)
@@ -91,14 +74,31 @@ func TestNewSpanContext(t *testing.T) {
 }
 
 func TestNewSpanContext_EmptyParent(t *testing.T) {
-	c := instana.NewSpanContext(instana.SpanContext{})
+	examples := map[string]instana.SpanContext{
+		"zero value": instana.SpanContext{},
+		"suppressed": instana.SpanContext{Suppressed: true},
+		"with correlation data": instana.SpanContext{
+			Correlation: instana.EUMCorrelationData{
+				Type: "web",
+				ID:   "1",
+			},
+		},
+	}
 
-	assert.NotEmpty(t, c.TraceID)
-	assert.Equal(t, c.SpanID, c.TraceID)
-	assert.False(t, c.Sampled)
-	assert.False(t, c.Suppressed)
-	assert.Equal(t, instana.EUMCorrelationData{}, c.Correlation)
-	assert.Empty(t, c.Baggage)
+	for name, parent := range examples {
+		t.Run(name, func(t *testing.T) {
+			c := instana.NewSpanContext(parent)
+
+			assert.NotEmpty(t, c.TraceID)
+			assert.Equal(t, c.SpanID, c.TraceID)
+			assert.Empty(t, c.ParentID)
+			assert.False(t, c.Sampled)
+			assert.Equal(t, parent.Suppressed, c.Suppressed)
+			assert.Equal(t, instana.EUMCorrelationData{}, c.Correlation)
+			assert.False(t, c.W3CContext.IsZero())
+			assert.Empty(t, c.Baggage)
+		})
+	}
 }
 
 func TestNewSpanContext_FromW3CTraceContext(t *testing.T) {


### PR DESCRIPTION
This PR updates the tracer to stop sending the trace and span ID downstream if the trace is suppressed via the `X-Instana-L` header.