### PR TITLE
Remove duplicate copyright headers

### DIFF
--- a/autoprofile/internal/pprof/profile/encode.go
+++ b/autoprofile/internal/pprof/profile/encode.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/filter.go
+++ b/autoprofile/internal/pprof/profile/filter.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/legacy_profile.go
+++ b/autoprofile/internal/pprof/profile/legacy_profile.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/profile.go
+++ b/autoprofile/internal/pprof/profile/profile.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/profile_test.go
+++ b/autoprofile/internal/pprof/profile/profile_test.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2015 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/proto.go
+++ b/autoprofile/internal/pprof/profile/proto.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/autoprofile/internal/pprof/profile/prune.go
+++ b/autoprofile/internal/pprof/profile/prune.go
@@ -1,6 +1,3 @@
-// (c) Copyright IBM Corp. 2021
-// (c) Copyright Instana Inc. 2020
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
This PR removes duplicate copyright headers added by accident.