### PR TITLE
relax assert statement in the test

### DIFF
--- a/instrumentation/instalogrus/instalogrus_test.go
+++ b/instrumentation/instalogrus/instalogrus_test.go
@@ -75,7 +75,8 @@ func TestNewHook_SendLogSpans(t *testing.T) {
 			assert.WithinDuration(t,
 				time.Unix(int64(sp.Timestamp)/1000, int64(sp.Timestamp)%1000*1e6),
 				time.Unix(int64(logSp.Timestamp)/1000, int64(logSp.Timestamp)%1000*1e6),
-				time.Duration(sp.Duration)*time.Millisecond,
+				// We relax this requirement, because of the rounding we make when calculating the duration and timestamps.
+				(time.Duration(sp.Duration)+time.Nanosecond)*time.Millisecond,
 			)
 
 			require.IsType(t, instana.LogSpanData{}, logSp.Data)


### PR DESCRIPTION
When we calculate durations and timestamps for a span, we use the division operation with uint64. When we do this we lose precision. This leads to having an operation with a duration equal to 0, which can't be true. It is always a positive number, bigger than 0.

This PR relaxes the assert statement.