### PR TITLE
Use go-proxy-pull-action/v1.0.3

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Pull new module version
-      uses: andrewslotin/go-proxy-pull-action@v1.0.0
+      uses: andrewslotin/go-proxy-pull-action@v1.0.3


### PR DESCRIPTION
The `go-proxy-pull-action` that triggers the update of go.dev documentation upon release uses `golang:alpine` image that has switched go `go1.18` recently. In this Go version the behavior of `go get` has been changed to work with modules only, which prevents the action from execution.

`go-proxy-pull-action@v1.0.3` has [added](https://github.com/andrewslotin/go-proxy-pull-action/pull/6) support for `go1.18` and should be used instead.