### PR TITLE
add support for the direct lambda invocation

### DIFF
--- a/instrumentation/instalambda/handler_test.go
+++ b/instrumentation/instalambda/handler_test.go
@@ -535,3 +535,119 @@ func TestNewHandler_PreferInstanaHeadersToW3ContextHeaders(t *testing.T) {
 		})
 	}
 }
+
+func TestNewHandler_InvokeLambda_Success(t *testing.T) {
+	testCases := map[string]*lambdacontext.LambdaContext{
+		"Invoke_WithInstanaHeadersOnly": {
+			AwsRequestID:       "req1",
+			InvokedFunctionArn: "aws:test-function",
+			ClientContext: lambdacontext.ClientContext{
+				Client: lambdacontext.ClientApplication{},
+				Env:    nil,
+				Custom: map[string]string{
+					instana.FieldT: "0000000000001234",
+					instana.FieldS: "0000000000004567",
+					instana.FieldL: "1",
+				},
+			},
+		},
+	}
+
+	for tc, lc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			recorder := instana.NewTestRecorder()
+			sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
+
+			h := instalambda.NewHandler(func(ctx context.Context, evt interface{}) error {
+				_, ok := instana.SpanFromContext(ctx)
+				assert.True(t, ok)
+
+				return nil
+			}, sensor)
+
+			lambdacontext.FunctionName = "test-function"
+			lambdacontext.FunctionVersion = "42"
+
+			ctx := lambdacontext.NewContext(context.Background(), lc)
+
+			_, err := h.Invoke(ctx, []byte("{}"))
+			require.NoError(t, err)
+
+			spans := recorder.GetQueuedSpans()
+			require.Len(t, spans, 1)
+
+			span := spans[0]
+
+			assert.EqualValues(t, 0x1234, span.TraceID)
+			assert.EqualValues(t, 0x4567, span.ParentID)
+			assert.NotEqual(t, span.ParentID, span.SpanID)
+
+			require.Equal(t, "aws.lambda.entry", span.Name)
+			assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
+
+			assert.Equal(t, instana.AWSLambdaSpanData{
+				Snapshot: instana.AWSLambdaSpanTags{
+					ARN:     "aws:test-function:42",
+					Runtime: "go",
+					Name:    "test-function",
+					Version: "42",
+					Trigger: "aws:lambda.invoke",
+				},
+			}, span.Data)
+		})
+	}
+}
+
+func TestNewHandler_InvokeLambda_WithIncompleteSetOfInstanaHeaders(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	sensor := instana.NewSensorWithTracer(instana.NewTracerWithEverything(instana.DefaultOptions(), recorder))
+
+	h := instalambda.NewHandler(func(ctx context.Context, evt interface{}) error {
+		_, ok := instana.SpanFromContext(ctx)
+		assert.True(t, ok)
+
+		return nil
+	}, sensor)
+
+	lambdacontext.FunctionName = "test-function"
+	lambdacontext.FunctionVersion = "42"
+
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+		AwsRequestID:       "req1",
+		InvokedFunctionArn: "aws:test-function",
+		ClientContext: lambdacontext.ClientContext{
+			Client: lambdacontext.ClientApplication{},
+			Env:    nil,
+			Custom: map[string]string{
+				"WRONG_HEADER_NAME": "0000000000001234",
+				instana.FieldS:      "0000000000004567",
+				instana.FieldL:      "1",
+			},
+		},
+	})
+
+	_, err := h.Invoke(ctx, []byte("{}"))
+	require.NoError(t, err)
+
+	spans := recorder.GetQueuedSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+
+	assert.NotEqual(t, 0x1234, span.TraceID)
+	assert.NotEqual(t, 0x4567, span.ParentID)
+	assert.NotEqual(t, span.ParentID, span.SpanID)
+
+	require.Equal(t, "aws.lambda.entry", span.Name)
+	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
+
+	assert.Equal(t, instana.AWSLambdaSpanData{
+		Snapshot: instana.AWSLambdaSpanTags{
+			ARN:     "aws:test-function:42",
+			Runtime: "go",
+			Name:    "test-function",
+			Version: "42",
+			Trigger: "aws:lambda.invoke",
+		},
+	}, span.Data)
+}

--- a/instrumentation/instalambda/triggers.go
+++ b/instrumentation/instalambda/triggers.go
@@ -18,6 +18,7 @@ const (
 	cloudWatchLogsEventType
 	s3EventType
 	sqsEventType
+	invokeRequestType
 )
 
 func detectTriggerEventType(payload []byte) triggerEventType {
@@ -68,6 +69,6 @@ func detectTriggerEventType(payload []byte) triggerEventType {
 	case len(v.Records) > 0 && v.Records[0].Source == "aws:sqs":
 		return sqsEventType
 	default:
-		return unknownEventType
+		return invokeRequestType
 	}
 }


### PR DESCRIPTION
This PR adds support for the direct lambda invocation. This direct invocation is now a default case when we are detecting trigger.