### PR TITLE
When Instana headers were corrupted, use w3Context and do not return en error

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -178,7 +178,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 
 	// reset the trace IDs if a correlation ID has been provided
 	if spanContext.Correlation.ID != "" {
-		resetSpanContextIDs(&spanContext)
+		spanContext.TraceIDHi, spanContext.TraceID, spanContext.SpanID = 0, 0, 0
 
 		return spanContext, nil
 	}
@@ -198,18 +198,15 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		if spanContext.W3CContext.IsZero() {
 			return spanContext, ot.ErrSpanContextCorrupted
 		} else {
-			// Reset the trace IDs and return spanContext
-			resetSpanContextIDs(&spanContext)
-			return spanContext, nil
+			// Return SpanContext with w3 context, ignore other values
+			return SpanContext{
+				W3CContext: spanContext.W3CContext,
+			}, nil
 		}
 
 	}
 
 	return spanContext, nil
-}
-
-func resetSpanContextIDs(spanContext *SpanContext) {
-	spanContext.TraceIDHi, spanContext.TraceID, spanContext.SpanID = 0, 0, 0
 }
 
 func addW3CTraceContext(h http.Header, sc SpanContext) {

--- a/propagation.go
+++ b/propagation.go
@@ -192,8 +192,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		(spanContext.SpanID == 0 != (spanContext.TraceIDHi == 0 && spanContext.TraceID == 0)) {
 		sensor.logger.Debug("broken Instana trace context:",
 			" SpanID=", FormatID(spanContext.SpanID),
-			" TraceID=", FormatID(spanContext.TraceID),
-			" TraceIDHi=", FormatID(spanContext.TraceIDHi))
+			" TraceID=", FormatLongID(spanContext.TraceIDHi, spanContext.TraceID))
 
 		// Check if w3 context was found or not
 		if spanContext.W3CContext.IsZero() {

--- a/propagation.go
+++ b/propagation.go
@@ -178,7 +178,13 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		return spanContext, ot.ErrSpanContextNotFound
 	}
 
-	if !spanContext.Suppressed && (spanContext.SpanID == 0 != (spanContext.TraceIDHi == 0 && spanContext.TraceID == 0)) {
+	// when the context is not suppressed
+	// and instana headers either can not be parsed or present partially
+	// and w3 context is not there
+	if !spanContext.Suppressed &&
+		(spanContext.SpanID == 0 != (spanContext.TraceIDHi == 0 && spanContext.TraceID == 0)) &&
+		spanContext.W3CContext.IsZero() {
+
 		return spanContext, ot.ErrSpanContextCorrupted
 	}
 

--- a/propagation.go
+++ b/propagation.go
@@ -115,7 +115,7 @@ func injectTraceContext(sc SpanContext, opaqueCarrier interface{}) error {
 }
 
 // This method searches for Instana headers (FieldT, FieldS, FieldL and header with name prefixed with FieldB)
-// and try to parse their values. It also tries to extract w3 context and assign it inside returned object. W3 context
+// and try to parse their values. It also tries to extract W3C context and assign it inside returned object. W3C context
 // will be propagated further and can be used as a fallback.
 func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 	spanContext := SpanContext{

--- a/propagation.go
+++ b/propagation.go
@@ -150,7 +150,7 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 				return ot.ErrSpanContextCorrupted
 			}
 		case FieldL:
-			// When FieldL is presented and equal to "0", then spanContext is suppressed.
+			// When FieldL is present and equals to "0", then spanContext is suppressed.
 			// In addition to that non-empty correlation data may be extracted.
 			suppressed, corrData, err := parseLevel(v)
 			if err != nil {

--- a/propagation.go
+++ b/propagation.go
@@ -190,17 +190,17 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 	// When the context is not suppressed and one of Instana ID headers set.
 	if !spanContext.Suppressed &&
 		(spanContext.SpanID == 0 != (spanContext.TraceIDHi == 0 && spanContext.TraceID == 0)) {
-		sensor.logger.Debug("only one Instana header present",
+		sensor.logger.Debug("only one of Instana ID headers present",
 			" SpanID=", spanContext.SpanID,
 			" TraceID=", spanContext.TraceID,
 			" TraceIDHi=", spanContext.TraceIDHi)
 
-		// check if w3 context was found
+		// Check if w3 context was found
 		if spanContext.W3CContext.IsZero() {
 			return spanContext, ot.ErrSpanContextCorrupted
 		}
 
-		// reset the trace IDs
+		// Reset the trace IDs
 		resetSpanContextIDs(&spanContext)
 	}
 

--- a/propagation.go
+++ b/propagation.go
@@ -140,13 +140,11 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 		case FieldT:
 			spanContext.TraceIDHi, spanContext.TraceID, err = ParseLongID(v)
 			if err != nil {
-				sensor.logger.Debug("extract trace context ", FieldT, "=", v, " : ", err)
 				return ot.ErrSpanContextCorrupted
 			}
 		case FieldS:
 			spanContext.SpanID, err = ParseID(v)
 			if err != nil {
-				sensor.logger.Debug("extract trace context ", FieldT, "=", v, " : ", err)
 				return ot.ErrSpanContextCorrupted
 			}
 		case FieldL:

--- a/propagation.go
+++ b/propagation.go
@@ -194,16 +194,15 @@ func extractTraceContext(opaqueCarrier interface{}) (SpanContext, error) {
 			" SpanID=", FormatID(spanContext.SpanID),
 			" TraceID=", FormatLongID(spanContext.TraceIDHi, spanContext.TraceID))
 
-		// Check if w3 context was found or not
-		if spanContext.W3CContext.IsZero() {
-			return spanContext, ot.ErrSpanContextCorrupted
-		} else {
+		// Check if w3 context was found
+		if !spanContext.W3CContext.IsZero() {
 			// Return SpanContext with w3 context, ignore other values
 			return SpanContext{
 				W3CContext: spanContext.W3CContext,
 			}, nil
 		}
 
+		return spanContext, ot.ErrSpanContextCorrupted
 	}
 
 	return spanContext, nil


### PR DESCRIPTION
Proposal to not return an error (ot.ErrSpanContextCorrupted) while extracting a trace context, for a case:

- when the context is not suppressed
- Instana headers either can not be parsed or present partially

But **w3 context is there** 