### PR TITLE
Enable use of "PreferSimpleProtocol" option for a "pgx" driver.

### DIFF
--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -236,6 +236,10 @@ func (conn sqlConn) ExecContext(ctx context.Context, query string, args []driver
 	return sqlResult{}, conn.Error
 }
 
+func (conn sqlConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return sqlRows{}, conn.Error
+}
+
 type sqlStmt struct{ Error error }
 
 func (sqlStmt) Close() error                                         { return nil }


### PR DESCRIPTION
After implementing QueryContext in the SQL instrumentation, instrumentation respects the`PreferSimpleProtocol` option for queries when used with `pgx` driver.