### PR TITLE
always read a response body, to enable connection reuse

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -280,7 +280,7 @@ func (agent *agentS) fullRequestResponse(url string, method string, data interfa
 					}
 				}
 
-				io.Copy(io.Discard, resp.Body)
+				io.Copy(ioutil.Discard, resp.Body)
 			}
 		}
 	}

--- a/agent.go
+++ b/agent.go
@@ -280,7 +280,7 @@ func (agent *agentS) fullRequestResponse(url string, method string, data interfa
 					}
 				}
 
-				io.Copy(ioutil.Discard, resp.Body)
+				io.CopyN(ioutil.Discard, resp.Body, 256 << 10)
 			}
 		}
 	}

--- a/agent.go
+++ b/agent.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -278,6 +279,8 @@ func (agent *agentS) fullRequestResponse(url string, method string, data interfa
 						ret = resp.Header.Get(header)
 					}
 				}
+
+				io.Copy(io.Discard, resp.Body)
 			}
 		}
 	}


### PR DESCRIPTION
Reading a Body together with closing it will allow the reuse of underlying network resources. According to https://github.com/golang/go/blob/a72622d028077643169dc48c90271a82021f0534/src/net/http/client.go#L562