### PR TITLE
Fix sensor init data race

### DIFF
--- a/event.go
+++ b/event.go
@@ -79,5 +79,5 @@ func sendEvent(event *EventData) {
 	}
 
 	// we do fire & forget here, because the whole pid dance isn't necessary to send events
-	go sensor.agent.SendEvent(event)
+	go sensor.Agent().SendEvent(event)
 }

--- a/meter.go
+++ b/meter.go
@@ -24,20 +24,12 @@ type EntityData acceptor.GoProcessData
 
 type meterS struct {
 	numGC uint32
-
-	logger LeveledLogger
 }
 
 func newMeter(logger LeveledLogger) *meterS {
-	if logger == nil {
-		logger = defaultLogger
-	}
+	meter := &meterS{}
 
 	logger.Debug("initializing meter")
-
-	meter := &meterS{
-		logger: logger,
-	}
 
 	ticker := time.NewTicker(1 * time.Second)
 	go func() {
@@ -51,10 +43,6 @@ func newMeter(logger LeveledLogger) *meterS {
 	}()
 
 	return meter
-}
-
-func (m *meterS) setLogger(l LeveledLogger) {
-	m.logger = l
 }
 
 func (m *meterS) collectMemoryMetrics() acceptor.MemoryStats {

--- a/recorder.go
+++ b/recorder.go
@@ -35,7 +35,7 @@ func NewRecorder() *Recorder {
 	ticker := time.NewTicker(1 * time.Second)
 	go func() {
 		for range ticker.C {
-			if sensor.agent.Ready() {
+			if sensor.Agent().Ready() {
 				go r.Flush(context.Background())
 			}
 		}
@@ -57,7 +57,7 @@ func NewTestRecorder() *Recorder {
 func (r *Recorder) RecordSpan(span *spanS) {
 	// If we're not announced and not in test mode then just
 	// return
-	if !r.testMode && !sensor.agent.Ready() {
+	if !r.testMode && !sensor.Agent().Ready() {
 		return
 	}
 
@@ -70,7 +70,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 
 	r.spans = append(r.spans, newSpan(span))
 
-	if r.testMode || !sensor.agent.Ready() {
+	if r.testMode || !sensor.Agent().Ready() {
 		return
 	}
 
@@ -109,7 +109,7 @@ func (r *Recorder) Flush(ctx context.Context) error {
 		return nil
 	}
 
-	if err := sensor.agent.SendSpans(spansToSend); err != nil {
+	if err := sensor.Agent().SendSpans(spansToSend); err != nil {
 		r.spans = append(r.spans, spansToSend...)
 		return fmt.Errorf("failed to send collected spans to the agent: %s", err)
 	}

--- a/sensor.go
+++ b/sensor.go
@@ -129,10 +129,6 @@ func (r *sensorS) setLogger(l LeveledLogger) {
 	if agent, ok := r.Agent().(*agentS); ok && agent != nil {
 		agent.setLogger(r.logger)
 	}
-
-	if r.meter != nil {
-		r.meter.setLogger(r.logger)
-	}
 }
 
 func (r *sensorS) setAgent(agent agentClient) {

--- a/sensor.go
+++ b/sensor.go
@@ -119,6 +119,7 @@ func newSensor(options *Options) *sensorS {
 
 	s.setAgent(agent)
 	s.meter = newMeter(s.logger)
+	go s.meter.Run(1 * time.Second)
 
 	return s
 }

--- a/tracer.go
+++ b/tracer.go
@@ -127,5 +127,5 @@ func (r *tracerS) Flush(ctx context.Context) error {
 		return err
 	}
 
-	return sensor.agent.Flush(ctx)
+	return sensor.Agent().Flush(ctx)
 }


### PR DESCRIPTION
This PR serializes access to the sensor's agent client instance and makes sure that meter uses the currently configured client to send collected metrics. It also addresses an issue when an agent is accessed before it's initialized by using a noop client implementation as a zero-value.