### PR TITLE
Requeue spans safely

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -113,7 +113,9 @@ func (r *Recorder) Flush(ctx context.Context) error {
 		r.Lock()
 		defer r.Unlock()
 
-		r.spans = append(r.spans, spansToSend...)
+		// put failed spans in front of the queue to make sure they are evicted first
+		// whenever the queue length exceeds options.MaxBufferedSpans
+		r.spans = append(spansToSend, r.spans...)
 
 		return fmt.Errorf("failed to send collected spans to the agent: %s", err)
 	}

--- a/recorder.go
+++ b/recorder.go
@@ -110,7 +110,11 @@ func (r *Recorder) Flush(ctx context.Context) error {
 	}
 
 	if err := sensor.Agent().SendSpans(spansToSend); err != nil {
+		r.Lock()
+		defer r.Unlock()
+
 		r.spans = append(r.spans, spansToSend...)
+
 		return fmt.Errorf("failed to send collected spans to the agent: %s", err)
 	}
 


### PR DESCRIPTION
This PR updates the span collector to safely re-queue spans in case the submission attempt has failed by acquiring the lock before modifying the span queue and putting them to the beginning of the queue, so they are evicted first should we truncate the buffer.