### PR TITLE
Mark spans resulted in HTTP 500 responses as errors

### DIFF
--- a/instrumentation_http.go
+++ b/instrumentation_http.go
@@ -122,8 +122,11 @@ func TracingHandlerFunc(sensor *Sensor, pathTemplate string, handler http.Handle
 		}
 
 		if wrapped.Status > 0 {
-			if wrapped.Status > http.StatusInternalServerError {
-				span.SetTag("http.error", http.StatusText(wrapped.Status))
+			if wrapped.Status >= http.StatusInternalServerError {
+				statusText := http.StatusText(wrapped.Status)
+
+				span.SetTag("http.error", statusText)
+				span.LogFields(otlog.Object("error", statusText))
 			}
 
 			span.SetTag("http.status", wrapped.Status)

--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -262,7 +262,7 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 	require.Len(t, spans, 1)
 
 	span := spans[0]
-	assert.Equal(t, 0, span.Ec)
+	assert.Equal(t, 1, span.Ec)
 	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
 	assert.False(t, span.Synthetic)
 
@@ -274,6 +274,7 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 		Method: "GET",
 		Host:   "example.com",
 		Path:   "/test",
+		Error:  "Internal Server Error",
 	}, data.Tags)
 }
 


### PR DESCRIPTION
This PR updates the HTTP handler instrumentation to mark the spans resulted in a server error (HTTP 500 and above) as errors in Instana UI.