### PR TITLE
Add OpenTracing log support

### DIFF
--- a/adapters_test.go
+++ b/adapters_test.go
@@ -75,21 +75,13 @@ func TestWithTracingSpan_PanicHandling(t *testing.T) {
 	assert.Equal(t, "test-span", data.Tags.Name)
 	assert.Equal(t, "entry", data.Tags.Type)
 
-	assert.Len(t, data.Tags.Custom, 2)
+	assert.Len(t, data.Tags.Custom, 1)
 	assert.Equal(t, ot.Tags{
 		"http.method":   "GET",
 		"http.url":      "/test",
 		"peer.hostname": "example.com",
 		"span.kind":     ext.SpanKindRPCServerEnum,
 	}, data.Tags.Custom["tags"])
-
-	require.IsType(t, map[uint64]map[string]interface{}{}, data.Tags.Custom["logs"])
-	logRecords := data.Tags.Custom["logs"].(map[uint64]map[string]interface{})
-
-	assert.Len(t, logRecords, 1)
-	for _, v := range logRecords {
-		assert.Equal(t, map[string]interface{}{"error": "something went wrong"}, v)
-	}
 
 	assert.Equal(t, span.TraceID, logSpan.TraceID)
 	assert.Equal(t, span.SpanID, logSpan.ParentID)

--- a/instrumentation_sql_go1.10_test.go
+++ b/instrumentation_sql_go1.10_test.go
@@ -65,9 +65,8 @@ func TestWrapSQLConnector_Exec_Error(t *testing.T) {
 		Service: "go-sensor-test",
 	}, recorder))
 
-	dbErr := errors.New("something went wrong")
 	db := sql.OpenDB(instana.WrapSQLConnector(s, "connection string", sqlConnector{
-		Error: dbErr,
+		Error: errors.New("something went wrong"),
 	}))
 
 	_, err := db.Exec("TEST QUERY")
@@ -81,21 +80,6 @@ func TestWrapSQLConnector_Exec_Error(t *testing.T) {
 	assert.EqualValues(t, instana.ExitSpanKind, span.Kind)
 
 	require.IsType(t, instana.SDKSpanData{}, span.Data)
-	data := span.Data.(instana.SDKSpanData)
-
-	require.IsType(t, map[uint64]map[string]interface{}{}, data.Tags.Custom["logs"])
-	logs := data.Tags.Custom["logs"].(map[uint64]map[string]interface{})
-
-	collected := make(map[string][]interface{})
-	for _, l := range logs {
-		for k, v := range l {
-			if k == "error.object" {
-				k = "error"
-			}
-			collected[k] = append(collected[k], v)
-		}
-	}
-	assert.Contains(t, collected["error"], dbErr)
 
 	assert.Equal(t, span.TraceID, logSpan.TraceID)
 	assert.Equal(t, span.SpanID, logSpan.ParentID)
@@ -176,21 +160,6 @@ func TestWrapSQLConnector_Query_Error(t *testing.T) {
 	assert.EqualValues(t, instana.ExitSpanKind, span.Kind)
 
 	require.IsType(t, instana.SDKSpanData{}, span.Data)
-	data := span.Data.(instana.SDKSpanData)
-
-	require.IsType(t, map[uint64]map[string]interface{}{}, data.Tags.Custom["logs"])
-	logs := data.Tags.Custom["logs"].(map[uint64]map[string]interface{})
-
-	collected := make(map[string][]interface{})
-	for _, l := range logs {
-		for k, v := range l {
-			if k == "error.object" {
-				k = "error"
-			}
-			collected[k] = append(collected[k], v)
-		}
-	}
-	assert.Contains(t, collected["error"], dbErr)
 
 	assert.Equal(t, span.TraceID, logSpan.TraceID)
 	assert.Equal(t, span.SpanID, logSpan.ParentID)

--- a/json_span.go
+++ b/json_span.go
@@ -284,10 +284,6 @@ func NewSDKSpanTags(span *spanS, spanType string) SDKSpanTags {
 		tags.Custom["tags"] = span.Tags
 	}
 
-	if logs := collectTracerSpanLogs(span); len(logs) > 0 {
-		tags.Custom["logs"] = logs
-	}
-
 	if len(span.context.Baggage) != 0 {
 		tags.Custom["baggage"] = span.context.Baggage
 	}
@@ -329,19 +325,4 @@ func readIntTag(dst *int, tag interface{}) {
 	case uint64:
 		*dst = int(n)
 	}
-}
-
-func collectTracerSpanLogs(span *spanS) map[uint64]map[string]interface{} {
-	logs := make(map[uint64]map[string]interface{})
-	for _, l := range span.Logs {
-		if _, ok := logs[uint64(l.Timestamp.UnixNano())/uint64(time.Millisecond)]; !ok {
-			logs[uint64(l.Timestamp.UnixNano())/uint64(time.Millisecond)] = make(map[string]interface{})
-		}
-
-		for _, f := range l.Fields {
-			logs[uint64(l.Timestamp.UnixNano())/uint64(time.Millisecond)][f.Key()] = f.Value()
-		}
-	}
-
-	return logs
 }

--- a/opentracing_log_encoder.go
+++ b/opentracing_log_encoder.go
@@ -1,0 +1,94 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instana
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	otlog "github.com/opentracing/opentracing-go/log"
+)
+
+type stringWriter interface {
+	WriteString(string) (int, error)
+}
+
+type otLogEncoder struct {
+	buf stringWriter
+}
+
+func newOpenTracingLogEncoder(buf stringWriter) *otLogEncoder {
+	return &otLogEncoder{
+		buf: buf,
+	}
+}
+
+// EmitString writes an opentracing/log.LogField containing string value to the buffer
+func (enc *otLogEncoder) EmitString(key, value string) {
+	enc.writeField(key, strconv.Quote(value))
+}
+
+// EmitBool writes an opentracing/log.LogField containing bool value to the buffer
+func (enc *otLogEncoder) EmitBool(key string, value bool) {
+	enc.writeField(key, strconv.FormatBool(value))
+}
+
+// EmitInt writes an opentracing/log.LogField containing int value to the buffer
+func (enc *otLogEncoder) EmitInt(key string, value int) {
+	enc.writeField(key, strconv.FormatInt(int64(value), 10))
+}
+
+// EmitInt32 writes an opentracing/log.LogField containing int32 value to the buffer
+func (enc *otLogEncoder) EmitInt32(key string, value int32) {
+	enc.writeField(key, strconv.FormatInt(int64(value), 10))
+}
+
+// EmitInt64 writes an opentracing/log.LogField containing int64 value to the buffer
+func (enc *otLogEncoder) EmitInt64(key string, value int64) {
+	enc.writeField(key, strconv.FormatInt(value, 10))
+}
+
+// EmitUint32 writes an opentracing/log.LogField containing uint32 value to the buffer
+func (enc *otLogEncoder) EmitUint32(key string, value uint32) {
+	enc.writeField(key, strconv.FormatUint(uint64(value), 10))
+}
+
+// EmitUint64 writes an opentracing/log.LogField containing uint64 value to the buffer
+func (enc *otLogEncoder) EmitUint64(key string, value uint64) {
+	enc.writeField(key, strconv.FormatUint(value, 10))
+}
+
+// EmitFloat32 writes an opentracing/log.LogField containing float32 value to the buffer
+func (enc *otLogEncoder) EmitFloat32(key string, value float32) {
+	enc.writeField(key, strconv.FormatFloat(float64(value), 'g', -1, 32))
+}
+
+// EmitFloat64 writes an opentracing/log.LogField containing float64 value to the buffer
+func (enc *otLogEncoder) EmitFloat64(key string, value float64) {
+	enc.writeField(key, strconv.FormatFloat(float64(value), 'g', -1, 64))
+}
+
+// EmitObject writes the JSON representation of an object value of opentracing/log.LogField to the buffer.
+// In case json.Marshal() returns an error the object representation is replaced by the error message.
+func (enc *otLogEncoder) EmitObject(key string, value interface{}) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		enc.writeField(key, fmt.Sprintf("<JSON marshaling failed: %s>", err))
+		return
+	}
+
+	enc.writeField(key, string(data))
+}
+
+// EmitLazyLogger delegates value writing to the LazyLogger
+func (enc *otLogEncoder) EmitLazyLogger(value otlog.LazyLogger) {
+	value(enc)
+}
+
+func (enc *otLogEncoder) writeField(key, value string) {
+	enc.buf.WriteString(key)
+	enc.buf.WriteString(": ")
+	enc.buf.WriteString(value)
+}

--- a/span_test.go
+++ b/span_test.go
@@ -289,7 +289,7 @@ func TestSpanErrorLogFields(t *testing.T) {
 
 		assert.Equal(t, instana.LogSpanTags{
 			Level:   "ERROR",
-			Message: `error: "simulated error"`,
+			Message: `error: "simulated error" function: "TestspanErrorLogFields"`,
 		}, logData.Tags, fmt.Sprintf("log span %d", i))
 	}
 }

--- a/span_test.go
+++ b/span_test.go
@@ -5,6 +5,7 @@ package instana_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -215,9 +216,9 @@ func TestSpanErrorLogKV(t *testing.T) {
 	sp.Finish()
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 
-	span := spans[0]
+	span, logSpan := spans[0], spans[1]
 	assert.Equal(t, 1, span.Ec)
 
 	require.IsType(t, instana.SDKSpanData{}, span.Data)
@@ -230,6 +231,22 @@ func TestSpanErrorLogKV(t *testing.T) {
 	for _, v := range logRecords {
 		assert.Equal(t, map[string]interface{}{"error": "simulated error"}, v)
 	}
+
+	assert.Equal(t, span.TraceID, logSpan.TraceID)
+	assert.Equal(t, span.SpanID, logSpan.ParentID)
+	assert.Equal(t, "log.go", logSpan.Name)
+
+	// assert that log message has been recorded within the span interval
+	assert.GreaterOrEqual(t, logSpan.Timestamp, span.Timestamp)
+	assert.LessOrEqual(t, logSpan.Duration, span.Duration)
+
+	require.IsType(t, instana.LogSpanData{}, logSpan.Data)
+	logData := logSpan.Data.(instana.LogSpanData)
+
+	assert.Equal(t, instana.LogSpanTags{
+		Level:   "ERROR",
+		Message: `error: "simulated error"`,
+	}, logData.Tags)
 }
 
 func TestSpanErrorLogFields(t *testing.T) {
@@ -244,9 +261,9 @@ func TestSpanErrorLogFields(t *testing.T) {
 	sp.Finish()
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 3)
 
-	span := spans[0]
+	span, logSpans := spans[0], spans[1:]
 	assert.Equal(t, 2, span.Ec)
 
 	require.IsType(t, instana.SDKSpanData{}, span.Data)
@@ -256,6 +273,25 @@ func TestSpanErrorLogFields(t *testing.T) {
 	logRecords := data.Tags.Custom["logs"].(map[uint64]map[string]interface{})
 
 	assert.Len(t, logRecords, 1)
+
+	require.Len(t, logSpans, 2)
+	for i, logSpan := range logSpans {
+		assert.Equal(t, span.TraceID, logSpan.TraceID, fmt.Sprintf("log span %d", i))
+		assert.Equal(t, span.SpanID, logSpan.ParentID, fmt.Sprintf("log span %d", i))
+		assert.Equal(t, "log.go", logSpan.Name, fmt.Sprintf("log span %d", i))
+
+		// assert that log message has been recorded within the span interval
+		assert.GreaterOrEqual(t, logSpan.Timestamp, span.Timestamp, fmt.Sprintf("log span %d", i))
+		assert.LessOrEqual(t, logSpan.Duration, span.Duration, fmt.Sprintf("log span %d", i))
+
+		require.IsType(t, instana.LogSpanData{}, logSpan.Data, fmt.Sprintf("log span %d", i))
+		logData := logSpan.Data.(instana.LogSpanData)
+
+		assert.Equal(t, instana.LogSpanTags{
+			Level:   "ERROR",
+			Message: `error: "simulated error"`,
+		}, logData.Tags, fmt.Sprintf("log span %d", i))
+	}
 }
 
 func TestSpan_Suppressed_StartSpanOption(t *testing.T) {


### PR DESCRIPTION
This PR adds support for forwarding the log messages created via the OpenTracing span API to Instana backend, while retiring the old and unsupported way of sending them as a part of SDK span payloads. Once merged, the log records that contain fields with either `"error"` or `"error.object"` keys will be forwarded as log spans and appear in the "Logs" view for the trace.