### PR TITLE
Ensure global sensor is initialized before running the metrics collector

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -115,7 +115,6 @@ func newSensor(options *Options) *sensorS {
 
 	s.setAgent(agent)
 	s.meter = newMeter(s.logger)
-	go s.meter.Run(1 * time.Second)
 
 	return s
 }
@@ -189,6 +188,9 @@ func InitSensor(options *Options) {
 
 		autoprofile.Enable()
 	}
+
+	// start collecting metrics
+	go sensor.meter.Run(1 * time.Second)
 
 	sensor.logger.Debug("initialized Instana sensor v", Version)
 }


### PR DESCRIPTION
This PR splits the sensor initialization and running the metrics collector loop to ensure that the global sensor is initialized before sending the data.