### PR TITLE
Add a method to report agent client readiness

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -195,6 +195,15 @@ func InitSensor(options *Options) {
 	sensor.logger.Debug("initialized Instana sensor v", Version)
 }
 
+// Ready returns whether the Instana collector is ready to collect and send data to the agent
+func Ready() bool {
+	if sensor == nil {
+		return false
+	}
+
+	return sensor.Agent().Ready()
+}
+
 func newServerlessAgent(serviceName, agentEndpoint, agentKey string, client *http.Client, logger LeveledLogger) agentClient {
 	switch {
 	case os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE" && os.Getenv("ECS_CONTAINER_METADATA_URI") != "":


### PR DESCRIPTION
This PR introduces a new API method `instana.Ready()` that reports whether the Instana collector is ready to collect and send trace data.