### PR TITLE
Expose an API method to flush buffered data to the agent

### DIFF
--- a/sensor.go
+++ b/sensor.go
@@ -204,6 +204,17 @@ func Ready() bool {
 	return sensor.Agent().Ready()
 }
 
+// Flush forces Instana collector to send all buffered data to the agent. This method is intended to implement
+// graceful service shutdown and not recommended for intermittent use. Once Flush() is called, it's not guaranteed
+// that collector remains in operational state.
+func Flush(ctx context.Context) error {
+	if sensor == nil {
+		return nil
+	}
+
+	return sensor.Agent().Flush(ctx)
+}
+
 func newServerlessAgent(serviceName, agentEndpoint, agentKey string, client *http.Client, logger LeveledLogger) agentClient {
 	switch {
 	case os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE" && os.Getenv("ECS_CONTAINER_METADATA_URI") != "":


### PR DESCRIPTION
This PR introduces the `instana.Flush()` to flush all buffered data to the agent. This method is intended to gracefully shut down the service and ensure that all trace data has been sent before exit. It's not recommended to use it to interfere with data transmission cycle, as it's not guaranteed to leave the agent client in operational state.