### PR TITLE
Do not send empty tracestate headers downstream

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -84,7 +84,6 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 				"Authorization": {"Basic 123"},
 				"X-Instana-L":   {"0"},
 				"Traceparent":   {"00-00000000000000010000000000002435-0000000000003546-00"},
-				"Tracestate":    {""},
 				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},
@@ -116,7 +115,6 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 			Expected: http.Header{
 				"X-Instana-L":   {"0"},
 				"Traceparent":   {"00-00000000000000010000000000002435-0000000000003546-00"},
-				"Tracestate":    {""},
 				"Server-Timing": {"intid;desc=0000000000002435"},
 			},
 		},

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -82,7 +82,9 @@ func Inject(trCtx Context, headers http.Header) {
 	}
 
 	headers.Set(TraceParentHeader, trCtx.RawParent)
-	headers.Set(TraceStateHeader, trCtx.RawState)
+	if trCtx.RawState != "" {
+		headers.Set(TraceStateHeader, trCtx.RawState)
+	}
 }
 
 // State parses RawState and returns the corresponding list.


### PR DESCRIPTION
The `tracestate` is an optional header to propagate vendor states as a part of W3C trace context. In case Instana trace is suppressed either by `X-Instana-L: 0` header or corresponding flag in `traceparent`, the tracer won't be adding any data to the `tracestate` header. In this case, if a trace context did not contain any other vendor data before, we'd send a header with an empty value. This PR addresses this behavior by skipping adding the `tracestate` header is the state is empty.