### PR TITLE
Make HTTP instrumentation wrapper implement `http.Hijacker` in case the `http.ResponseWriter` does

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/instana/go-sensor
 
-go 1.8
+go 1.9
 
 require (
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65

--- a/instrumentation/instagrpc/client.go
+++ b/instrumentation/instagrpc/client.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instagrpc
 
 import (

--- a/instrumentation/instagrpc/client_test.go
+++ b/instrumentation/instagrpc/client_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instagrpc_test
 
 import (

--- a/instrumentation/instagrpc/example_test.go
+++ b/instrumentation/instagrpc/example_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instagrpc_test
 
 import (

--- a/instrumentation/instagrpc/server.go
+++ b/instrumentation/instagrpc/server.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instagrpc
 
 import (

--- a/instrumentation/instagrpc/server_test.go
+++ b/instrumentation/instagrpc/server_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instagrpc_test
 
 import (

--- a/instrumentation/instasarama/async_producer.go
+++ b/instrumentation/instasarama/async_producer.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/async_producer_test.go
+++ b/instrumentation/instasarama/async_producer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/consumer.go
+++ b/instrumentation/instasarama/consumer.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/consumer_group_handler.go
+++ b/instrumentation/instasarama/consumer_group_handler.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/consumer_group_handler_test.go
+++ b/instrumentation/instasarama/consumer_group_handler_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/consumer_test.go
+++ b/instrumentation/instasarama/consumer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/example_async_producer_test.go
+++ b/instrumentation/instasarama/example_async_producer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/example_consumer_group_test.go
+++ b/instrumentation/instasarama/example_consumer_group_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/example_consumer_test.go
+++ b/instrumentation/instasarama/example_consumer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/example_sync_producer_test.go
+++ b/instrumentation/instasarama/example_sync_producer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/instasarama_test.go
+++ b/instrumentation/instasarama/instasarama_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/partition_consumer.go
+++ b/instrumentation/instasarama/partition_consumer.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/partition_consumer_test.go
+++ b/instrumentation/instasarama/partition_consumer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/propagation.go
+++ b/instrumentation/instasarama/propagation.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/propagation_test.go
+++ b/instrumentation/instasarama/propagation_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/record_header.go
+++ b/instrumentation/instasarama/record_header.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/record_header_test.go
+++ b/instrumentation/instasarama/record_header_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (

--- a/instrumentation/instasarama/span_registry.go
+++ b/instrumentation/instasarama/span_registry.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/sync_producer.go
+++ b/instrumentation/instasarama/sync_producer.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama
 
 import (

--- a/instrumentation/instasarama/sync_producer_test.go
+++ b/instrumentation/instasarama/sync_producer_test.go
@@ -1,8 +1,6 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-// +build go1.9
-
 package instasarama_test
 
 import (


### PR DESCRIPTION
This PR updates the HTTP instrumentation wrapper to implement `http.Hijacker` whenever the underlying `http.ResponseWriter` implements this interface.

It also lifts the min Go version for `github.com/instana/go-sensor` because of type aliases support.