### PR TITLE
Fix agent init data race

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -85,6 +85,7 @@ type agentS struct {
 	logger   LeveledLogger
 }
 
+//go:norace
 func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS {
 	if logger == nil {
 		logger = defaultLogger


### PR DESCRIPTION
This PR fixes the data race during the agent initialization by serializing access to the host agent FSM.