### PR TITLE
Update READMEs and method receiver names

### DIFF
--- a/EventAPI.md
+++ b/EventAPI.md
@@ -6,7 +6,7 @@ Events are a versatile way to broaden the knowledge base that Instana has to con
 
 # Example: A High Latency Service Event
 
-Suppose that we have a remote point of presence monitoring a specific public microservice (_games_) in Eastern Asia that is critical to our infrastructure for that local area.  When that monitor detects slow response times to it's queries, it reports a custom high latency event to Instana.
+Suppose that we have a remote point of presence monitoring a specific public microservice (_games_) in Eastern Asia that is critical to our infrastructure for that local area.  When that monitor detects slow response times to its queries, it reports a custom high latency event to Instana.
 
 The following example shows how such Go code would send a _critical_ event on the service _games_.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To use Instana Go sensor for monitoring a service running in a serverless enviro
 * [Configuring AWS Lambda functions](https://www.instana.com/docs/ecosystem/aws-lambda/go)
 * [Configuring Google Cloud Run services](https://www.instana.com/docs/ecosystem/google-cloud-run/#configure-your-cloud-run-service)
 
-Services running in serverless environments don't use host agent to send metrics and trace data to Instana backend, therefore the usual way of configuring the in-app sensor via [`configuration.yaml`](https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#agent-configuration-file) file is not applicable. Instead there is a set of environment variables that can optionally be configured in service task definition:
+Services running in serverless environments don't use host agent to send metrics and trace data to Instana backend, therefore the usual way of configuring the in-app sensor via [`configuration.yaml`](https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#agent-configuration-file) file is not applicable. Instead, there is a set of environment variables that can optionally be configured in service task definition:
 
 | Environment variable         | Default value                              | Description                                                                              |
 |------------------------------|--------------------------------------------|------------------------------------------------------------------------------------------|

--- a/autoprofile/internal/pprof/profile/encode.go
+++ b/autoprofile/internal/pprof/profile/encode.go
@@ -382,16 +382,16 @@ var mappingDecoder = []decoder{
 	func(b *buffer, m message) error { return decodeBool(b, &m.(*Mapping).HasInlineFrames) }, // optional bool has_inline_frames = 10
 }
 
-func (p *Location) decoder() []decoder {
+func (loc *Location) decoder() []decoder {
 	return locationDecoder
 }
 
-func (p *Location) encode(b *buffer) {
-	encodeUint64Opt(b, 1, p.ID)
-	encodeUint64Opt(b, 2, p.mappingIDX)
-	encodeUint64Opt(b, 3, p.Address)
-	for i := range p.Line {
-		encodeMessage(b, 4, &p.Line[i])
+func (loc *Location) encode(b *buffer) {
+	encodeUint64Opt(b, 1, loc.ID)
+	encodeUint64Opt(b, 2, loc.mappingIDX)
+	encodeUint64Opt(b, 3, loc.Address)
+	for i := range loc.Line {
+		encodeMessage(b, 4, &loc.Line[i])
 	}
 }
 

--- a/autoprofile/internal/pprof/profile/profile.go
+++ b/autoprofile/internal/pprof/profile/profile.go
@@ -467,7 +467,7 @@ func (p *Profile) Merge(pb *Profile, r float64) error {
 	if r != 1.0 {
 		for _, s := range pb.Sample {
 			for i, v := range s.Value {
-				s.Value[i] = int64((float64(v) * r))
+				s.Value[i] = int64(float64(v) * r)
 			}
 		}
 	}

--- a/example/README.md
+++ b/example/README.md
@@ -4,10 +4,10 @@ Examples
 This folder contains examples of instrumenting the common use-cases with `github.com/instana/go-sensor`
 
 * [Greeter](./http-database-greeter) - an instrumented HTTP server that queries a database
-* [Doubler](./kafka-producer-consumer) - an instrumented Kafka processor, that counsumes and produces messages
-* [event/](./example/event/) - Demonstrates usage of the Events API
-* [autoprofile/](./example/autoprofile/) - Demonstrates usage of the AutoProfile™
-* [OpenTracing](./example/opentracing/) - an example of usage of Instana tracer in an app instrumented with OpentTracing
+* [Doubler](./kafka-producer-consumer) - an instrumented Kafka processor, that consumes and produces messages
+* [Event](./event) - Demonstrates usage of the Events API
+* [Autoprofile](./autoprofile) - Demonstrates usage of the AutoProfile™
+* [OpenTracing](./opentracing) - an example of usage of Instana tracer in an app instrumented with OpenTracing
 
 For more up-to-date instrumentation code examples please consult the respective package documentation page:
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,4 @@ require (
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/looplab/fsm v0.1.0
 	github.com/opentracing/opentracing-go v1.1.0
-	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 )

--- a/instrumentation/cloud.google.com/go/iam/README.md
+++ b/instrumentation/cloud.google.com/go/iam/README.md
@@ -17,7 +17,7 @@ $ go get github.com/instana/go-sensor/instrumentation/cloud.google.com/go/iam
 Usage
 -----
 
-Currently this module is meant to be used together with [the Google Cloud Storage instrumentation](../storage) and
+Currently, this module is meant to be used together with [the Google Cloud Storage instrumentation](../storage) and
 limited to the Buckets IAM only.
 
 [godoc]: https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/cloud.google.com/go/iam

--- a/instrumentation/cloud.google.com/go/iam/iam.go
+++ b/instrumentation/cloud.google.com/go/iam/iam.go
@@ -23,7 +23,7 @@ type Resource struct {
 // Handle is an instrumented wrapper for cloud.google.com/go/iam.Handle
 // that traces calls made to Google Cloud IAM API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle for further details on wrapped type.
 type Handle struct {
 	*iam.Handle
 
@@ -33,7 +33,7 @@ type Handle struct {
 // Handle3 is an instrumented wrapper for cloud.google.com/go/iam.Handle3.
 // that traces calls made to Google Cloud IAM API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3 for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3 for further details on wrapped type.
 type Handle3 struct {
 	*iam.Handle3
 
@@ -43,7 +43,7 @@ type Handle3 struct {
 // V3 returns an instrumented cloud.google.com/go/iam.Handle3.
 // that traces requests to the Google Cloud API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.V3 for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.V3 for further details on wrapped method
 func (h *Handle) V3() *Handle3 {
 	return &Handle3{
 		Handle3:  h.Handle.V3(),
@@ -53,7 +53,7 @@ func (h *Handle) V3() *Handle3 {
 
 // Policy calls and traces the Policy() method of the wrapped cloud.google.com/go/iam.Handle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.Policy for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.Policy for further details on wrapped method
 func (h *Handle) Policy(ctx context.Context) (p *iam.Policy, err error) {
 	internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                   iamOpPrefix(h.Resource) + ".getIamPolicy",
@@ -66,7 +66,7 @@ func (h *Handle) Policy(ctx context.Context) (p *iam.Policy, err error) {
 
 // SetPolicy calls and traces the SetPolicy() method of the wrapped cloud.google.com/go/iam.Handle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.SetPolicy for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.SetPolicy for further details on wrapped method
 func (h *Handle) SetPolicy(ctx context.Context, policy *iam.Policy) (err error) {
 	internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                   iamOpPrefix(h.Resource) + ".setIamPolicy",
@@ -79,7 +79,7 @@ func (h *Handle) SetPolicy(ctx context.Context, policy *iam.Policy) (err error) 
 
 // TestPermissions calls and traces the TestPermissions() method of the wrapped cloud.google.com/go/iam.Handle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.TestPermissions for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle.TestPermissions for further details on wrapped method
 func (h *Handle) TestPermissions(ctx context.Context, permissions []string) (allowed []string, err error) {
 	internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                   iamOpPrefix(h.Resource) + ".testIamPermissions",
@@ -92,7 +92,7 @@ func (h *Handle) TestPermissions(ctx context.Context, permissions []string) (all
 
 // Policy calls and traces the Policy() method of the wrapped cloud.google.com/go/iam.Handle3.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3.Policy for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3.Policy for further details on wrapped method
 func (h *Handle3) Policy(ctx context.Context) (p *iam.Policy3, err error) {
 	internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                   iamOpPrefix(h.Resource) + ".getIamPolicy",
@@ -105,7 +105,7 @@ func (h *Handle3) Policy(ctx context.Context) (p *iam.Policy3, err error) {
 
 // SetPolicy calls and traces the SetPolicy() method of the wrapped cloud.google.com/go/iam.Handle3.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3.SetPolicy for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3.SetPolicy for further details on wrapped method
 func (h *Handle3) SetPolicy(ctx context.Context, policy *iam.Policy3) (err error) {
 	internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                   iamOpPrefix(h.Resource) + ".setIamPolicy",
@@ -118,7 +118,7 @@ func (h *Handle3) SetPolicy(ctx context.Context, policy *iam.Policy3) (err error
 
 // TestPermissions calls and traces the TestPermissions() method of the wrapped cloud.google.com/go/iam.Handle3.
 //
-// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3.TestPermissions for furter details on wrapped method
+// See https://pkg.go.dev/cloud.google.com/go/iam?tab=doc#Handle3.TestPermissions for further details on wrapped method
 func (h *Handle3) TestPermissions(ctx context.Context, permissions []string) (allowed []string, err error) {
 	internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                   iamOpPrefix(h.Resource) + ".testIamPermissions",

--- a/instrumentation/cloud.google.com/go/pubsub/README.md
+++ b/instrumentation/cloud.google.com/go/pubsub/README.md
@@ -17,11 +17,11 @@ $ go get github.com/instana/go-sensor/instrumentation/cloud.google.com/go/pubsub
 Usage
 -----
 
-This module is a drop-in replacement for `cloud.google.com/go/pubsub` in common publisher/subscriber use cases. It provides
+This module is a drop-in replacement for `cloud.google.com/go/pubsub` in a common publisher/subscriber use cases. It provides
 type aliases for `pubsub.Message`, `pubsub.PublishResult` and `pubsub.Subscription`, however if your code performs any
 configuration calls to the Pub/Sub API, such as [updating the topic configuration](https://pkg.go.dev/cloud.google.com/go/pubsub#example-Topic.Update) or [creating subscriptions](https://pkg.go.dev/cloud.google.com/go/pubsub#example-Client.CreateSubscription), you might need add the named import for `cloud.google.com/go/pubsub` as well.
 
-The instrumentation is implemented as a thin wrapper around service object methods and does not change their behavior. Thus
+The instrumentation is implemented as a thin wrapper around service object methods and does not change their behavior. Thus,
 any limitations/usage patterns/recommendations for the original method also apply to the wrapped one.
 
 In most cases it is enough to change the import path from `cloud.google.com/go/pubsub` to `github.com/instana/go-sensor/instrumentation/cloud.google.com/go/pubsub` and add an instance of [`instana.Sensor`][instana.Sensor] to the list of [`pubsub.NewClient()`][pubsub.NewClient] arguments to start tracing your communication over Google Cloud Pub/Sub with Instana.

--- a/instrumentation/cloud.google.com/go/pubsub/README.md
+++ b/instrumentation/cloud.google.com/go/pubsub/README.md
@@ -17,7 +17,7 @@ $ go get github.com/instana/go-sensor/instrumentation/cloud.google.com/go/pubsub
 Usage
 -----
 
-This module is a drop-in replacement for `cloud.google.com/go/pubsub` in a common publisher/subscriber use cases. It provides
+This module is a drop-in replacement for `cloud.google.com/go/pubsub` in common publisher/subscriber use cases. It provides
 type aliases for `pubsub.Message`, `pubsub.PublishResult` and `pubsub.Subscription`, however if your code performs any
 configuration calls to the Pub/Sub API, such as [updating the topic configuration](https://pkg.go.dev/cloud.google.com/go/pubsub#example-Topic.Update) or [creating subscriptions](https://pkg.go.dev/cloud.google.com/go/pubsub#example-Client.CreateSubscription), you might need add the named import for `cloud.google.com/go/pubsub` as well.
 

--- a/instrumentation/cloud.google.com/go/pubsub/pubsub.go
+++ b/instrumentation/cloud.google.com/go/pubsub/pubsub.go
@@ -28,7 +28,7 @@ type (
 // writes to and from Google Cloud Pub/Sub topics. It also  and ensures Instana trace propagation across
 // the Pub/Sub producers and consumers.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client for further details on wrapped type.
 type Client struct {
 	*pubsub.Client
 	projectID string
@@ -39,7 +39,7 @@ type Client struct {
 // NewClient returns a new wrapped cloud.google.com/go/pubsub.Client that uses provided instana.Sensor to
 // trace the publish/receive operations.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#NewClient for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#NewClient for further details on wrapped method.
 func NewClient(ctx context.Context, projectID string, sensor *instana.Sensor, opts ...option.ClientOption) (*Client, error) {
 	c, err := pubsub.NewClient(ctx, projectID, opts...)
 	return &Client{c, projectID, sensor}, err
@@ -47,7 +47,7 @@ func NewClient(ctx context.Context, projectID string, sensor *instana.Sensor, op
 
 // CreateTopic calls CreateTopic() of underlying Client and wraps the returned topic.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.CreateTopic for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.CreateTopic for further details on wrapped method.
 func (c *Client) CreateTopic(ctx context.Context, id string) (*Topic, error) {
 	top, err := c.Client.CreateTopic(ctx, id)
 	return &Topic{top, c.projectID, c.sensor}, err
@@ -55,7 +55,7 @@ func (c *Client) CreateTopic(ctx context.Context, id string) (*Topic, error) {
 
 // CreateTopicWithConfig calls CreateTopicWithConfig() of underlying Client and wraps returned topic.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.CreateTopicWithConfig for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.CreateTopicWithConfig for further details on wrapped method.
 func (c *Client) CreateTopicWithConfig(ctx context.Context, topicID string, tc *pubsub.TopicConfig) (*Topic, error) {
 	top, err := c.Client.CreateTopicWithConfig(ctx, topicID, tc)
 	return &Topic{top, c.projectID, c.sensor}, err
@@ -63,28 +63,28 @@ func (c *Client) CreateTopicWithConfig(ctx context.Context, topicID string, tc *
 
 // Topic calls Topic() of underlying Client and wraps the returned topic.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Topic for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Topic for further details on wrapped method.
 func (c *Client) Topic(id string) *Topic {
 	return &Topic{c.Client.Topic(id), c.projectID, c.sensor}
 }
 
 // TopicInProject calls TopicInProject() of underlying Client and wraps the returned topic.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.TopicInProject for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.TopicInProject for further details on wrapped method.
 func (c *Client) TopicInProject(id, projectID string) *Topic {
 	return &Topic{c.Client.TopicInProject(id, projectID), projectID, c.sensor}
 }
 
 // Topics calls Topics() of underlying Client and wraps the returned topic iterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Topics for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Topics for further details on wrapped method.
 func (c *Client) Topics(ctx context.Context) *TopicIterator {
 	return &TopicIterator{c.Client.Topics(ctx), c.projectID, c.sensor}
 }
 
 // CreateSubscription calls CreateSubscription() of underlying Client and wraps the returned subscription.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.CreateSubscription for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.CreateSubscription for further details on wrapped method.
 func (c *Client) CreateSubscription(ctx context.Context, id string, cfg pubsub.SubscriptionConfig) (*Subscription, error) {
 	sub, err := c.Client.CreateSubscription(ctx, id, cfg)
 	return &Subscription{sub, c.projectID, c.sensor}, err
@@ -92,21 +92,21 @@ func (c *Client) CreateSubscription(ctx context.Context, id string, cfg pubsub.S
 
 // Subscription calls Subscription() of underlying Client and wraps the returned subscription.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Subscription for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Subscription for further details on wrapped method.
 func (c *Client) Subscription(id string) *Subscription {
 	return &Subscription{c.Client.Subscription(id), c.projectID, c.sensor}
 }
 
 // SubscriptionInProject calls SubscriptionInProject() of underlying Client and wraps the returned subscription.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.SubscriptionInProject for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.SubscriptionInProject for further details on wrapped method.
 func (c *Client) SubscriptionInProject(id, projectID string) *Subscription {
 	return &Subscription{c.Client.SubscriptionInProject(id, projectID), projectID, c.sensor}
 }
 
 // Subscriptions calls Subscriptions() of underlying Client and wraps the returned subscription iterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Subscriptions for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Client.Subscriptions for further details on wrapped method.
 func (c *Client) Subscriptions(ctx context.Context) *SubscriptionIterator {
 	return &SubscriptionIterator{c.Client.Subscriptions(ctx), c.projectID, c.sensor}
 }

--- a/instrumentation/cloud.google.com/go/pubsub/subscription.go
+++ b/instrumentation/cloud.google.com/go/pubsub/subscription.go
@@ -17,7 +17,7 @@ import (
 // Subscription is an instrumented wrapper for cloud.google.com/go/pubsub.Subscription that traces Receive() calls
 // and ensures Instana trace propagation across the Pub/Sub producers and consumers.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Subscription for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Subscription for further details on wrapped type.
 type Subscription struct {
 	*pubsub.Subscription
 
@@ -29,7 +29,7 @@ type Subscription struct {
 // Receive wraps the Receive() call of the underlying cloud.google.com/go/pubsub.Subscription starting a new
 // entry span using the provided instana.Sensor and ensuring the trace continuation.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Subscription.Receive for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Subscription.Receive for further details on wrapped method.
 func (sub *Subscription) Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error {
 	return sub.Subscription.Receive(ctx, func(mCtx context.Context, msg *pubsub.Message) {
 		opts := []opentracing.StartSpanOption{
@@ -55,7 +55,7 @@ func (sub *Subscription) Receive(ctx context.Context, f func(context.Context, *p
 // SubscriptionIterator is a wrapper for cloud.google.com/go/pubsub.SubscriptionIterator that retrieves and instruments
 // subscriptions in a project.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#SubscriptionIterator for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#SubscriptionIterator for further details on wrapped type.
 type SubscriptionIterator struct {
 	*pubsub.SubscriptionIterator
 
@@ -66,7 +66,7 @@ type SubscriptionIterator struct {
 
 // Next fetches the next subscription in project via the wrapped SubscriptionIterator and returns its wrapped version.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#SubscriptionIterator.Next for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#SubscriptionIterator.Next for further details on wrapped method.
 func (it *SubscriptionIterator) Next() (*Subscription, error) {
 	sub, err := it.SubscriptionIterator.Next()
 	return &Subscription{sub, it.projectID, it.sensor}, err

--- a/instrumentation/cloud.google.com/go/pubsub/topic.go
+++ b/instrumentation/cloud.google.com/go/pubsub/topic.go
@@ -18,7 +18,7 @@ import (
 // Topic is an instrumented wrapper for cloud.google.com/go/pubsub.Topic that traces Publish() calls
 // and ensures Instana trace propagation across the Pub/Sub producers and consumers.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic for further details on wrapped type.
 type Topic struct {
 	*pubsub.Topic
 
@@ -31,7 +31,7 @@ type Topic struct {
 // The exit span created for this operation will be finished only after the message was submitted to
 // the server.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic.Publish for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic.Publish for further details on wrapped method.
 func (top *Topic) Publish(ctx context.Context, msg *pubsub.Message) *pubsub.PublishResult {
 	parent, ok := instana.SpanFromContext(ctx)
 	if !ok {
@@ -70,7 +70,7 @@ func (top *Topic) Publish(ctx context.Context, msg *pubsub.Message) *pubsub.Publ
 
 // Subscriptions calls Subscriptions() of underlying Topic and wraps the returned subscription iterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic.Subscriptions for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#Topic.Subscriptions for further details on wrapped method.
 func (top *Topic) Subscriptions(ctx context.Context) *SubscriptionIterator {
 	return &SubscriptionIterator{top.Topic.Subscriptions(ctx), top.projectID, top.sensor}
 }
@@ -78,7 +78,7 @@ func (top *Topic) Subscriptions(ctx context.Context) *SubscriptionIterator {
 // TopicIterator is a wrapper for cloud.google.com/go/pubsub.TopicIterator that retrieves and instruments
 // topics in a project.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#TopicIterator for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#TopicIterator for further details on wrapped type.
 type TopicIterator struct {
 	*pubsub.TopicIterator
 
@@ -89,7 +89,7 @@ type TopicIterator struct {
 
 // Next fetches the next topic in project via the wrapped TopicIterator and returns its wrapped version.
 //
-// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#TopicIterator.Next for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/pubsub?tab=doc#TopicIterator.Next for further details on wrapped method.
 func (it *TopicIterator) Next() (*Topic, error) {
 	top, err := it.TopicIterator.Next()
 	return &Topic{top, it.projectID, it.sensor}, err

--- a/instrumentation/cloud.google.com/go/storage/README.md
+++ b/instrumentation/cloud.google.com/go/storage/README.md
@@ -17,10 +17,10 @@ $ go get github.com/instana/go-sensor/instrumentation/cloud.google.com/go/storag
 Usage
 -----
 
-This module is a drop-in replacement for `cloud.google.com/go/storage`. However if your code references any value types,
+This module is a drop-in replacement for `cloud.google.com/go/storage`. However, if your code references any value types,
 e.g. `cloud.google.com/go/storage.ObjectAttrs`, you might need to add a named import for the original library as well.
 
-The instrumentation is implemented as a thin wrapper around service object methods and does not change their behavior. Thus
+The instrumentation is implemented as a thin wrapper around service object methods and does not change their behavior. Thus,
 any limitations/usage patterns/recommendations for the original method also apply to the wrapped one.
 
 In most cases changing the import path of `cloud.google.com/go/storage` should be enough:

--- a/instrumentation/cloud.google.com/go/storage/acl.go
+++ b/instrumentation/cloud.google.com/go/storage/acl.go
@@ -16,7 +16,7 @@ import (
 // ACLHandle is an instrumented wrapper for cloud.google.com/go/storage.ACLHandle
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle for further details on wrapped type.
 type ACLHandle struct {
 	*storage.ACLHandle
 	Bucket  string
@@ -26,7 +26,7 @@ type ACLHandle struct {
 
 // Delete calls and traces the Delete() method of the wrapped cloud.google.com/go/storage.ACLHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle.Delete for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle.Delete for further details on wrapped method.
 func (a *ACLHandle) Delete(ctx context.Context, entity storage.ACLEntity) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     aclOpPrefix(a) + ".delete",
@@ -42,7 +42,7 @@ func (a *ACLHandle) Delete(ctx context.Context, entity storage.ACLEntity) (err e
 
 // Set calls and traces the Set() method of the wrapped cloud.google.com/go/storage.ACLHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle.Set for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle.Set for further details on wrapped method.
 func (a *ACLHandle) Set(ctx context.Context, entity storage.ACLEntity, role storage.ACLRole) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     aclOpPrefix(a) + ".update",
@@ -58,7 +58,7 @@ func (a *ACLHandle) Set(ctx context.Context, entity storage.ACLEntity, role stor
 
 // List calls and traces the List() method of the wrapped cloud.google.com/go/storage.ACLHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle.List for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ACLHandle.List for further details on wrapped method.
 func (a *ACLHandle) List(ctx context.Context) (rules []storage.ACLRule, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     aclOpPrefix(a) + ".list",

--- a/instrumentation/cloud.google.com/go/storage/bucket.go
+++ b/instrumentation/cloud.google.com/go/storage/bucket.go
@@ -17,7 +17,7 @@ import (
 // BucketHandle is an instrumented wrapper for cloud.google.com/go/storage.BucketHandle
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle for further details on wrapped type.
 type BucketHandle struct {
 	*storage.BucketHandle
 	Name string
@@ -25,7 +25,7 @@ type BucketHandle struct {
 
 // Bucket returns an instrumented cloud.google.com/go/storage.BucketHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.Bucket for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.Bucket for further details on wrapped method.
 func (c *Client) Bucket(name string) *BucketHandle {
 	return &BucketHandle{
 		BucketHandle: c.Client.Bucket(name),
@@ -35,7 +35,7 @@ func (c *Client) Bucket(name string) *BucketHandle {
 
 // Create calls and traces the Create() method of the wrapped cloud.google.com/go/storage.BucketHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Create for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Create for further details on wrapped method.
 func (b *BucketHandle) Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "buckets.insert",
@@ -50,7 +50,7 @@ func (b *BucketHandle) Create(ctx context.Context, projectID string, attrs *stor
 
 // Delete calls and traces the Delete() method of the wrapped cloud.google.com/go/storage.BucketHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Delete for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Delete for further details on wrapped method.
 func (b *BucketHandle) Delete(ctx context.Context) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "buckets.delete",
@@ -64,7 +64,7 @@ func (b *BucketHandle) Delete(ctx context.Context) (err error) {
 
 // ACL returns an instrumented cloud.google.com/go/storage.ACLHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.ACL for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.ACL for further details on wrapped method.
 func (b *BucketHandle) ACL() *ACLHandle {
 	return &ACLHandle{
 		ACLHandle: b.BucketHandle.ACL(),
@@ -75,7 +75,7 @@ func (b *BucketHandle) ACL() *ACLHandle {
 // DefaultObjectACL returns an instrumented cloud.google.com/go/storage.ACLHandle, which provides
 // access to the bucket's default object ACLs.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.DefaultObjectACL for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.DefaultObjectACL for further details on wrapped method.
 func (b *BucketHandle) DefaultObjectACL() *ACLHandle {
 	return &ACLHandle{
 		ACLHandle: b.BucketHandle.DefaultObjectACL(),
@@ -87,7 +87,7 @@ func (b *BucketHandle) DefaultObjectACL() *ACLHandle {
 // Object returns an instrumented cloud.google.com/go/storage.ObjectHandle, which provides operations
 // on the named object.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Object for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Object for further details on wrapped method.
 func (b *BucketHandle) Object(name string) *ObjectHandle {
 	return &ObjectHandle{
 		ObjectHandle: b.BucketHandle.Object(name),
@@ -98,7 +98,7 @@ func (b *BucketHandle) Object(name string) *ObjectHandle {
 
 // Attrs calls and traces the Attrs() method of the wrapped cloud.google.com/go/storage.BucketHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Attrs for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Attrs for further details on wrapped method.
 func (b *BucketHandle) Attrs(ctx context.Context) (attrs *storage.BucketAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "buckets.get",
@@ -112,7 +112,7 @@ func (b *BucketHandle) Attrs(ctx context.Context) (attrs *storage.BucketAttrs, e
 
 // Update calls and traces the Update() method of the wrapped cloud.google.com/go/storage.BucketHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Update for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Update for further details on wrapped method.
 func (b *BucketHandle) Update(ctx context.Context, uattrs storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "buckets.patch",
@@ -126,7 +126,7 @@ func (b *BucketHandle) Update(ctx context.Context, uattrs storage.BucketAttrsToU
 
 // If returns an instrumented cloud.google.com/go/storage.BucketHandle that applies a set of preconditions.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.If for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.If for further details on wrapped method.
 func (b *BucketHandle) If(conds storage.BucketConditions) *BucketHandle {
 	return &BucketHandle{
 		BucketHandle: b.BucketHandle.If(conds),
@@ -137,7 +137,7 @@ func (b *BucketHandle) If(conds storage.BucketConditions) *BucketHandle {
 // UserProject returns an instrumented cloud.google.com/go/storage.BucketHandle that passes the project ID as the user
 // project for all subsequent calls.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.UserProject for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.UserProject for further details on wrapped method.
 func (b *BucketHandle) UserProject(projectID string) *BucketHandle {
 	return &BucketHandle{
 		BucketHandle: b.BucketHandle.UserProject(projectID),
@@ -147,7 +147,7 @@ func (b *BucketHandle) UserProject(projectID string) *BucketHandle {
 
 // LockRetentionPolicy calls and traces the LockRetentionPolicy() method of the wrapped cloud.google.com/go/storage.BucketHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.LockRetentionPolicy for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.LockRetentionPolicy for further details on wrapped method.
 func (b *BucketHandle) LockRetentionPolicy(ctx context.Context) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "buckets.lockRetentionPolicy",
@@ -162,7 +162,7 @@ func (b *BucketHandle) LockRetentionPolicy(ctx context.Context) (err error) {
 // Objects returns an instrumented object iterator that traces and proxies requests to
 // the underlying cloud.google.com/go/storage.ObjectIterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Objects for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.Objects for further details on wrapped method.
 func (b *BucketHandle) Objects(ctx context.Context, q *storage.Query) *ObjectIterator {
 	return &ObjectIterator{
 		ObjectIterator: b.BucketHandle.Objects(ctx, q),
@@ -174,7 +174,7 @@ func (b *BucketHandle) Objects(ctx context.Context, q *storage.Query) *ObjectIte
 // ObjectIterator is an instrumented wrapper for cloud.google.com/go/storage.ObjectIterator
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectIterator for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectIterator for further details on wrapped type.
 type ObjectIterator struct {
 	*storage.ObjectIterator
 	Bucket string
@@ -184,7 +184,7 @@ type ObjectIterator struct {
 // Next calls the Next() method of the wrapped iterator and creates a span for each call
 // that results in an API request.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectIterator.Next for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectIterator.Next for further details on wrapped method.
 func (it *ObjectIterator) Next() (attrs *storage.ObjectAttrs, err error) {
 	// don't trace calls returning buffered data
 	if it.ObjectIterator.PageInfo().Remaining() > 0 {
@@ -213,7 +213,7 @@ func (it *ObjectIterator) Next() (attrs *storage.ObjectAttrs, err error) {
 // Buckets returns an instrumented bucket iterator that traces and proxies requests to
 // the underlying cloud.google.com/go/storage.BucketIterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.Buckets for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.Buckets for further details on wrapped method.
 func (c *Client) Buckets(ctx context.Context, projectID string) *BucketIterator {
 	return &BucketIterator{
 		BucketIterator: c.Client.Buckets(ctx, projectID),
@@ -224,7 +224,7 @@ func (c *Client) Buckets(ctx context.Context, projectID string) *BucketIterator 
 
 // BucketIterator is an instrumented wrapper for cloud.google.com/go/storage.BucketIterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketIterator for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketIterator for further details on wrapped type.
 type BucketIterator struct {
 	*storage.BucketIterator
 	projectID string
@@ -234,7 +234,7 @@ type BucketIterator struct {
 // Next calls the Next() method of the wrapped iterator and creates a span for each call
 // that results in an API request.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketIterator.Next for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketIterator.Next for further details on wrapped method.
 func (it *BucketIterator) Next() (attrs *storage.BucketAttrs, err error) {
 	// don't trace calls returning buffered data
 	if it.BucketIterator.PageInfo().Remaining() > 0 {

--- a/instrumentation/cloud.google.com/go/storage/copy.go
+++ b/instrumentation/cloud.google.com/go/storage/copy.go
@@ -17,13 +17,13 @@ import (
 // CopierFrom returns an instrumented cloud.google.com/go/storage.Copier.
 //
 // See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.CopierFrom for further details on wrapped method.
-func (dst *ObjectHandle) CopierFrom(src *ObjectHandle) *Copier {
+func (o *ObjectHandle) CopierFrom(src *ObjectHandle) *Copier {
 	return &Copier{
-		Copier:            dst.ObjectHandle.CopierFrom(src.ObjectHandle),
+		Copier:            o.ObjectHandle.CopierFrom(src.ObjectHandle),
 		SourceBucket:      src.Bucket,
 		SourceName:        src.Name,
-		DestinationBucket: dst.Bucket,
-		DestinationName:   dst.Name,
+		DestinationBucket: o.Bucket,
+		DestinationName:   o.Name,
 	}
 }
 
@@ -57,7 +57,7 @@ func (c *Copier) Run(ctx context.Context) (attrs *storage.ObjectAttrs, err error
 // ComposerFrom returns an instrumented cloud.google.com/go/storage.Composer.
 //
 // See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ComposerFrom for further details on wrapped method.
-func (dst *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer {
+func (o *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer {
 	srcsCopy := make([]*storage.ObjectHandle, len(srcs))
 	sourceObjects := make([]string, len(srcs))
 	for i := range srcs {
@@ -66,9 +66,9 @@ func (dst *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer {
 	}
 
 	return &Composer{
-		Composer:          dst.ObjectHandle.ComposerFrom(srcsCopy...),
-		DestinationBucket: dst.Bucket,
-		DestinationName:   dst.Name,
+		Composer:          o.ObjectHandle.ComposerFrom(srcsCopy...),
+		DestinationBucket: o.Bucket,
+		DestinationName:   o.Name,
 		SourceObjects:     sourceObjects,
 	}
 }

--- a/instrumentation/cloud.google.com/go/storage/copy.go
+++ b/instrumentation/cloud.google.com/go/storage/copy.go
@@ -16,7 +16,7 @@ import (
 
 // CopierFrom returns an instrumented cloud.google.com/go/storage.Copier.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.CopierFrom for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.CopierFrom for further details on wrapped method.
 func (dst *ObjectHandle) CopierFrom(src *ObjectHandle) *Copier {
 	return &Copier{
 		Copier:            dst.ObjectHandle.CopierFrom(src.ObjectHandle),
@@ -30,7 +30,7 @@ func (dst *ObjectHandle) CopierFrom(src *ObjectHandle) *Copier {
 // Copier is an instrumented wrapper for cloud.google.com/go/storage.Copier
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Copier for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Copier for further details on wrapped type.
 type Copier struct {
 	*storage.Copier
 	SourceBucket, SourceName           string
@@ -39,7 +39,7 @@ type Copier struct {
 
 // Run calls and traces the Run() method of the wrapped Copier.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Copier.Run for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Copier.Run for further details on wrapped method.
 func (c *Copier) Run(ctx context.Context) (attrs *storage.ObjectAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                "objects.copy",
@@ -56,7 +56,7 @@ func (c *Copier) Run(ctx context.Context) (attrs *storage.ObjectAttrs, err error
 
 // ComposerFrom returns an instrumented cloud.google.com/go/storage.Composer.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ComposerFrom for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ComposerFrom for further details on wrapped method.
 func (dst *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer {
 	srcsCopy := make([]*storage.ObjectHandle, len(srcs))
 	sourceObjects := make([]string, len(srcs))
@@ -76,7 +76,7 @@ func (dst *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer {
 // Composer is an instrumented wrapper for cloud.google.com/go/storage.Composer.
 // that traces calls made to Google Cloud Storage API
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Composer for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Composer for further details on wrapped type.
 type Composer struct {
 	*storage.Composer
 	DestinationBucket, DestinationName string
@@ -85,7 +85,7 @@ type Composer struct {
 
 // Run calls and traces the Run() method of the wrapped cloud.google.com/go/storage.Composer.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Composer.Run for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Composer.Run for further details on wrapped method.
 func (c *Composer) Run(ctx context.Context) (attrs *storage.ObjectAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":                "objects.compose",

--- a/instrumentation/cloud.google.com/go/storage/hmac.go
+++ b/instrumentation/cloud.google.com/go/storage/hmac.go
@@ -17,7 +17,7 @@ import (
 // HMACKeyHandle is an instrumented wrapper for cloud.google.com/go/storage.HMACKeyHandle
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle for further details on wrapped type.
 type HMACKeyHandle struct {
 	*storage.HMACKeyHandle
 	ProjectID string
@@ -26,7 +26,7 @@ type HMACKeyHandle struct {
 
 // HMACKeyHandle returns an instrumented cloud.google.com/go/storage.HMACKeyHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.HMACKeyHandle for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.HMACKeyHandle for further details on wrapped method.
 func (c *Client) HMACKeyHandle(projectID, accessID string) *HMACKeyHandle {
 	return &HMACKeyHandle{
 		HMACKeyHandle: c.Client.HMACKeyHandle(projectID, accessID),
@@ -37,7 +37,7 @@ func (c *Client) HMACKeyHandle(projectID, accessID string) *HMACKeyHandle {
 
 // Get calls and traces the Get() method of the wrapped cloud.google.com/go/storage.HMACKeyHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Get for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Get for further details on wrapped method.
 func (hkh *HMACKeyHandle) Get(ctx context.Context, opts ...storage.HMACKeyOption) (hk *storage.HMACKey, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "hmacKeys.get",
@@ -52,7 +52,7 @@ func (hkh *HMACKeyHandle) Get(ctx context.Context, opts ...storage.HMACKeyOption
 
 // Delete calls and traces the Delete() method of the wrapped cloud.google.com/go/storage.HMACKeyHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Delete for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Delete for further details on wrapped method.
 func (hkh *HMACKeyHandle) Delete(ctx context.Context, opts ...storage.HMACKeyOption) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "hmacKeys.delete",
@@ -67,7 +67,7 @@ func (hkh *HMACKeyHandle) Delete(ctx context.Context, opts ...storage.HMACKeyOpt
 
 // CreateHMACKey calls and traces the CreateHMACKey() method of the wrapped cloud.google.com/go/storage.Client.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.CreateHMACKey for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.CreateHMACKey for further details on wrapped method.
 func (c *Client) CreateHMACKey(ctx context.Context, projectID, serviceAccountEmail string, opts ...storage.HMACKeyOption) (hk *storage.HMACKey, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "hmacKeys.create",
@@ -81,7 +81,7 @@ func (c *Client) CreateHMACKey(ctx context.Context, projectID, serviceAccountEma
 
 // Update calls and traces the Update() method of the wrapped cloud.google.com/go/storage.HMACKeyHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Update for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeyHandle.Update for further details on wrapped method.
 func (hkh *HMACKeyHandle) Update(ctx context.Context, au storage.HMACKeyAttrsToUpdate, opts ...storage.HMACKeyOption) (hk *storage.HMACKey, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "hmacKeys.update",
@@ -97,7 +97,7 @@ func (hkh *HMACKeyHandle) Update(ctx context.Context, au storage.HMACKeyAttrsToU
 // HMACKeysIterator is an instrumented wrapper for cloud.google.com/go/storage.HMACKeysIterator
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeysIterator for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeysIterator for further details on wrapped type.
 type HMACKeysIterator struct {
 	*storage.HMACKeysIterator
 	ProjectID string
@@ -107,7 +107,7 @@ type HMACKeysIterator struct {
 // ListHMACKeys returns an instrumented object iterator that traces and proxies requests to
 // the underlying cloud.google.com/go/storage.HMACKeysIterator.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.ListHMACKeys for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.ListHMACKeys for further details on wrapped method.
 func (c *Client) ListHMACKeys(ctx context.Context, projectID string, opts ...storage.HMACKeyOption) *HMACKeysIterator {
 	return &HMACKeysIterator{
 		HMACKeysIterator: c.Client.ListHMACKeys(ctx, projectID, opts...),
@@ -119,7 +119,7 @@ func (c *Client) ListHMACKeys(ctx context.Context, projectID string, opts ...sto
 // Next calls the Next() method of the wrapped iterator and creates a span for each call
 // that results in an API request.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeysIterator.Next for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#HMACKeysIterator.Next for further details on wrapped method.
 func (it *HMACKeysIterator) Next() (hk *storage.HMACKey, err error) {
 	// don't trace calls returning buffered data
 	if it.HMACKeysIterator.PageInfo().Remaining() > 0 {

--- a/instrumentation/cloud.google.com/go/storage/iam.go
+++ b/instrumentation/cloud.google.com/go/storage/iam.go
@@ -11,7 +11,7 @@ import (
 
 // IAM returns an instrumented wrapper for cloud.google.com/go/iam.Handle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.IAM for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#BucketHandle.IAM for further details on wrapped method.
 func (b *BucketHandle) IAM() *iam.Handle {
 	return &iam.Handle{
 		Handle: b.BucketHandle.IAM(),

--- a/instrumentation/cloud.google.com/go/storage/reader.go
+++ b/instrumentation/cloud.google.com/go/storage/reader.go
@@ -17,7 +17,7 @@ import (
 
 // NewReader returns an instrumented wrapper for cloud.google.com/go/storage.Reader for an object.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.NewReader for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.NewReader for further details on wrapped method.
 func (o *ObjectHandle) NewReader(ctx context.Context) (*Reader, error) {
 	return o.NewRangeReader(ctx, 0, -1)
 }
@@ -25,7 +25,7 @@ func (o *ObjectHandle) NewReader(ctx context.Context) (*Reader, error) {
 // NewRangeReader returns an instrumented wrapper for cloud.google.com/go/storage.Reader that reads
 // the object partially.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.NewRangeReader for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.NewRangeReader for further details on wrapped method.
 func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64) (r *Reader, err error) {
 	attrsCtx := internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "objects.get",
@@ -46,7 +46,7 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64)
 // Reader is an instrumented wrapper for cloud.google.com/go/storage.Reader
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Reader for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Reader for further details on wrapped type.
 type Reader struct {
 	*storage.Reader
 	ctx context.Context
@@ -57,7 +57,7 @@ type Reader struct {
 
 // Read calls and traces the Read() method of the wrapped cloud.google.com/go.Reader.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Reader.Read for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Reader.Read for further details on wrapped method.
 func (r *Reader) Read(p []byte) (n int, err error) {
 	tags := ot.Tags{
 		"gcs.op":     "objects.get",

--- a/instrumentation/cloud.google.com/go/storage/storage.go
+++ b/instrumentation/cloud.google.com/go/storage/storage.go
@@ -17,14 +17,14 @@ import (
 // Client is an instrumented wrapper for cloud.google.com/go/storage.Client
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client for further details on wrapped type.
 type Client struct {
 	*storage.Client
 }
 
 // NewClient returns a new wrapped cloud.google.com/go/storage.Client.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#NewClient for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#NewClient for further details on wrapped method.
 func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
 	c, err := storage.NewClient(ctx, opts...)
 	return &Client{Client: c}, err
@@ -33,7 +33,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
 // ObjectHandle is an instrumented wrapper for cloud.google.com/go/storage.ObjectHandle
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle for further details on wrapped type.
 type ObjectHandle struct {
 	*storage.ObjectHandle
 	Bucket string
@@ -43,7 +43,7 @@ type ObjectHandle struct {
 // ACL returns an instrumented cloud.google.com/go/storage.ACLHandle that provides access to the
 // object's access control list.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ACL for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ACL for further details on wrapped method.
 func (o *ObjectHandle) ACL() *ACLHandle {
 	return &ACLHandle{
 		ACLHandle: o.ObjectHandle.ACL(),
@@ -55,7 +55,7 @@ func (o *ObjectHandle) ACL() *ACLHandle {
 // Generation returns an instrumented cloud.google.com/go/storage.ObjectHandle that operates on a specific generation
 // of the object.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Generation for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Generation for further details on wrapped method.
 func (o *ObjectHandle) Generation(gen int64) *ObjectHandle {
 	return &ObjectHandle{
 		ObjectHandle: o.ObjectHandle.Generation(gen),
@@ -66,7 +66,7 @@ func (o *ObjectHandle) Generation(gen int64) *ObjectHandle {
 
 // If returns an instrumented cloud.google.com/go/storage.ObjectHandle that applies a set of preconditions.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.If for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.If for further details on wrapped method.
 func (o *ObjectHandle) If(conds storage.Conditions) *ObjectHandle {
 	return &ObjectHandle{
 		ObjectHandle: o.ObjectHandle.If(conds),
@@ -78,7 +78,7 @@ func (o *ObjectHandle) If(conds storage.Conditions) *ObjectHandle {
 // Key returns an instrumented cloud.google.com/go/storage.ObjectHandle that uses the supplied encryption
 // key to encrypt and decrypt the object's contents.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Key for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Key for further details on wrapped method.
 func (o *ObjectHandle) Key(encryptionKey []byte) *ObjectHandle {
 	return &ObjectHandle{
 		ObjectHandle: o.ObjectHandle.Key(encryptionKey),
@@ -89,7 +89,7 @@ func (o *ObjectHandle) Key(encryptionKey []byte) *ObjectHandle {
 
 // Attrs calls and traces the Attrs() method of the wrapped cloud.google.com/go/storage.ObjectHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Attrs for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Attrs for further details on wrapped method.
 func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *storage.ObjectAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "objects.attrs",
@@ -104,7 +104,7 @@ func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *storage.ObjectAttrs, e
 
 // Update calls and traces the Update() method of the wrapped cloud.google.com/go/storage.ObjectHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Update for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Update for further details on wrapped method.
 func (o *ObjectHandle) Update(ctx context.Context, uattrs storage.ObjectAttrsToUpdate) (oa *storage.ObjectAttrs, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "objects.patch",
@@ -119,7 +119,7 @@ func (o *ObjectHandle) Update(ctx context.Context, uattrs storage.ObjectAttrsToU
 
 // Delete calls and traces the Delete() method of the wrapped cloud.google.com/go/storage.ObjectHandle.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Delete for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.Delete for further details on wrapped method.
 func (o *ObjectHandle) Delete(ctx context.Context) (err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":     "objects.delete",
@@ -135,7 +135,7 @@ func (o *ObjectHandle) Delete(ctx context.Context) (err error) {
 // ReadCompressed returns an instrumented cloud.google.com/go/storage.ObjectHandle that performs reads without
 // decompressing when given true as an argument.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ReadCompressed for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.ReadCompressed for further details on wrapped method.
 func (o *ObjectHandle) ReadCompressed(compressed bool) *ObjectHandle {
 	return &ObjectHandle{
 		ObjectHandle: o.ObjectHandle.ReadCompressed(compressed),
@@ -147,7 +147,7 @@ func (o *ObjectHandle) ReadCompressed(compressed bool) *ObjectHandle {
 // NewWriter returns an instrumented cloud.google.com/go/storage.Writer
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.NewWriter for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#ObjectHandle.NewWriter for further details on wrapped method.
 func (o *ObjectHandle) NewWriter(ctx context.Context) *Writer {
 	return &Writer{
 		Writer: o.ObjectHandle.NewWriter(ctx),
@@ -158,7 +158,7 @@ func (o *ObjectHandle) NewWriter(ctx context.Context) *Writer {
 
 // ServiceAccount calls and traces the ServiceAccount() method of the wrapped cloud.google.com/go/storage.Client.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.ServiceAccount for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Client.ServiceAccount for further details on wrapped method.
 func (c *Client) ServiceAccount(ctx context.Context, projectID string) (email string, err error) {
 	ctx = internal.StartExitSpan(ctx, "gcs", ot.Tags{
 		"gcs.op":        "serviceAccount.get",

--- a/instrumentation/cloud.google.com/go/storage/writer.go
+++ b/instrumentation/cloud.google.com/go/storage/writer.go
@@ -17,7 +17,7 @@ import (
 // Writer is an instrumented wrapper for cloud.google.com/go/storage.Writer
 // that traces calls made to Google Cloud Storage API.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer for furter details on wrapped type.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer for further details on wrapped type.
 type Writer struct {
 	*storage.Writer
 	Bucket string
@@ -34,7 +34,7 @@ type Writer struct {
 // a single object insertion operation regardless of the number of Write() calls before the Writer
 // is closed.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer.Write for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer.Write for further details on wrapped method.
 func (w *Writer) Write(p []byte) (n int, err error) {
 	bucket := w.Writer.ObjectAttrs.Bucket
 	if bucket == "" {
@@ -56,7 +56,7 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 
 // Close closes the underlying cloud.google.com/go/storage.Writer and finalizes current exit span.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer.Close for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer.Close for further details on wrapped method.
 func (w *Writer) Close() error {
 	err := w.Writer.Close()
 
@@ -72,7 +72,7 @@ func (w *Writer) Close() error {
 
 // CloseWithError terminates any writes performed by this Writer with an error and finalizes current exit span.
 //
-// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer.CloseWithError for furter details on wrapped method.
+// See https://pkg.go.dev/cloud.google.com/go/storage?tab=doc#Writer.CloseWithError for further details on wrapped method.
 //
 // Deprecated: this method is added for compatibility with the cloud.google.com/go/storage.Writer interface, however
 // it is recommended to cancel the write operation using the context passed to NewWriter instead.

--- a/instrumentation/instalambda/README.md
+++ b/instrumentation/instalambda/README.md
@@ -51,7 +51,7 @@ func main() {
 ### Instrumenting a handler function
 
 To instrument a handler function passed to `lambda.Start()` or `lambda.StartWithContext()` first create an instrumented
-handler from it using [`instalambda.NewHandler()`][instalambda.NewHandler] and than pass it to `lambda.StartHandler()`:
+handler from it using [`instalambda.NewHandler()`][instalambda.NewHandler] and then pass it to `lambda.StartHandler()`:
 
 ```go
 func handle() {

--- a/instrumentation/instasarama/README.md
+++ b/instrumentation/instasarama/README.md
@@ -58,7 +58,7 @@ before passing it to the wrapped producer.
 ### Instrumenting `sarama.AsyncProducer`
 
 Similarly to `sarama.SyncProducer`, `instasarama` provides wrappers for constructor methods of `sarama.AsyncProducer` and expects
-the parent span context to be injected into message headers using using `instasarama.ProducerMessageWithSpan()`.
+the parent span context to be injected into message headers using `instasarama.ProducerMessageWithSpan()`.
 
 For more detailed example code please consult the [package documentation][godoc] or [example_async_producer_test.go](./example_async_producer_test.go).
 

--- a/instrumentation/instasarama/README.md
+++ b/instrumentation/instasarama/README.md
@@ -18,7 +18,11 @@ $ go get github.com/instana/go-sensor/instrumentation/instasarama
 Usage
 -----
 
-For detailed usage example see [the documentation][godoc] or [`example_test.go`](./example_test.go).
+For detailed usage examples see [the documentation][godoc] or the following links:
+- [Async producer example](./example_async_producer_test.go)
+- [Sync producer example](./example_sync_producer_test.go)
+- [Consumer_group example](./example_consumer_group_test.go)
+- [Consumer_example](./example_consumer_group_test.go)
 
 This instrumentation requires an instance of `instana.Sensor` to initialize spans and handle the trace context propagation.
 You can create a new instance of Instana sensor using `instana.NewSensor()`.

--- a/instrumentation/instasarama/partition_consumer_test.go
+++ b/instrumentation/instasarama/partition_consumer_test.go
@@ -54,12 +54,12 @@ func TestPartitionConsumer_Messages(t *testing.T) {
 	var collected []*sarama.ConsumerMessage
 	timeout := time.After(1 * time.Second)
 
-CONSUMER_LOOP:
+ConsumerLoop:
 	for {
 		select {
 		case msg, ok := <-wrapped.Messages():
 			if !ok {
-				break CONSUMER_LOOP
+				break ConsumerLoop
 			}
 			collected = append(collected, msg)
 		case <-timeout:

--- a/instrumentation/instasarama/partition_consumer_test.go
+++ b/instrumentation/instasarama/partition_consumer_test.go
@@ -54,12 +54,12 @@ func TestPartitionConsumer_Messages(t *testing.T) {
 	var collected []*sarama.ConsumerMessage
 	timeout := time.After(1 * time.Second)
 
-ConsumerLoop:
+CONSUMER_LOOP:
 	for {
 		select {
 		case msg, ok := <-wrapped.Messages():
 			if !ok {
-				break ConsumerLoop
+				break CONSUMER_LOOP
 			}
 			collected = append(collected, msg)
 		case <-timeout:

--- a/span_context.go
+++ b/span_context.go
@@ -185,8 +185,8 @@ func restoreFromW3CTraceState(trCtx w3ctrace.Context) SpanContext {
 }
 
 // ForeachBaggageItem belongs to the opentracing.SpanContext interface
-func (c SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
-	for k, v := range c.Baggage {
+func (sc SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
+	for k, v := range sc.Baggage {
 		if !handler(k, v) {
 			break
 		}
@@ -195,8 +195,8 @@ func (c SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
 
 // WithBaggageItem returns an entirely new SpanContext with the
 // given key:value baggage pair set.
-func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
-	res := c.Clone()
+func (sc SpanContext) WithBaggageItem(key, val string) SpanContext {
+	res := sc.Clone()
 
 	if res.Baggage == nil {
 		res.Baggage = make(map[string]string, 1)
@@ -207,20 +207,20 @@ func (c SpanContext) WithBaggageItem(key, val string) SpanContext {
 }
 
 // Clone returns a deep copy of a SpanContext
-func (c SpanContext) Clone() SpanContext {
+func (sc SpanContext) Clone() SpanContext {
 	res := SpanContext{
-		TraceIDHi:  c.TraceIDHi,
-		TraceID:    c.TraceID,
-		SpanID:     c.SpanID,
-		ParentID:   c.ParentID,
-		Sampled:    c.Sampled,
-		Suppressed: c.Suppressed,
-		W3CContext: c.W3CContext,
+		TraceIDHi:  sc.TraceIDHi,
+		TraceID:    sc.TraceID,
+		SpanID:     sc.SpanID,
+		ParentID:   sc.ParentID,
+		Sampled:    sc.Sampled,
+		Suppressed: sc.Suppressed,
+		W3CContext: sc.W3CContext,
 	}
 
-	if c.Baggage != nil {
-		res.Baggage = make(map[string]string, len(c.Baggage))
-		for k, v := range c.Baggage {
+	if sc.Baggage != nil {
+		res.Baggage = make(map[string]string, len(sc.Baggage))
+		for k, v := range sc.Baggage {
 			res.Baggage[k] = v
 		}
 	}


### PR DESCRIPTION
There are a few minor typos fixed. And some method receivers are renamed because they had different names in different places.