### PR TITLE
Add registered span type for MongoDB client spans

### DIFF
--- a/registered_span_test.go
+++ b/registered_span_test.go
@@ -66,6 +66,10 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 			Operation: "log.go",
 			Expected:  instana.LogSpanData{},
 		},
+		"mongodb": {
+			Operation: "mongo",
+			Expected:  instana.MongoDBSpanData{},
+		},
 	}
 
 	for name, example := range examples {


### PR DESCRIPTION
This PR adds the types to serialize and send the MongoDB client spans to Instana backend.