### PR TITLE
Add a script to automate module releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ patch : ensure-git-clean update-local-copy
 	git push $(GIT_REMOTE) HEAD
 
 CHANGELOG.txt :
-	echo 'This release includes the following fixes & improvements:' > CHANGELOG.txt
+	echo 'This release of `github.com/instana/go-sensor``` includes the following fixes & improvements:' > CHANGELOG.txt
 	git log --merges $(VERSION_TAG_PREFIX)$(GIT_VERSION).. --pretty='format:%s' | \
 		sed 's~Merge pull request #\([0-9]*\).*~\1~' | \
 		xargs -n1 $(GITHUB_CLI) pr view | \

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,13 @@ install:
 legal:
 	awk 'FNR==1 { if (tolower($$0) !~ "^//.+copyright") { print FILENAME" does not contain copyright header"; rc=1 } }; END { exit rc }' $$(find . -name '*.go' -type f | grep -v "/vendor/")
 
+instrumentation/% :
+	mkdir -p $@
+	cd $@ && go mod init github.com/instana/go-sensor/$@
+	sed "s~Copyright (c) [0-9]*~Copyright (c) $(shell date +%Y)~" LICENSE.md > $@/LICENSE.md
+	printf "VERSION_TAG_PREFIX ?= $@/v\nGO_MODULE_NAME ?= github.com/instana/go-sensor/$@\n\ninclude ../../Makefile.release\n" > $@/Makefile
+	printf '// (c) Copyright IBM Corp. %s\n// (c) Copyright Instana Inc. %s\n\npackage %s\n\nconst Version = "0.0.0"\n' $(shell date +%Y) $(shell date +%Y) $(notdir $@) > $@/version.go
+
 .PHONY: test vendor install legal $(MODULES) $(INTEGRATION_TESTS)
 
 # Release targets

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ $(VENDOR_GO):
 
 install:
 	cd .git/hooks && ln -fs ../../.githooks/* .
+	brew install gh
 
 # Make sure there is a copyright at the first line of each .go file
 legal:

--- a/Makefile
+++ b/Makefile
@@ -9,29 +9,6 @@ VENDOR_GO_VERSION ?= go1.15
 VENDOR_GO = $(shell go env GOPATH)/bin/$(VENDOR_GO_VERSION)
 MODULES_VENDOR = $(addsuffix /vendor,$(MODULES))
 
-VERSION_TAG_PREFIX ?= v
-VERSION_GO_FILE ?= $(shell grep -l '^var Version = ".\+"' *.go | head -1)
-
-GIT_REMOTE ?= origin
-GIT_MAIN_BRANCH ?= $(shell git remote show $(GIT_REMOTE) | sed -n '/HEAD branch/s/.*: //p')
-GIT_TREE_STATE = $(shell (git status --porcelain | grep -q .) && echo dirty || echo clean)
-
-GITHUB_CLI = $(shell which gh 2>/dev/null)
-
-# Search for the latest vX.Y.Z tag ignoring all others, and use the X.Y.Z part as a version
-GIT_VERSION = $(shell git tag | grep "^$(VERSION_TAG_PREFIX)[0-9]\+\(\.[0-9]\+\)\{2\}" | sort -V | tail -n1 | sed "s~^$(VERSION_TAG_PREFIX)~~" )
-ifeq ($(GIT_VERSION),)
-	GIT_VERSION = 0.0.0
-endif
-
-# Parse semantic version X.Y.Z found in git tags
-GIT_MAJOR_VERSION = $(word 1,$(subst ., ,$(GIT_VERSION)))
-GIT_MINOR_VERSION = $(word 2,$(subst ., ,$(GIT_VERSION)))
-GIT_PATCH_VERSION = $(word 3,$(subst ., ,$(GIT_VERSION)))
-
-# Parse version from version.go file
-VERSION = $(shell grep -hm1 '^var Version = ".\+"' ${VERSION_GO_FILE} | head -1 | sed -E 's/var Version = "([0-9\.]+)"/\1/')
-
 ifeq ($(RUN_LINTER),yes)
 test: $(LINTER)
 endif
@@ -59,7 +36,6 @@ $(LINTER):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/a2bc9b7a99e3280805309d71036e8c2106853250/install.sh \
 	| sh -s -- -b $(basename $(GOPATH))/bin v1.23.8
 
-
 $(MODULES_VENDOR): $(VENDOR_GO)
 	cd $(shell dirname $@) && $(VENDOR_GO) mod vendor
 	find $@ -name go.mod -delete
@@ -78,66 +54,5 @@ legal:
 
 .PHONY: test vendor install legal $(MODULES) $(INTEGRATION_TESTS)
 
-# Create changelog if GitHub CLI is installed
-ifneq ($(GITHUB_CLI),)
-release : CHANGELOG.txt
-endif
-
-# Create new release tag and publish a release from it
-release :
-	git tag $(VERSION_TAG_PREFIX)$(VERSION)
-	git push --tags
-ifneq ($(GITHUB_CLI),)
-	$(GITHUB_CLI) release create $(VERSION_TAG_PREFIX)$(VERSION) \
-		--draft \
-		--title $(VERSION_TAG_PREFIX)$(VERSION) \
-		--notes-file CHANGELOG.txt
-	rm CHANGELOG.txt
-else
-	@echo "GitHub CLI is not installed. Please proceed with creating the release on https://github.com"
-endif
-
-# Calculate the next major version from the latest one found in git tags, update version.go, commit and push changes to remote
-major : ensure-git-clean update-local-copy
-	$(eval VERSION = $(shell echo $$(($(GIT_MAJOR_VERSION)+1))).0.0)
-	@printf "You are about to increase the major version to $(VERSION), are you sure? [y/N]: " && read ans && [ $${ans:-N} = y ]
-	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
-	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
-	git push $(GIT_REMOTE) HEAD
-
-# Calculate the next minor version from the latest one found in git tags, update version.go, commit and push changes to remote
-minor : ensure-git-clean update-local-copy
-	$(eval VERSION = $(GIT_MAJOR_VERSION).$(shell echo $$(($(GIT_MINOR_VERSION)+1))).0)
-	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
-	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
-	git push $(GIT_REMOTE) HEAD
-
-# Calculate the next patch version from the latest one found in git tags, update version.go, commit and push changes to remote
-patch : ensure-git-clean update-local-copy
-	$(eval VERSION = $(GIT_MAJOR_VERSION).$(GIT_MINOR_VERSION).$(shell echo $$(($(GIT_PATCH_VERSION)+1))))
-	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
-	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
-	git push $(GIT_REMOTE) HEAD
-
-CHANGELOG.txt :
-	echo 'This release of `github.com/instana/go-sensor``` includes the following fixes & improvements:' > CHANGELOG.txt
-	git log --merges $(VERSION_TAG_PREFIX)$(GIT_VERSION).. --pretty='format:%s' | \
-		sed 's~Merge pull request #\([0-9]*\).*~\1~' | \
-		xargs -n1 $(GITHUB_CLI) pr view | \
-		grep '^title:' | \
-		sed 's~^title:~*~' >> CHANGELOG.txt
-	echo >> CHANGELOG.txt
-
-# Make sure there are no uncommitted changes in the working tree
-ensure-git-clean :
-ifeq ($(GIT_TREE_STATE),dirty)
-	$(error "There are uncommitted changes in current working tree. Please stash or commit them before release.")
-endif
-
-# Switch to the main branch, then pull and rebase to the latest changes including tags
-update-local-copy :
-	git fetch --tags $(GIT_REMOTE)
-	git checkout $(GIT_MAIN_BRANCH)
-	git rebase $(GIT_REMOTE)/$(GIT_MAIN_BRANCH)
-
-.PHONY : major minor patch release ensure-git-clean update-local-copy
+# Release targets
+include Makefile.release

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,29 @@ VENDOR_GO_VERSION ?= go1.15
 VENDOR_GO = $(shell go env GOPATH)/bin/$(VENDOR_GO_VERSION)
 MODULES_VENDOR = $(addsuffix /vendor,$(MODULES))
 
+VERSION_TAG_PREFIX ?= v
+VERSION_GO_FILE ?= $(shell grep -l '^var Version = ".\+"' *.go | head -1)
+
+GIT_REMOTE ?= origin
+GIT_MAIN_BRANCH ?= $(shell git remote show $(GIT_REMOTE) | sed -n '/HEAD branch/s/.*: //p')
+GIT_TREE_STATE = $(shell (git status --porcelain | grep -q .) && echo dirty || echo clean)
+
+GITHUB_CLI = $(shell which gh 2>/dev/null)
+
+# Search for the latest vX.Y.Z tag ignoring all others, and use the X.Y.Z part as a version
+GIT_VERSION = $(shell git tag | grep "^$(VERSION_TAG_PREFIX)[0-9]\+\(\.[0-9]\+\)\{2\}" | sort -V | tail -n1 | sed "s~^$(VERSION_TAG_PREFIX)~~" )
+ifeq ($(GIT_VERSION),)
+	GIT_VERSION = 0.0.0
+endif
+
+# Parse semantic version X.Y.Z found in git tags
+GIT_MAJOR_VERSION = $(word 1,$(subst ., ,$(GIT_VERSION)))
+GIT_MINOR_VERSION = $(word 2,$(subst ., ,$(GIT_VERSION)))
+GIT_PATCH_VERSION = $(word 3,$(subst ., ,$(GIT_VERSION)))
+
+# Parse version from version.go file
+VERSION = $(shell grep -hm1 '^var Version = ".\+"' ${VERSION_GO_FILE} | head -1 | sed -E 's/var Version = "([0-9\.]+)"/\1/')
+
 ifeq ($(RUN_LINTER),yes)
 test: $(LINTER)
 endif
@@ -53,3 +76,67 @@ legal:
 	awk 'FNR==1 { if (tolower($$0) !~ "^//.+copyright") { print FILENAME" does not contain copyright header"; rc=1 } }; END { exit rc }' $$(find . -name '*.go' -type f | grep -v "/vendor/")
 
 .PHONY: test vendor install legal $(MODULES) $(INTEGRATION_TESTS)
+
+# Create changelog if GitHub CLI is installed
+ifneq ($(GITHUB_CLI),)
+release : CHANGELOG.txt
+endif
+
+# Create new release tag and publish a release from it
+release :
+	git tag $(VERSION_TAG_PREFIX)$(VERSION)
+	git push --tags
+ifneq ($(GITHUB_CLI),)
+	$(GITHUB_CLI) release create $(VERSION_TAG_PREFIX)$(VERSION) \
+		--draft \
+		--title $(VERSION_TAG_PREFIX)$(VERSION) \
+		--notes-file CHANGELOG.txt
+	rm CHANGELOG.txt
+else
+	@echo "GitHub CLI is not installed. Please proceed with creating the release on https://github.com"
+endif
+
+# Calculate the next major version from the latest one found in git tags, update version.go, commit and push changes to remote
+major : ensure-git-clean update-local-copy
+	$(eval VERSION = $(shell echo $$(($(GIT_MAJOR_VERSION)+1))).0.0)
+	@printf "You are about to increase the major version to $(VERSION), are you sure? [y/N]: " && read ans && [ $${ans:-N} = y ]
+	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
+	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
+	git push $(GIT_REMOTE) HEAD
+
+# Calculate the next minor version from the latest one found in git tags, update version.go, commit and push changes to remote
+minor : ensure-git-clean update-local-copy
+	$(eval VERSION = $(GIT_MAJOR_VERSION).$(shell echo $$(($(GIT_MINOR_VERSION)+1))).0)
+	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
+	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
+	git push $(GIT_REMOTE) HEAD
+
+# Calculate the next patch version from the latest one found in git tags, update version.go, commit and push changes to remote
+patch : ensure-git-clean update-local-copy
+	$(eval VERSION = $(GIT_MAJOR_VERSION).$(GIT_MINOR_VERSION).$(shell echo $$(($(GIT_PATCH_VERSION)+1))))
+	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
+	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
+	git push $(GIT_REMOTE) HEAD
+
+CHANGELOG.txt :
+	echo 'This release includes the following fixes & improvements:' > CHANGELOG.txt
+	git log --merges $(VERSION_TAG_PREFIX)$(GIT_VERSION).. --pretty='format:%s' | \
+		sed 's~Merge pull request #\([0-9]*\).*~\1~' | \
+		xargs -n1 $(GITHUB_CLI) pr view | \
+		grep '^title:' | \
+		sed 's~^title:~*~' >> CHANGELOG.txt
+	echo >> CHANGELOG.txt
+
+# Make sure there are no uncommitted changes in the working tree
+ensure-git-clean :
+ifeq ($(GIT_TREE_STATE),dirty)
+	$(error "There are uncommitted changes in current working tree. Please stash or commit them before release.")
+endif
+
+# Switch to the main branch, then pull and rebase to the latest changes including tags
+update-local-copy :
+	git fetch --tags $(GIT_REMOTE)
+	git checkout $(GIT_MAIN_BRANCH)
+	git rebase $(GIT_REMOTE)/$(GIT_MAIN_BRANCH)
+
+.PHONY : major minor patch release ensure-git-clean update-local-copy

--- a/Makefile.release
+++ b/Makefile.release
@@ -1,0 +1,89 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor
+
+VERSION_TAG_PREFIX ?= v
+VERSION_GO_FILE ?= $(shell grep -l '^var Version = ".\+"' *.go | head -1)
+
+GIT_REMOTE ?= origin
+GIT_MAIN_BRANCH ?= $(shell git remote show $(GIT_REMOTE) | sed -n '/HEAD branch/s/.*: //p')
+GIT_TREE_STATE = $(shell (git status --porcelain | grep -q .) && echo dirty || echo clean)
+
+GITHUB_CLI = $(shell which gh 2>/dev/null)
+
+# Search for the latest vX.Y.Z tag ignoring all others, and use the X.Y.Z part as a version
+GIT_VERSION = $(shell git tag | grep "^$(VERSION_TAG_PREFIX)[0-9]\+\(\.[0-9]\+\)\{2\}" | sort -V | tail -n1 | sed "s~^$(VERSION_TAG_PREFIX)~~" )
+ifeq ($(GIT_VERSION),)
+	GIT_VERSION = 0.0.0
+endif
+
+# Parse semantic version X.Y.Z found in git tags
+GIT_MAJOR_VERSION = $(word 1,$(subst ., ,$(GIT_VERSION)))
+GIT_MINOR_VERSION = $(word 2,$(subst ., ,$(GIT_VERSION)))
+GIT_PATCH_VERSION = $(word 3,$(subst ., ,$(GIT_VERSION)))
+
+# Parse version from version.go file
+VERSION = $(shell grep -hm1 '^var Version = ".\+"' ${VERSION_GO_FILE} | head -1 | sed -E 's/var Version = "([0-9\.]+)"/\1/')
+
+# Create changelog if GitHub CLI is installed
+ifneq ($(GITHUB_CLI),)
+release : CHANGELOG.txt
+endif
+
+# Create new release tag and publish a release from it
+release :
+	git tag $(VERSION_TAG_PREFIX)$(VERSION)
+	git push --tags
+ifneq ($(GITHUB_CLI),)
+	$(GITHUB_CLI) release create $(VERSION_TAG_PREFIX)$(VERSION) \
+		--draft \
+		--title $(VERSION_TAG_PREFIX)$(VERSION) \
+		--notes-file CHANGELOG.txt
+	rm CHANGELOG.txt
+else
+	@echo "GitHub CLI is not installed. Please proceed with creating the release on https://github.com"
+endif
+
+# Calculate the next major version from the latest one found in git tags, update version.go, commit and push changes to remote
+major : ensure-git-clean update-local-copy
+	$(eval VERSION = $(shell echo $$(($(GIT_MAJOR_VERSION)+1))).0.0)
+	@printf "You are about to increase the major version to $(VERSION), are you sure? [y/N]: " && read ans && [ $${ans:-N} = y ]
+	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
+	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
+	git push $(GIT_REMOTE) HEAD
+
+# Calculate the next minor version from the latest one found in git tags, update version.go, commit and push changes to remote
+minor : ensure-git-clean update-local-copy
+	$(eval VERSION = $(GIT_MAJOR_VERSION).$(shell echo $$(($(GIT_MINOR_VERSION)+1))).0)
+	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
+	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
+	git push $(GIT_REMOTE) HEAD
+
+# Calculate the next patch version from the latest one found in git tags, update version.go, commit and push changes to remote
+patch : ensure-git-clean update-local-copy
+	$(eval VERSION = $(GIT_MAJOR_VERSION).$(GIT_MINOR_VERSION).$(shell echo $$(($(GIT_PATCH_VERSION)+1))))
+	sed -i '' 's/^var Version = ".*"/var Version = "$(VERSION)"/' ${VERSION_GO_FILE}
+	git commit -m "Bump version to v$(VERSION)" ${VERSION_GO_FILE}
+	git push $(GIT_REMOTE) HEAD
+
+.INTERMEDIATE : CHANGELOG.txt
+CHANGELOG.txt :
+	echo "This release of `$(GO_MODULE_NAME)` includes the following fixes & improvements:" > CHANGELOG.txt
+	git log --merges $(VERSION_TAG_PREFIX)$(GIT_VERSION).. --pretty='format:%s' | \
+		sed 's~Merge pull request #\([0-9]*\).*~\1~' | \
+		xargs -n1 $(GITHUB_CLI) pr view | \
+		grep '^title:' | \
+		sed 's~^title:~*~' >> CHANGELOG.txt
+	echo >> CHANGELOG.txt
+
+# Make sure there are no uncommitted changes in the working tree
+ensure-git-clean :
+ifeq ($(GIT_TREE_STATE),dirty)
+	$(error "There are uncommitted changes in current working tree. Please stash or commit them before release.")
+endif
+
+# Switch to the main branch, then pull and rebase to the latest changes including tags
+update-local-copy :
+	git fetch --tags $(GIT_REMOTE)
+	git checkout $(GIT_MAIN_BRANCH)
+	git rebase $(GIT_REMOTE)/$(GIT_MAIN_BRANCH)
+
+.PHONY : major minor patch release ensure-git-clean update-local-copy

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,39 +1,10 @@
 Release Steps
 =============
 
+**Never ever update version tags that were already pushed**, this will cause errors on the user side because of different checksum. If a tag has been created accidentally pointing to a wrong commit, create a new patch version with a fix instead of updating it.
+
 1. Ensure tests are passing on [Circle CI](https://app.circleci.com/pipelines/github/instana/go-sensor)
-2. Make sure your local `master` branch is up-to-date:
-
-   ```bash
-   git checkout master && git pull --rebase
-   ```
-3. If you're about to release a new version of the main module, bump the package version in [`version.go`](./version.go), commit & push the
-   version change to the `master` branch
-4. Create a git tag for the new version:
-   - for the main module the tag should be `v1.X.Y`, where `X` and `Y` correspond to the version in the `version.go`
-   - for instrumentation submodules tags should be prefixed with the relative path to the submodule, for example `instrumentation/instalambda/v1.2.0`.
-     Sumodule versions are independent from the version of `github.com/instana/go-sensor`
-5. Push the tag to GitHub with `git push --tag`
-
-   **Never ever update version tags that were already pushed**, this will cause errors on the user side because of different checksum. If a tag has been
-   created accidentally pointing to a wrong commit, create a new patch version with a fix instead of updating it.
-7. Go to the [Releases](https://github.com/instana/go-sensor/releases) page and create a new release for the version tag. Use the [appropriate template](#release-templates)
-   depending on the release type and module.
-8. Make sure that the [Renew pkg.go.dev documentation](https://github.com/instana/go-sensor/actions/workflows/documentation.yml) workflow has been executed. This
-   makes [GoDoc](https://pkg.go.dev/instana/go-sensor) aware of the new version.
-
-Release templates
------------------
-
-* <details>
-  <summary>Main module</summary>
-  This {minor,patch} release includes the following fixes & improvements:
-
-  * ...
-  </details>
-* <details>
-  <summary>Instrumentation submodule</summary>
-  This {minor,patch} release of &lt;submodule name&gt; includes the following fixes & improvements:
-
-  * ...
-  </details>
+2. From the module directory run `make (minor|patch) release`
+   - This would create a new commit updating the module version constant in `version.go`, tag and push it to GitHub.
+   - If you have [GitHub CLI](https://cli.github.com/) installed, it will also create a draft release with the changelog
+3. Go to [Releases](https://github.com/instana/go-sensor/releases) page, review and publish the draft release created by `make`

--- a/instrumentation/cloud.google.com/go/Makefile
+++ b/instrumentation/cloud.google.com/go/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/cloud.google.com/go
+VERSION_TAG_PREFIX ?= instrumentation/cloud.google.com/go/v
+
+include ../../Makefile.release

--- a/instrumentation/cloud.google.com/go/version.go
+++ b/instrumentation/cloud.google.com/go/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instago
+
+// Version is the instrumentation module semantic version
+const Version = "v1.3.0"

--- a/instrumentation/instaawssdk/Makefile
+++ b/instrumentation/instaawssdk/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instaawssdk
+VERSION_TAG_PREFIX ?= instrumentation/instaawssdk/v
+
+include ../../Makefile.release

--- a/instrumentation/instaawssdk/version.go
+++ b/instrumentation/instaawssdk/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instaawssdk
+
+// Version is the instrumentation module semantic version
+const Version = "v1.1.0"

--- a/instrumentation/instaecho/Makefile
+++ b/instrumentation/instaecho/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instaecho
+VERSION_TAG_PREFIX ?= instrumentation/instaecho/v
+
+include ../../Makefile.release

--- a/instrumentation/instaecho/version.go
+++ b/instrumentation/instaecho/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instaecho
+
+// Version is the instrumentation module semantic version
+const Version = "v1.1.1"

--- a/instrumentation/instagin/Makefile
+++ b/instrumentation/instagin/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instagin
+VERSION_TAG_PREFIX ?= instrumentation/instagin/v
+
+include ../../Makefile.release

--- a/instrumentation/instagin/version.go
+++ b/instrumentation/instagin/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instagin
+
+// Version is the instrumentation module semantic version
+const Version = "v1.0.0"

--- a/instrumentation/instagrpc/Makefile
+++ b/instrumentation/instagrpc/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instagrpc
+VERSION_TAG_PREFIX ?= instrumentation/instagrpc/v
+
+include ../../Makefile.release

--- a/instrumentation/instagrpc/version.go
+++ b/instrumentation/instagrpc/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instagrpc
+
+// Version is the instrumentation module semantic version
+const Version = "v1.1.0"

--- a/instrumentation/instahttprouter/Makefile
+++ b/instrumentation/instahttprouter/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instahttprouter
+VERSION_TAG_PREFIX ?= instrumentation/instahttprouter/v
+
+include ../../Makefile.release

--- a/instrumentation/instahttprouter/version.go
+++ b/instrumentation/instahttprouter/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instahttprouter
+
+// Version is the instrumentation module semantic version
+const Version = "v1.0.0"

--- a/instrumentation/instalambda/Makefile
+++ b/instrumentation/instalambda/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instalambda
+VERSION_TAG_PREFIX ?= instrumentation/instalambda/v
+
+include ../../Makefile.release

--- a/instrumentation/instalambda/version.go
+++ b/instrumentation/instalambda/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instalambda
+
+// Version is the instrumentation module semantic version
+const Version = "v1.4.0"

--- a/instrumentation/instalogrus/Makefile
+++ b/instrumentation/instalogrus/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instalogrus
+VERSION_TAG_PREFIX ?= instrumentation/instalogrus/v
+
+include ../../Makefile.release

--- a/instrumentation/instalogrus/version.go
+++ b/instrumentation/instalogrus/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instalogrus
+
+// Version is the instrumentation module semantic version
+const Version = "v1.0.0"

--- a/instrumentation/instamongo/Makefile
+++ b/instrumentation/instamongo/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instamongo
+VERSION_TAG_PREFIX ?= instrumentation/instamongo/v
+
+include ../../Makefile.release

--- a/instrumentation/instamongo/version.go
+++ b/instrumentation/instamongo/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instamongo
+
+// Version is the instrumentation module semantic version
+const Version = "v1.0.0"

--- a/instrumentation/instamux/Makefile
+++ b/instrumentation/instamux/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instamux
+VERSION_TAG_PREFIX ?= instrumentation/instamux/v
+
+include ../../Makefile.release

--- a/instrumentation/instamux/version.go
+++ b/instrumentation/instamux/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instamux
+
+// Version is the instrumentation module semantic version
+const Version = "v1.1.1"

--- a/instrumentation/instasarama/Makefile
+++ b/instrumentation/instasarama/Makefile
@@ -1,0 +1,4 @@
+GO_MODULE_NAME ?= github.com/instana/go-sensor/instrumentation/instasarama
+VERSION_TAG_PREFIX ?= instrumentation/instasarama/v
+
+include ../../Makefile.release

--- a/instrumentation/instasarama/version.go
+++ b/instrumentation/instasarama/version.go
@@ -1,0 +1,7 @@
+// (c) Copyright IBM Corp. 2021
+// (c) Copyright Instana Inc. 2021
+
+package instasarama
+
+// Version is the instrumentation module semantic version
+const Version = "v1.1.0"


### PR DESCRIPTION
This PR adds several `make` targets to manage Go modules:
* `make minor release` creates a release for the next minor version
* `make patch release` creates a release for the next patch version
* `make instrumentation/...` initializes a new empty instrumentation module with a license, Makefile and `go.mod`