### PR TITLE
Improve announce process

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -50,7 +50,7 @@ type discoveryS struct {
 	Args              []string `json:"args"`
 	Fd                string   `json:"fd"`
 	Inode             string   `json:"inode"`
-	CpuSetFileContent string   `json:"cpuSetFileContent"`
+	CPUSetFileContent string   `json:"cpuSetFileContent"`
 }
 
 type fromS struct {

--- a/agent.go
+++ b/agent.go
@@ -45,11 +45,12 @@ type agentResponse struct {
 }
 
 type discoveryS struct {
-	PID   int      `json:"pid"`
-	Name  string   `json:"name"`
-	Args  []string `json:"args"`
-	Fd    string   `json:"fd"`
-	Inode string   `json:"inode"`
+	PID               int      `json:"pid"`
+	Name              string   `json:"name"`
+	Args              []string `json:"args"`
+	Fd                string   `json:"fd"`
+	Inode             string   `json:"inode"`
+	CpuSetFileContent string   `json:"cpuSetFileContent"`
 }
 
 type fromS struct {

--- a/fsm.go
+++ b/fsm.go
@@ -160,7 +160,7 @@ func (r *fsmS) announceSensor(e *f.Event) {
 
 		d := &discoveryS{
 			PID:               pid,
-			CpuSetFileContent: cpuSetFileContent,
+			CPUSetFileContent: cpuSetFileContent,
 			Name:              os.Args[0],
 			Args:              os.Args[1:],
 		}

--- a/fsm.go
+++ b/fsm.go
@@ -5,6 +5,7 @@ package instana
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -228,7 +229,7 @@ func (r *fsmS) reset() {
 
 func (r *fsmS) cpuSetFileContent(pid int) string {
 	path := filepath.Join("proc", strconv.Itoa(pid), "cpuset")
-	data, err := os.ReadFile(path)
+	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		r.agent.logger.Info("error while reading ", path, ":", err.Error())
 		return ""


### PR DESCRIPTION
This PR:
- adds `cpuSetFileContent` field to the announce request, similar to what nodejs sensor does https://github.com/instana/nodejs/blob/8cf7bc766a16a0c29135f2d55541f952f7e937a4/packages/collector/src/agentConnection.js#L491
- removes logic build around `/proc/$PID/sched` file, because of https://github.com/torvalds/linux/commit/74dc3384fc7983b78cc46ebb1824968a3db85eb1. The file now always contains `in container` PID.
- change the name of a local variable to not be the same as the named import