### PR TITLE
Add go1.17 to the CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,9 @@ workflows:
           name: "latest"
           go_version: "latest"
       - build:
+          name: "go1.17"
+          go_version: "1.17"
+      - build:
           name: "go1.16"
           go_version: "1.16"
       - build:


### PR DESCRIPTION
This PR adds go1.17 to the list of test targets for CircleCI. The check for 1.17 can be set as `required` as soon as [`circleci/golang:1.17`](https://hub.docker.com/r/circleci/golang) is published.