### PR TITLE
Extended w3 c trace context support in aws lambda

### DIFF
--- a/instrumentation/instalambda/go.mod
+++ b/instrumentation/instalambda/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/aws/aws-lambda-go v1.20.0
-	github.com/instana/go-sensor v1.24.0
+	github.com/instana/go-sensor v1.27.5
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/opentracing/opentracing-go v1.1.0
 )

--- a/instrumentation/instalambda/go.sum
+++ b/instrumentation/instalambda/go.sum
@@ -6,8 +6,10 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/instana/go-sensor v1.24.0 h1:l7nbiP5dNetEJzyAVsoNkvx6Qog0Unlj73SLvJy44QA=
-github.com/instana/go-sensor v1.24.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
+github.com/instana/go-sensor v1.27.0 h1:A/aCr0J3fY3hI3bc5nvcfcG/Rto8igMVEKUicwPsrJo=
+github.com/instana/go-sensor v1.27.0/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
+github.com/instana/go-sensor v1.27.5 h1:hHd+rY+q1dGDCm90siE+cu9Aa9Yf5LkN8CQ+bh3w91Q=
+github.com/instana/go-sensor v1.27.5/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65 h1:T25FL3WEzgmKB0m6XCJNZ65nw09/QIp3T1yXr487D+A=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65/go.mod h1:nYhEREG/B7HUY7P+LKOrqy53TpIqmJ9JyUShcaEKtGw=
 github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=

--- a/instrumentation/instalambda/handler_test.go
+++ b/instrumentation/instalambda/handler_test.go
@@ -35,261 +35,219 @@ func TestMain(m *testing.M) {
 }
 
 func TestNewHandler_APIGatewayEvent(t *testing.T) {
-	recorder := instana.NewTestRecorder()
-	sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
+	testCases := map[string]string{
+		"ApiGWVEvent":              "testdata/apigw_event.json",
+		"ApiGWVEventWithW3Context": "testdata/apigw_event_with_w3context.json",
+	}
 
-	payload, err := ioutil.ReadFile("testdata/apigw_event.json")
-	require.NoError(t, err)
+	for tc, fileName := range testCases {
+		t.Run(tc, func(t *testing.T) {
 
-	h := instalambda.NewHandler(func(ctx context.Context, evt *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-		_, ok := instana.SpanFromContext(ctx)
-		assert.True(t, ok)
+			recorder := instana.NewTestRecorder()
+			sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
 
-		return events.APIGatewayProxyResponse{
-			StatusCode: http.StatusOK,
-			Body:       "OK",
-		}, nil
-	}, sensor)
+			payload, err := ioutil.ReadFile(fileName)
+			require.NoError(t, err)
 
-	lambdacontext.FunctionName = "test-function"
-	lambdacontext.FunctionVersion = "42"
+			h := instalambda.NewHandler(func(ctx context.Context, evt *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+				_, ok := instana.SpanFromContext(ctx)
+				assert.True(t, ok)
 
-	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
-		AwsRequestID:       "req1",
-		InvokedFunctionArn: "aws:test-function",
-	})
+				return events.APIGatewayProxyResponse{
+					StatusCode: http.StatusOK,
+					Body:       "OK",
+				}, nil
+			}, sensor)
 
-	resp, err := h.Invoke(ctx, payload)
-	require.NoError(t, err)
+			lambdacontext.FunctionName = "test-function"
+			lambdacontext.FunctionVersion = "42"
 
-	assert.JSONEq(t, `{"statusCode":200,"headers":null,"multiValueHeaders":null,"body":"OK"}`, string(resp))
+			ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+				AwsRequestID:       "req1",
+				InvokedFunctionArn: "aws:test-function",
+			})
 
-	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+			resp, err := h.Invoke(ctx, payload)
+			require.NoError(t, err)
 
-	span := spans[0]
+			assert.JSONEq(t, `{"statusCode":200,"headers":null,"multiValueHeaders":null,"body":"OK"}`, string(resp))
 
-	assert.EqualValues(t, 0x1234, span.TraceID)
-	assert.EqualValues(t, 0x4567, span.ParentID)
-	assert.NotEqual(t, span.ParentID, span.SpanID)
+			spans := recorder.GetQueuedSpans()
+			require.Len(t, spans, 1)
 
-	require.Equal(t, "aws.lambda.entry", span.Name)
-	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
+			span := spans[0]
 
-	assert.Equal(t, instana.AWSLambdaSpanData{
-		Snapshot: instana.AWSLambdaSpanTags{
-			ARN:     "aws:test-function:42",
-			Runtime: "go",
-			Name:    "test-function",
-			Version: "42",
-			Trigger: "aws:api.gateway",
-		},
-		HTTP: &instana.HTTPSpanTags{
-			URL:          "/",
-			Method:       "GET",
-			PathTemplate: "/",
-			Params:       "multisecret=%3Credacted%3E&multisecret=%3Credacted%3E&q=term&secret=%3Credacted%3E&value=1&value=2",
-			Headers: map[string]string{
-				"X-Custom-Header-1": "value1",
-				"X-Custom-Header-2": "value2",
-			},
-		},
-	}, span.Data)
-}
+			assert.EqualValues(t, 0x1234, span.TraceID)
+			assert.EqualValues(t, 0x4567, span.ParentID)
+			assert.NotEqual(t, span.ParentID, span.SpanID)
 
-func TestNewHandler_APIGatewayV2Event(t *testing.T) {
-	recorder := instana.NewTestRecorder()
-	sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
+			require.Equal(t, "aws.lambda.entry", span.Name)
+			assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
 
-	payload, err := ioutil.ReadFile("testdata/apigw_v2_event.json")
-	require.NoError(t, err)
-
-	h := instalambda.NewHandler(func(ctx context.Context, evt *events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-		_, ok := instana.SpanFromContext(ctx)
-		assert.True(t, ok)
-
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: http.StatusOK,
-			Body:       "OK",
-		}, nil
-	}, sensor)
-
-	lambdacontext.FunctionName = "test-function"
-	lambdacontext.FunctionVersion = "42"
-
-	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
-		AwsRequestID:       "req1",
-		InvokedFunctionArn: "aws:test-function",
-	})
-
-	resp, err := h.Invoke(ctx, payload)
-	require.NoError(t, err)
-
-	assert.JSONEq(t, `{"statusCode":200,"headers":null,"multiValueHeaders":null,"body":"OK","cookies":null}`, string(resp))
-
-	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
-
-	span := spans[0]
-
-	assert.EqualValues(t, 0x1234, span.TraceID)
-	assert.EqualValues(t, 0x4567, span.ParentID)
-	assert.NotEqual(t, span.ParentID, span.SpanID)
-
-	require.Equal(t, "aws.lambda.entry", span.Name)
-	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
-
-	assert.Equal(t, instana.AWSLambdaSpanData{
-		Snapshot: instana.AWSLambdaSpanTags{
-			ARN:     "aws:test-function:42",
-			Runtime: "go",
-			Name:    "test-function",
-			Version: "42",
-			Trigger: "aws:api.gateway",
-		},
-		HTTP: &instana.HTTPSpanTags{
-			URL:          "/my/path",
-			Method:       "POST",
-			PathTemplate: "/my/{resource}",
-			Params:       "q=term&secret=%3Credacted%3E",
-			Headers: map[string]string{
-				"X-Custom-Header-1": "value1",
-				"X-Custom-Header-2": "value2",
-			},
-		},
-	}, span.Data)
+			assert.Equal(t, instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "aws:test-function:42",
+					Runtime: "go",
+					Name:    "test-function",
+					Version: "42",
+					Trigger: "aws:api.gateway",
+				},
+				HTTP: &instana.HTTPSpanTags{
+					URL:          "/",
+					Method:       "GET",
+					PathTemplate: "/",
+					Params:       "multisecret=%3Credacted%3E&multisecret=%3Credacted%3E&q=term&secret=%3Credacted%3E&value=1&value=2",
+					Headers: map[string]string{
+						"X-Custom-Header-1": "value1",
+						"X-Custom-Header-2": "value2",
+					},
+				},
+			}, span.Data)
+		})
+	}
 }
 
 func TestNewHandler_APIGatewayV2Event_WithW3Context(t *testing.T) {
-	testDataFileNames := []string{
-		"testdata/apigw_v2_event.json",
-		"testdata/apigw_v2_event_with_w3context.json",
+	testCases := map[string]string{
+		"ApiGWV2Event":              "testdata/apigw_v2_event.json",
+		"ApiGWV2EventWithW3Context": "testdata/apigw_v2_event_with_w3context.json",
 	}
 
-	for _, fileName := range testDataFileNames {
-		recorder := instana.NewTestRecorder()
-		sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
+	for tc, fileName := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			recorder := instana.NewTestRecorder()
+			sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
 
-		payload, err := ioutil.ReadFile(fileName)
-		require.NoError(t, err)
+			payload, err := ioutil.ReadFile(fileName)
+			require.NoError(t, err)
 
-		h := instalambda.NewHandler(func(ctx context.Context, evt *events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-			_, ok := instana.SpanFromContext(ctx)
-			assert.True(t, ok)
+			h := instalambda.NewHandler(func(ctx context.Context, evt *events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+				_, ok := instana.SpanFromContext(ctx)
+				assert.True(t, ok)
 
-			return events.APIGatewayV2HTTPResponse{
-				StatusCode: http.StatusOK,
-				Body:       "OK",
-			}, nil
-		}, sensor)
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: http.StatusOK,
+					Body:       "OK",
+				}, nil
+			}, sensor)
 
-		lambdacontext.FunctionName = "test-function"
-		lambdacontext.FunctionVersion = "42"
+			lambdacontext.FunctionName = "test-function"
+			lambdacontext.FunctionVersion = "42"
 
-		ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
-			AwsRequestID:       "req1",
-			InvokedFunctionArn: "aws:test-function",
-		})
+			ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+				AwsRequestID:       "req1",
+				InvokedFunctionArn: "aws:test-function",
+			})
 
-		resp, err := h.Invoke(ctx, payload)
-		require.NoError(t, err)
+			resp, err := h.Invoke(ctx, payload)
+			require.NoError(t, err)
 
-		assert.JSONEq(t, `{"statusCode":200,"headers":null,"multiValueHeaders":null,"body":"OK","cookies":null}`, string(resp))
+			assert.JSONEq(t, `{"statusCode":200,"headers":null,"multiValueHeaders":null,"body":"OK","cookies":null}`, string(resp))
 
-		spans := recorder.GetQueuedSpans()
-		require.Len(t, spans, 1)
+			spans := recorder.GetQueuedSpans()
+			require.Len(t, spans, 1)
 
-		span := spans[0]
+			span := spans[0]
 
-		assert.EqualValues(t, 0x1234, span.TraceID)
-		assert.EqualValues(t, 0x4567, span.ParentID)
-		assert.NotEqual(t, span.ParentID, span.SpanID)
+			assert.EqualValues(t, 0x1234, span.TraceID)
+			assert.EqualValues(t, 0x4567, span.ParentID)
+			assert.NotEqual(t, span.ParentID, span.SpanID)
 
-		require.Equal(t, "aws.lambda.entry", span.Name)
-		assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
+			require.Equal(t, "aws.lambda.entry", span.Name)
+			assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
 
-		assert.Equal(t, instana.AWSLambdaSpanData{
-			Snapshot: instana.AWSLambdaSpanTags{
-				ARN:     "aws:test-function:42",
-				Runtime: "go",
-				Name:    "test-function",
-				Version: "42",
-				Trigger: "aws:api.gateway",
-			},
-			HTTP: &instana.HTTPSpanTags{
-				URL:          "/my/path",
-				Method:       "POST",
-				PathTemplate: "/my/{resource}",
-				Params:       "q=term&secret=%3Credacted%3E",
-				Headers: map[string]string{
-					"X-Custom-Header-1": "value1",
-					"X-Custom-Header-2": "value2",
+			assert.Equal(t, instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "aws:test-function:42",
+					Runtime: "go",
+					Name:    "test-function",
+					Version: "42",
+					Trigger: "aws:api.gateway",
 				},
-			},
-		}, span.Data)
+				HTTP: &instana.HTTPSpanTags{
+					URL:          "/my/path",
+					Method:       "POST",
+					PathTemplate: "/my/{resource}",
+					Params:       "q=term&secret=%3Credacted%3E",
+					Headers: map[string]string{
+						"X-Custom-Header-1": "value1",
+						"X-Custom-Header-2": "value2",
+					},
+				},
+			}, span.Data)
+		})
 	}
 }
 
 func TestNewHandler_ALBEvent(t *testing.T) {
-	recorder := instana.NewTestRecorder()
-	sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
+	testCases := map[string]string{
+		"ALBEvent":         "testdata/alb_event.json",
+		"ALBWithW3Context": "testdata/alb_event_with_w3context.json",
+	}
 
-	payload, err := ioutil.ReadFile("testdata/alb_event.json")
-	require.NoError(t, err)
+	for tc, fileName := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			recorder := instana.NewTestRecorder()
+			sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
 
-	h := instalambda.NewHandler(func(ctx context.Context, evt *events.ALBTargetGroupRequest) (events.ALBTargetGroupResponse, error) {
-		_, ok := instana.SpanFromContext(ctx)
-		assert.True(t, ok)
+			payload, err := ioutil.ReadFile(fileName)
+			require.NoError(t, err)
 
-		return events.ALBTargetGroupResponse{
-			StatusCode: http.StatusOK,
-			Body:       "OK",
-		}, nil
-	}, sensor)
+			h := instalambda.NewHandler(func(ctx context.Context, evt *events.ALBTargetGroupRequest) (events.ALBTargetGroupResponse, error) {
+				_, ok := instana.SpanFromContext(ctx)
+				assert.True(t, ok)
 
-	lambdacontext.FunctionName = "test-function"
-	lambdacontext.FunctionVersion = "42"
+				return events.ALBTargetGroupResponse{
+					StatusCode: http.StatusOK,
+					Body:       "OK",
+				}, nil
+			}, sensor)
 
-	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
-		AwsRequestID:       "req1",
-		InvokedFunctionArn: "aws:test-function",
-	})
+			lambdacontext.FunctionName = "test-function"
+			lambdacontext.FunctionVersion = "42"
 
-	resp, err := h.Invoke(ctx, payload)
-	require.NoError(t, err)
+			ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+				AwsRequestID:       "req1",
+				InvokedFunctionArn: "aws:test-function",
+			})
 
-	assert.JSONEq(t, `{"statusCode":200,"statusDescription":"","headers":null,"multiValueHeaders":null,"body":"OK","isBase64Encoded":false}`, string(resp))
+			resp, err := h.Invoke(ctx, payload)
+			require.NoError(t, err)
 
-	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+			assert.JSONEq(t, `{"statusCode":200,"statusDescription":"","headers":null,"multiValueHeaders":null,"body":"OK","isBase64Encoded":false}`, string(resp))
 
-	span := spans[0]
+			spans := recorder.GetQueuedSpans()
+			require.Len(t, spans, 1)
 
-	assert.EqualValues(t, 0x1234, span.TraceID)
-	assert.EqualValues(t, 0x4567, span.ParentID)
-	assert.NotEqual(t, span.ParentID, span.SpanID)
+			span := spans[0]
 
-	require.Equal(t, "aws.lambda.entry", span.Name)
-	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
+			assert.EqualValues(t, 0x1234, span.TraceID)
+			assert.EqualValues(t, 0x4567, span.ParentID)
+			assert.NotEqual(t, span.ParentID, span.SpanID)
 
-	assert.Equal(t, instana.AWSLambdaSpanData{
-		Snapshot: instana.AWSLambdaSpanTags{
-			ARN:     "aws:test-function:42",
-			Runtime: "go",
-			Name:    "test-function",
-			Version: "42",
-			Trigger: "aws:application.load.balancer",
-		},
-		HTTP: &instana.HTTPSpanTags{
-			URL:    "/lambda",
-			Method: "GET",
-			Params: "multikey=%3Credacted%3E&multikey=%3Credacted%3E&multisecret=%3Credacted%3E&multisecret=%3Credacted%3E&query=1234ABCD&secret=%3Credacted%3E",
-			Headers: map[string]string{
-				"X-Custom-Header-1": "value1",
-				"X-Custom-Header-2": "value2",
-			},
-		},
-	}, span.Data)
+			require.Equal(t, "aws.lambda.entry", span.Name)
+			assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
+
+			assert.Equal(t, instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "aws:test-function:42",
+					Runtime: "go",
+					Name:    "test-function",
+					Version: "42",
+					Trigger: "aws:application.load.balancer",
+				},
+				HTTP: &instana.HTTPSpanTags{
+					URL:    "/lambda",
+					Method: "GET",
+					Params: "multikey=%3Credacted%3E&multikey=%3Credacted%3E&multisecret=%3Credacted%3E&multisecret=%3Credacted%3E&query=1234ABCD&secret=%3Credacted%3E",
+					Headers: map[string]string{
+						"X-Custom-Header-1": "value1",
+						"X-Custom-Header-2": "value2",
+					},
+				},
+			}, span.Data)
+		})
+	}
 }
 
 func TestNewHandler_CloudWatchEvent(t *testing.T) {

--- a/instrumentation/instalambda/testdata/alb_event_with_instana_headers_and_w3context.json
+++ b/instrumentation/instalambda/testdata/alb_event_with_instana_headers_and_w3context.json
@@ -1,0 +1,42 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/lambda-279XGJDqGZ5rsrHC2Fjr/49e9d65c45c6791a"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/lambda",
+  "queryStringParameters": {
+    "query": "1234ABCD",
+    "secret": "key"
+  },
+  "multiValueQueryStringParameters": {
+    "multikey": ["value1", "value2"],
+    "multisecret": ["key1", "key2"]
+  },
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+    "accept-encoding": "gzip",
+    "accept-language": "en-US,en;q=0.9",
+    "connection": "keep-alive",
+    "host": "lambda-alb-123578498.us-east-2.elb.amazonaws.com",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+    "x-amzn-trace-id": "Root=1-5c536348-3d683b8b04734faae651f476",
+    "x-forwarded-for": "72.12.164.125",
+    "x-forwarded-port": "80",
+    "x-forwarded-proto": "http",
+    "x-imforwards": "20",
+    "X-Instana-T": "0000000000001234",
+    "X-Instana-S": "0000000000004567",
+    "X-Instana-L": "1",
+    "traceparent": "00-00000000000000000000000000008888-0000000000009999-01",
+    "tracestate":  "in=1314;2435,rojo=0000000000009999",
+    "x-custom-header-1": "value1"
+  },
+  "multiValueHeaders": {
+    "x-custom-header-2": ["value2", "value3"]
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/instrumentation/instalambda/testdata/alb_event_with_w3context.json
+++ b/instrumentation/instalambda/testdata/alb_event_with_w3context.json
@@ -1,0 +1,39 @@
+{
+    "requestContext": {
+        "elb": {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/lambda-279XGJDqGZ5rsrHC2Fjr/49e9d65c45c6791a"
+        }
+    },
+    "httpMethod": "GET",
+    "path": "/lambda",
+    "queryStringParameters": {
+        "query": "1234ABCD",
+        "secret": "key"
+    },
+    "multiValueQueryStringParameters": {
+        "multikey": ["value1", "value2"],
+        "multisecret": ["key1", "key2"]
+    },
+    "headers": {
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+        "accept-encoding": "gzip",
+        "accept-language": "en-US,en;q=0.9",
+        "connection": "keep-alive",
+        "host": "lambda-alb-123578498.us-east-2.elb.amazonaws.com",
+        "upgrade-insecure-requests": "1",
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+        "x-amzn-trace-id": "Root=1-5c536348-3d683b8b04734faae651f476",
+        "x-forwarded-for": "72.12.164.125",
+        "x-forwarded-port": "80",
+        "x-forwarded-proto": "http",
+        "x-imforwards": "20",
+        "traceparent": "00-00000000000000000000000000001234-0000000000004567-01",
+        "tracestate":  "in=1314;2435,rojo=0000000000004567",
+        "x-custom-header-1": "value1"
+    },
+    "multiValueHeaders": {
+        "x-custom-header-2": ["value2", "value3"]
+    },
+    "body": "",
+    "isBase64Encoded": false
+}

--- a/instrumentation/instalambda/testdata/apigw_event_with_instana_headers_and_w3context.json
+++ b/instrumentation/instalambda/testdata/apigw_event_with_instana_headers_and_w3context.json
@@ -1,0 +1,116 @@
+{
+  "resource": "/",
+  "path": "/",
+  "httpMethod": "POST",
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "cookie": "s_fid=7AAB6XMPLAFD9BBF-0643XMPL09956DE2; regStatus=pre-register",
+    "Host": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+    "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
+    "X-Forwarded-For": "52.255.255.12",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https",
+    "X-Instana-T": "0000000000001234",
+    "X-Instana-S": "0000000000004567",
+    "X-Instana-L": "1",
+    "traceparent": "00-00000000000000000000000000008888-0000000000009999-01",
+    "tracestate":  "in=1314;2435,rojo=0000000000009999",
+    "x-custom-header-1": "value1"
+  },
+  "multiValueHeaders": {
+    "accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+    ],
+    "accept-encoding": [
+      "gzip, deflate, br"
+    ],
+    "accept-language": [
+      "en-US,en;q=0.9"
+    ],
+    "cookie": [
+      "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2; regStatus=pre-register;"
+    ],
+    "Host": [
+      "70ixmpl4fl.execute-api.ca-central-1.amazonaws.com"
+    ],
+    "sec-fetch-dest": [
+      "document"
+    ],
+    "sec-fetch-mode": [
+      "navigate"
+    ],
+    "sec-fetch-site": [
+      "none"
+    ],
+    "upgrade-insecure-requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-5e66d96f-7491f09xmpl79d18acf3d050"
+    ],
+    "X-Forwarded-For": [
+      "52.255.255.12"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ],
+    "x-custom-header-2": [
+      "value2"
+    ]
+  },
+  "queryStringParameters": {
+    "q": "term",
+    "secret": "key"
+  },
+  "multiValueQueryStringParameters": {
+    "value": ["1", "2"],
+    "multisecret": ["key1", "key2"]
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "2gxmpl",
+    "resourcePath": "/",
+    "httpMethod": "GET",
+    "extendedRequestId": "JJbxmplHYosFVYQ=",
+    "requestTime": "10/Mar/2020:00:03:59 +0000",
+    "path": "/Prod/",
+    "accountId": "123456789012",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "domainPrefix": "70ixmpl4fl",
+    "requestTimeEpoch": 1583798639428,
+    "requestId": "77375676-xmpl-4b79-853a-f982474efe18",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "52.255.255.12",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+      "user": null
+    },
+    "domainName": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
+    "apiId": "70ixmpl4fl"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/instrumentation/instalambda/testdata/apigw_event_with_w3context.json
+++ b/instrumentation/instalambda/testdata/apigw_event_with_w3context.json
@@ -1,0 +1,113 @@
+{
+  "resource": "/",
+  "path": "/",
+  "httpMethod": "GET",
+  "headers": {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br",
+    "accept-language": "en-US,en;q=0.9",
+    "cookie": "s_fid=7AAB6XMPLAFD9BBF-0643XMPL09956DE2; regStatus=pre-register",
+    "Host": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+    "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
+    "X-Forwarded-For": "52.255.255.12",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https",
+    "traceparent": "00-00000000000000000000000000001234-0000000000004567-01",
+    "tracestate":  "in=1314;2435,rojo=0000000000004567",
+    "x-custom-header-1": "value1"
+  },
+  "multiValueHeaders": {
+    "accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+    ],
+    "accept-encoding": [
+      "gzip, deflate, br"
+    ],
+    "accept-language": [
+      "en-US,en;q=0.9"
+    ],
+    "cookie": [
+      "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2; regStatus=pre-register;"
+    ],
+    "Host": [
+      "70ixmpl4fl.execute-api.ca-central-1.amazonaws.com"
+    ],
+    "sec-fetch-dest": [
+      "document"
+    ],
+    "sec-fetch-mode": [
+      "navigate"
+    ],
+    "sec-fetch-site": [
+      "none"
+    ],
+    "upgrade-insecure-requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-5e66d96f-7491f09xmpl79d18acf3d050"
+    ],
+    "X-Forwarded-For": [
+      "52.255.255.12"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ],
+    "x-custom-header-2": [
+      "value2"
+    ]
+  },
+  "queryStringParameters": {
+    "q": "term",
+    "secret": "key"
+  },
+  "multiValueQueryStringParameters": {
+    "value": ["1", "2"],
+    "multisecret": ["key1", "key2"]
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "2gxmpl",
+    "resourcePath": "/",
+    "httpMethod": "GET",
+    "extendedRequestId": "JJbxmplHYosFVYQ=",
+    "requestTime": "10/Mar/2020:00:03:59 +0000",
+    "path": "/Prod/",
+    "accountId": "123456789012",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "domainPrefix": "70ixmpl4fl",
+    "requestTimeEpoch": 1583798639428,
+    "requestId": "77375676-xmpl-4b79-853a-f982474efe18",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "52.255.255.12",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+      "user": null
+    },
+    "domainName": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
+    "apiId": "70ixmpl4fl"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/instrumentation/instalambda/testdata/apigw_v2_event_with_instana_headers_and_w3context.json
+++ b/instrumentation/instalambda/testdata/apigw_v2_event_with_instana_headers_and_w3context.json
@@ -1,0 +1,76 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /my/{resource}",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "cookie1",
+    "cookie2"
+  ],
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value1,value2",
+    "X-Instana-T": "0000000000001234",
+    "X-Instana-S": "0000000000004567",
+    "X-Instana-L": "1",
+    "traceparent": "00-00000000000000000000000000008888-0000000000009999-01",
+    "tracestate":  "in=1314;2435,rojo=0000000000009999",
+    "X-Custom-Header-1": "value1",
+    "x-custom-header-2": "value2"
+  },
+  "queryStringParameters": {
+    "secret": "key",
+    "q": "term"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "claim1": "value1",
+          "claim2": "value2"
+        },
+        "scopes": [
+          "scope1",
+          "scope2"
+        ]
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "Hello from Lambda",
+  "pathParameters": {
+    "parameter1": "value1"
+  },
+  "isBase64Encoded": false,
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  }
+}

--- a/instrumentation/instalambda/testdata/apigw_v2_event_with_w3context.json
+++ b/instrumentation/instalambda/testdata/apigw_v2_event_with_w3context.json
@@ -1,0 +1,73 @@
+{
+  "version": "2.0",
+  "routeKey": "ANY /my/{resource}",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "cookie1",
+    "cookie2"
+  ],
+  "headers": {
+    "Header1": "value1",
+      "Header2": "value1,value2",
+      "traceparent": "00-00000000000000000000000000001234-0000000000004567-01",
+      "tracestate":  "in=1314;2435,rojo=0000000000004567",
+      "X-Custom-Header-1": "value1",
+      "x-custom-header-2": "value2"
+  },
+  "queryStringParameters": {
+      "secret": "key",
+      "q": "term"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "claim1": "value1",
+          "claim2": "value2"
+        },
+        "scopes": [
+          "scope1",
+          "scope2"
+        ]
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "Hello from Lambda",
+  "pathParameters": {
+    "parameter1": "value1"
+  },
+  "isBase64Encoded": false,
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  }
+}


### PR DESCRIPTION
This PR enables the use of w3 trace context headers, in case of Instana headers are absent. 

It is done by increasing the version of the go-sensor package which already contains all necessary logic.

In addition to that, there are few test cases, that test this behavior.