### PR TITLE
Add logging span to the list of registered spans

### DIFF
--- a/registered_span_test.go
+++ b/registered_span_test.go
@@ -62,6 +62,10 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 			Operation: "aws.lambda.invoke",
 			Expected:  instana.AWSLambdaInvokeSpanData{},
 		},
+		"logger": {
+			Operation: "log.go",
+			Expected:  instana.LogSpanData{},
+		},
 	}
 
 	for name, example := range examples {


### PR DESCRIPTION
This PR adds a new registered span type intended for logger instrumentation.