### PR TITLE
Cleanup timer test

### DIFF
--- a/autoprofile/internal/timer_test.go
+++ b/autoprofile/internal/timer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/instana/testify/assert"
 )
 
-func TestTimer_Stop(t *testing.T) {
+func TestTimer_Stop_Restart(t *testing.T) {
 	var fired int64
 	timer := internal.NewTimer(0, 60*time.Millisecond, func() {
 		atomic.AddInt64(&fired, 1)
@@ -24,7 +24,7 @@ func TestTimer_Stop(t *testing.T) {
 	assert.EqualValues(t, 1, atomic.LoadInt64(&fired))
 
 	time.Sleep(200 * time.Millisecond)
-	assert.EqualValues(t, 1, atomic.LoadInt64(&fired))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&fired), "a stopped timer should not be restarted")
 }
 
 func TestTimer_Sleep_Stopped(t *testing.T) {


### PR DESCRIPTION
There are two changes:

- Rename test
- Remove test case which is duplicated inside another test case