### PR TITLE
Forward warning logs collected via the OpenTracing API to the agent

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -24,6 +24,12 @@ const DefaultPrefix = "instana: "
 // Level defines the minimum logging level for logger.Log
 type Level uint8
 
+// Less returns whether the log level is less than the given one in logical order:
+// ErrorLevel > WarnLevel > InfoLevel > DebugLevel
+func (lvl Level) Less(other Level) bool {
+	return uint8(lvl) > uint8(other)
+}
+
 // String returns the log line label for this level
 func (lvl Level) String() string {
 	switch lvl {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/instana/testify/require"
 )
 
+func TestLevel_Less(t *testing.T) {
+	levels := []logger.Level{logger.ErrorLevel, logger.WarnLevel, logger.InfoLevel, logger.DebugLevel}
+	for i := range levels[:len(levels)-1] {
+		assert.True(t, levels[i+1].Less(levels[i]), "%s should be less than %s", levels[i+1], levels[i])
+	}
+}
+
 func TestLogger_SetPrefix(t *testing.T) {
 	p := &printer{}
 

--- a/span.go
+++ b/span.go
@@ -14,7 +14,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
-const minSpanLogLevel = logger.ErrorLevel
+const minSpanLogLevel = logger.WarnLevel
 
 type spanS struct {
 	Service     string
@@ -242,6 +242,8 @@ func openTracingLogFieldLevel(lf otlog.Field) logger.Level {
 	switch lf.Key() {
 	case "error", "error.object":
 		return logger.ErrorLevel
+	case "warn":
+		return logger.WarnLevel
 	default:
 		return logger.DebugLevel
 	}

--- a/span.go
+++ b/span.go
@@ -199,7 +199,7 @@ func (r *spanS) sendOpenTracingLogRecords() {
 func (r *spanS) sendOpenTracingLogRecord(lr ot.LogRecord) {
 	lvl := openTracingHighestLogRecordLevel(lr)
 
-	if lvl > minSpanLogLevel {
+	if lvl.Less(minSpanLogLevel) {
 		return
 	}
 
@@ -226,11 +226,14 @@ func (r *spanS) sendOpenTracingLogRecord(lr ot.LogRecord) {
 	)
 }
 
+// openTracingHighestLogRecordLevel determines the level of this record by inspecting its fields.
+// If there are multiple fields suggesting the log level, i.e. both "error" and "warn" are present,
+// the highest one takes precedence.
 func openTracingHighestLogRecordLevel(lr ot.LogRecord) logger.Level {
 	highestLvl := logger.DebugLevel
 
 	for _, lf := range lr.Fields {
-		if lvl := openTracingLogFieldLevel(lf); lvl < highestLvl {
+		if lvl := openTracingLogFieldLevel(lf); highestLvl.Less(lvl) {
 			highestLvl = lvl
 		}
 	}

--- a/span_test.go
+++ b/span_test.go
@@ -183,23 +183,33 @@ func TestSpan_LogFields(t *testing.T) {
 		"error object": {
 			Fields: []log.Field{
 				log.Error(errors.New("simulated error")),
-				log.String("function", "TestspanErrorLogFields"),
+				log.String("function", "ErrorFunc"),
 			},
 			ExpectedErrorCount: 1,
 			ExpectedTags: instana.LogSpanTags{
 				Level:   "ERROR",
-				Message: `error: "simulated error" function: "TestspanErrorLogFields"`,
+				Message: `error: "simulated error" function: "ErrorFunc"`,
 			},
 		},
 		"error log": {
 			Fields: []log.Field{
 				log.String("error", "simulated error"),
-				log.String("function", "TestspanErrorLogFields"),
+				log.String("function", "ErrorFunc"),
 			},
 			ExpectedErrorCount: 1,
 			ExpectedTags: instana.LogSpanTags{
 				Level:   "ERROR",
-				Message: `error: "simulated error" function: "TestspanErrorLogFields"`,
+				Message: `error: "simulated error" function: "ErrorFunc"`,
+			},
+		},
+		"warn log": {
+			Fields: []log.Field{
+				log.String("warn", "simulated warning"),
+				log.String("function", "WarnFunc"),
+			},
+			ExpectedTags: instana.LogSpanTags{
+				Level:   "WARN",
+				Message: `warn: "simulated warning" function: "WarnFunc"`,
 			},
 		},
 	}


### PR DESCRIPTION
This PR updates Go collector to send the OpenTracing warning log records to the agent. A record is considered as a warning if it contains at least one field with `"warn"` as a key. Such logs are send with `WARN` level.