### PR TITLE
Send custom tags for registered spans within `sdk.custom.tags` section

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -194,7 +194,7 @@ func filterCustomSpanTags(tags map[string]interface{}, st RegisteredSpanType) ma
 // common for all span types.
 type SpanData struct {
 	Service string          `json:"service,omitempty"`
-	Custom  *CustomSpanData `json:"custom,omitempty"`
+	Custom  *CustomSpanData `json:"sdk.custom,omitempty"`
 
 	st RegisteredSpanType
 }


### PR DESCRIPTION
Any arbitrary data, e.g. custom tags or logs, set via the SDK API has to be sent within the `data.sdk` section of span JSON document. This PR updates the JSON key for `(instana.SpanData).Custom` to be the JSON path string to avoid changing the field type and thus breaking the API.