### PR TITLE
Use defaults to initialize the sensor if no options are given

### DIFF
--- a/meter.go
+++ b/meter.go
@@ -36,20 +36,18 @@ func newMeter(logger LeveledLogger) *meterS {
 }
 
 func (m *meterS) Run(collectInterval time.Duration) {
-	go func() {
-		ticker := time.NewTicker(collectInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-m.done:
-				return
-			case <-ticker.C:
-				if sensor.Agent().Ready() {
-					go sensor.Agent().SendMetrics(m.collectMetrics())
-				}
+	ticker := time.NewTicker(collectInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.done:
+			return
+		case <-ticker.C:
+			if sensor.Agent().Ready() {
+				go sensor.Agent().SendMetrics(m.collectMetrics())
 			}
 		}
-	}()
+	}
 }
 
 func (m *meterS) Stop() {

--- a/sensor.go
+++ b/sensor.go
@@ -64,11 +64,7 @@ var (
 )
 
 func newSensor(options *Options) *sensorS {
-	if options == nil {
-		options = DefaultOptions()
-	} else {
-		options.setDefaults()
-	}
+	options.setDefaults()
 
 	s := &sensorS{
 		options:     options,
@@ -155,6 +151,10 @@ func (r *sensorS) Agent() agentClient {
 func InitSensor(options *Options) {
 	if sensor != nil {
 		return
+	}
+
+	if options == nil {
+		options = DefaultOptions()
 	}
 
 	sensor = newSensor(options)

--- a/sensor.go
+++ b/sensor.go
@@ -135,7 +135,13 @@ func (r *sensorS) setAgent(agent agentClient) {
 	r.agent = agent
 }
 
+// Agent returns the agent client used by the global sensor. It will return a noopAgent that is never ready
+// until both the global sensor and its agent are initialized
 func (r *sensorS) Agent() agentClient {
+	if r == nil {
+		return noopAgent{}
+	}
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/tracer.go
+++ b/tracer.go
@@ -29,8 +29,13 @@ func NewTracerWithOptions(options *Options) *tracerS {
 	return NewTracerWithEverything(options, NewRecorder())
 }
 
-// NewTracerWithEverything initializes and configures a new tracer
+// NewTracerWithEverything initializes and configures a new tracer. It uses instana.DefaultOptions() if nil
+// is provided
 func NewTracerWithEverything(options *Options, recorder SpanRecorder) *tracerS {
+	if options == nil {
+		options = DefaultOptions()
+	}
+
 	InitSensor(options)
 
 	tracer := &tracerS{

--- a/tracer.go
+++ b/tracer.go
@@ -26,17 +26,17 @@ func NewTracer() *tracerS {
 
 // NewTracerWithOptions initializes and configures a new tracer that collects and sends spans to the agent
 func NewTracerWithOptions(options *Options) *tracerS {
-	return NewTracerWithEverything(options, NewRecorder())
+	return NewTracerWithEverything(options, nil)
 }
 
 // NewTracerWithEverything initializes and configures a new tracer. It uses instana.DefaultOptions() if nil
 // is provided
 func NewTracerWithEverything(options *Options, recorder SpanRecorder) *tracerS {
-	if options == nil {
-		options = DefaultOptions()
-	}
-
 	InitSensor(options)
+
+	if recorder == nil {
+		recorder = NewRecorder()
+	}
 
 	tracer := &tracerS{
 		recorder: recorder,

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 package instana
 
 // Version is the version of Instana sensor
-const Version = "1.27.2"
+const Version = "1.27.3"


### PR DESCRIPTION
This PR updates the tracer to use `instana.DefaultOptions()` if there were no options provided to the `instana.NewTracerWithOptions()`. It also ensures that both the global sensor and its agent were initialized before flushing collected metrics and spans to the agent.