### PR TITLE
Avoid panicking while instrumenting the same DB driver twice

### DIFF
--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -17,6 +17,18 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+func TestInstrumentSQLDriver(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
+		Service: "go-sensor-test",
+	}, recorder))
+
+	instana.InstrumentSQLDriver(s, "test_register_driver", sqlDriver{})
+	assert.NotPanics(t, func() {
+		instana.InstrumentSQLDriver(s, "test_register_driver", sqlDriver{})
+	})
+}
+
 func TestOpenSQLDB(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{


### PR DESCRIPTION
This PR addresses an issue when a database driver instrumentation with `instana.InstrumentSQLDriver()` may panic in case the same driver is instrumented twice. The panic is caused by an attempt to register a driver with the same name via `sql.Register()` and generally should not be the case, however we would like to avoid crashing the service in case of double instrumentation.