### PR TITLE
add new span type for AWS Invoke

### DIFF
--- a/registered_span_test.go
+++ b/registered_span_test.go
@@ -58,6 +58,10 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 			Operation: "dynamodb",
 			Expected:  instana.AWSDynamoDBSpanData{},
 		},
+		"aws invoke": {
+			Operation: "aws.lambda.invoke",
+			Expected:  instana.AWSLambdaInvokeSpanData{},
+		},
 	}
 
 	for name, example := range examples {


### PR DESCRIPTION
This PR contains a definition of the new span for AWS Invoke and the new version number. It was created based on https://github.com/instana/go-sensor/pull/226.