### PR TITLE
do not discard the Instana tracestate list member

### DIFF
--- a/example/gin/go.mod
+++ b/example/gin/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/instana/go-sensor v1.30.0
 	github.com/instana/go-sensor/instrumentation/instagin v1.0.0
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 )

--- a/example/gin/go.sum
+++ b/example/gin/go.sum
@@ -54,8 +54,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/instrumentation/instagin/go.mod
+++ b/instrumentation/instagin/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/instana/go-sensor v1.30.0
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/opentracing/opentracing-go v1.2.0
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 )

--- a/instrumentation/instagin/go.sum
+++ b/instrumentation/instagin/go.sum
@@ -52,8 +52,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/instrumentation/instalogrus/go.mod
+++ b/instrumentation/instalogrus/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/sirupsen/logrus v1.5.0
 )
 
-require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+require golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect

--- a/instrumentation/instalogrus/go.sum
+++ b/instrumentation/instalogrus/go.sum
@@ -20,8 +20,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/propagation.go
+++ b/propagation.go
@@ -234,7 +234,7 @@ func addW3CTraceContext(h http.Header, sc SpanContext) {
 	// participate in w3c trace context if tracing is enabled
 	if !sc.Suppressed {
 		// propagate truncated trace ID downstream
-		trCtx.RawState = trCtx.State().SetInstanaTraceStateValue(FormatID(sc.TraceID)+";"+spanID).String()
+		trCtx.RawState = w3ctrace.FormStateWithInstanaTraceStateValue(trCtx.State(), FormatID(sc.TraceID)+";"+spanID).String()
 	}
 
 	w3ctrace.Inject(trCtx, h)

--- a/propagation.go
+++ b/propagation.go
@@ -234,7 +234,7 @@ func addW3CTraceContext(h http.Header, sc SpanContext) {
 	// participate in w3c trace context if tracing is enabled
 	if !sc.Suppressed {
 		// propagate truncated trace ID downstream
-		trCtx.RawState = trCtx.State().Add(w3ctrace.VendorInstana, FormatID(sc.TraceID)+";"+spanID).String()
+		trCtx.RawState = trCtx.State().SetInstanaTraceStateValue(FormatID(sc.TraceID)+";"+spanID).String()
 	}
 
 	w3ctrace.Inject(trCtx, h)

--- a/span_context.go
+++ b/span_context.go
@@ -103,7 +103,7 @@ func NewSpanContext(parent SpanContext) SpanContext {
 	// check if there is Instana state stored in the W3C tracestate header
 	if foreignTrace {
 		w3cState := c.W3CContext.State()
-		if ancestor, ok := w3cState.Fetch(w3ctrace.VendorInstana); ok {
+		if ancestor, ok := w3cState.FetchInstanaTraceStateValue(); ok {
 			if ref, ok := parseW3CInstanaState(ancestor); ok {
 				c.Links = append(c.Links, ref)
 			}
@@ -160,7 +160,7 @@ func restoreFromW3CTraceState(trCtx w3ctrace.Context) SpanContext {
 		W3CContext: trCtx,
 	}
 
-	state, ok := trCtx.State().Fetch(w3ctrace.VendorInstana)
+	state, ok := trCtx.State().FetchInstanaTraceStateValue()
 	if !ok {
 		return c
 	}

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -88,14 +88,8 @@ func Inject(trCtx Context, headers http.Header) {
 }
 
 // State parses RawState and returns the corresponding list.
-// It silently discards malformed state. To check errors use ParseState().
 func (c Context) State() State {
-	st, err := ParseState(c.RawState)
-	if err != nil {
-		return State{}
-	}
-
-	return st
+	return ParseState(c.RawState)
 }
 
 // Parent parses RawParent and returns the corresponding list.

--- a/w3ctrace/context_test.go
+++ b/w3ctrace/context_test.go
@@ -95,7 +95,7 @@ func TestContext_State(t *testing.T) {
 		RawState:  exampleTraceState,
 	}
 
-	assert.Equal(t, w3ctrace.State{"vendorname1=opaqueValue1 ", " vendorname2=opaqueValue2"}, trCtx.State())
+	assert.Equal(t, w3ctrace.NewState([]string{"vendorname1=opaqueValue1 ", " vendorname2=opaqueValue2"}, ""), trCtx.State())
 }
 
 func TestContext_Parent(t *testing.T) {

--- a/w3ctrace/state.go
+++ b/w3ctrace/state.go
@@ -5,6 +5,7 @@ package w3ctrace
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 )
 
@@ -17,109 +18,117 @@ const maxKVPairs = 32
 // Length of entries that should be filtered first in case, if tracestate has more than `maxKVPairs` items
 const thresholdLen = 128
 
+var instanaListMemberRegex = regexp.MustCompile("^\\s*" + VendorInstana + "\\s*=\\s*([^,]*)\\s*$")
+
 // State is list of key=value pairs representing vendor-specific data in the trace context
-type State []string
+type State struct {
+	// The key-value pairs of other vendors. The "in" list member, if present, will be stored separately
+	// (Note: list member is the term the W3C trace context specfication uses for the key-value pairs.)
+	listMembers []string
+
+	// The value for the Instana-specific list member ("in=...").
+	instanaTraceStateValue string
+}
+
+// makeState creates a new State with the given values
+func NewState(listMembers []string, instanaTraceStateValue string) State {
+	return State{
+		listMembers:            listMembers,
+		instanaTraceStateValue: instanaTraceStateValue,
+	}
+}
 
 // ParseState parses the value of `tracestate` header. Empty list items are omitted.
 func ParseState(traceStateValue string) (State, error) {
-	states := filterEmptyItems(strings.Split(traceStateValue, ","))
-	if len(states) < maxKVPairs {
-		return states, nil
+	listMembers := filterEmptyItems(strings.Split(traceStateValue, ","))
+
+	// Look for the Instana list member first, before discarding any list members due to length restrictions.
+	var instanaTraceStateValue string
+	instanaTraceStateIdx := -1
+	for i, vd := range listMembers {
+		matchResult := instanaListMemberRegex.FindStringSubmatch(vd)
+		if len(matchResult) == 2 {
+			instanaTraceStateValue = strings.TrimSpace(matchResult[1])
+			instanaTraceStateIdx = i
+			break
+		}
 	}
 
-	itemsToFilter := len(states) - maxKVPairs
-	filteredStates := states[:0]
+	if instanaTraceStateIdx >= 0 {
+		// remove the entry for instana from the array of list members
+		listMembers = append(listMembers[:instanaTraceStateIdx], listMembers[instanaTraceStateIdx+1:]...)
+	}
 
+	// Depending on whether we found an Instana list member, we can either allow 31 or 32 list members from other vendors.
+	maxListMembers := maxKVPairs
+	if instanaTraceStateValue != "" {
+		maxListMembers--
+	}
+
+	if len(listMembers) < maxListMembers {
+		return State{listMembers: listMembers, instanaTraceStateValue: instanaTraceStateValue}, nil
+	}
+
+	itemsToFilter := len(listMembers) - maxListMembers
+	filteredListMembers := listMembers[:0]
 	i := 0
-	for ; itemsToFilter > 0 && i < len(states); i++ {
-
-		if len(states[i]) > thresholdLen {
+	for ; itemsToFilter > 0 && i < len(listMembers); i++ {
+		if len(listMembers[i]) > thresholdLen {
 			itemsToFilter--
 			continue
 		}
-
-		filteredStates = append(filteredStates, states[i])
+		filteredListMembers = append(filteredListMembers, listMembers[i])
 	}
-	filteredStates = append(filteredStates, states[i:]...)
+	filteredListMembers = append(filteredListMembers, listMembers[i:]...)
 
-	if len(filteredStates) > maxKVPairs {
-		return filteredStates[:maxKVPairs], nil
+	if len(filteredListMembers) > maxListMembers {
+		return State{listMembers: filteredListMembers[:maxListMembers], instanaTraceStateValue: instanaTraceStateValue}, nil
 	}
 
-	return filteredStates, nil
+	return State{listMembers: filteredListMembers, instanaTraceStateValue: instanaTraceStateValue}, nil
 }
 
-// Add returns a new state prepended with provided vendor-specific data. It removes any existing
-// entries for this vendor and returns the same state if vendor is empty. If the number of entries
-// in a state reaches the MaxStateEntries, rest of the items will be truncated
-func (st State) Add(vendor, data string) State {
-	if vendor == "" {
-		return st
+// SetInstanaValue returns a new state prepended with the provided Instana value. If the original state had an Instana
+// list member pair, it is discarded/overwritten.
+func (st State) SetInstanaTraceStateValue(instanaTraceStateValue string) State {
+	var listMembers []string
+	if st.instanaTraceStateValue == "" && instanaTraceStateValue != "" && len(st.listMembers) == maxKVPairs {
+		// The incoming tracestate had the maximum number of list members but no Instana list member, now we are adding an
+		// Instana list member, so we would exceed the maximum by one. Hence, we need to discard one of the other list
+		// members to stay within the limits mandated by the specification.
+		listMembers = st.listMembers[:maxKVPairs-1]
+	} else {
+		listMembers = st.listMembers
 	}
 
-	newSt := make(State, 1, len(st)+1)
-	newSt[0] = vendor + "=" + data
-	newSt = append(newSt, st.Remove(vendor)...)
-
-	// truncate the state if it reached the max number of entries
-	if len(newSt) > MaxStateEntries {
-		newSt = newSt[:MaxStateEntries]
-	}
-
-	return newSt
+	return State{listMembers: listMembers, instanaTraceStateValue: instanaTraceStateValue}
 }
 
-// Fetch retrieves stored vendor-specific data for given vendor
-func (st State) Fetch(vendor string) (string, bool) {
-	i := st.Index(vendor)
-	if i < 0 {
-		return "", false
-	}
-
-	return strings.TrimPrefix(st[i], vendor+"="), true
-}
-
-// Index returns the index of vendor-specific data for given vendor in the state.
-// It returns -1 if the state does not contain data for this vendor.
-func (st State) Index(vendor string) int {
-	prefix := vendor + "="
-
-	for i, vd := range st {
-		if strings.HasPrefix(vd, prefix) {
-			return i
-		}
-	}
-
-	return -1
-}
-
-// Remove returns a new state without data for specified vendor. It returns the same state if vendor is empty
-func (st State) Remove(vendor string) State {
-	if vendor == "" {
-		return st
-	}
-
-	prefix := vendor + "="
-
-	var newSt State
-	for _, vd := range st {
-		if !strings.HasPrefix(vd, prefix) {
-			newSt = append(newSt, vd)
-		}
-	}
-
-	return newSt
+// FetchInstanaTraceStateValue retrieves the value of the Instana tracestate list member, if any.
+func (st State) FetchInstanaTraceStateValue() (string, bool) {
+	return st.instanaTraceStateValue, st.instanaTraceStateValue != ""
 }
 
 // String returns string representation of a trace state. The returned value is compatible with the
-// `tracestate` header format
+// `tracestate` header format. If the state has an Instana-specific list member, that one is always rendered first. This
+// is optimized for the use case of injecting the string represenation of the tracestate header into downstream
+// requests.
 func (st State) String() string {
-	if len(st) == 0 {
+	if len(st.listMembers) == 0 && st.instanaTraceStateValue == "" {
 		return ""
+	}
+	if len(st.listMembers) == 0 {
+		return VendorInstana + "=" + st.instanaTraceStateValue
 	}
 
 	buf := bytes.NewBuffer(nil)
-	for _, vd := range st {
+	if st.instanaTraceStateValue != "" {
+		buf.WriteString(VendorInstana)
+		buf.WriteString("=")
+		buf.WriteString(st.instanaTraceStateValue)
+		buf.WriteString(",")
+	}
+	for _, vd := range st.listMembers {
 		buf.WriteString(vd)
 		buf.WriteByte(',')
 	}

--- a/w3ctrace/state_test.go
+++ b/w3ctrace/state_test.go
@@ -103,39 +103,38 @@ func TestParseState(t *testing.T) {
 
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
-			st, err := w3ctrace.ParseState(example.Header)
-			require.NoError(t, err)
+			st := w3ctrace.ParseState(example.Header)
 			assert.Equal(t, example.Expected, st)
 		})
 	}
 }
 
-func TestState_SetInstanaTraceStateValueIntoEmptyTraceState(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueIntoEmptyTraceState(t *testing.T) {
 	st := w3ctrace.NewState([]string{}, "")
-	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "fa2375d711a4ca0f;02468acefdb97531")
 	require.Equal(t, w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531"), st)
 }
 
-func TestState_SetInstanaTraceStateValueIntoNonEmptyTraceState(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueIntoNonEmptyTraceState(t *testing.T) {
 	st := w3ctrace.NewState([]string{"key1=value1", "key2=value"}, "")
-	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "fa2375d711a4ca0f;02468acefdb97531")
 	require.Equal(t, w3ctrace.NewState([]string{"key1=value1", "key2=value"}, "fa2375d711a4ca0f;02468acefdb97531"), st)
 }
 
-func TestState_SetInstanaTraceStateValueOverwriteExistingValue(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueOverwriteExistingValue(t *testing.T) {
 	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
-	st = st.SetInstanaTraceStateValue("aaabbccddeeff012;123456789abcdef0")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "aaabbccddeeff012;123456789abcdef0")
 	require.Equal(t, w3ctrace.NewState([]string{}, "aaabbccddeeff012;123456789abcdef0"), st)
 }
 
-func TestState_SetInstanaTraceStateValueResetExistingValue(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueResetExistingValue(t *testing.T) {
 	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
-	st = st.SetInstanaTraceStateValue("")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "")
 	require.Equal(t, w3ctrace.NewState([]string{}, ""), st)
 }
 
-func TestState_SetInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMembers(t *testing.T) {
-	listMembers := []string{}
+func TestState_FormStateWithInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMembers(t *testing.T) {
+	var listMembers []string
 	for i := 0; i < maxKVPairs; i++ {
 		listMembers = append(listMembers, fmt.Sprintf("key%d=value%d", i, i))
 	}
@@ -144,7 +143,7 @@ func TestState_SetInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMember
 	st := w3ctrace.NewState(listMembers, "")
 	require.Equal(t, w3ctrace.NewState(listMembers, ""), st)
 	// now we also add an Instana list member, which brings us over the limit
-	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "fa2375d711a4ca0f;02468acefdb97531")
 	// so we expect the right-most list member to be dropped
 	require.Equal(t, w3ctrace.NewState(listMembers[:maxKVPairs-1], "fa2375d711a4ca0f;02468acefdb97531"), st)
 }

--- a/w3ctrace/state_test.go
+++ b/w3ctrace/state_test.go
@@ -13,55 +13,91 @@ import (
 	"github.com/instana/testify/require"
 )
 
+const maxKVPairs = 32
+
 func TestParseState(t *testing.T) {
-	const maxKVPairs = 32
 
 	examples := map[string]struct {
 		Header   string
 		Expected w3ctrace.State
 	}{
 		"empty": {
-			Expected: w3ctrace.State{},
+			Expected: w3ctrace.NewState([]string{}, ""),
 		},
 		"single tracing system": {
 			Header:   "rojo=00f067aa0ba902b7",
-			Expected: w3ctrace.State{"rojo=00f067aa0ba902b7"},
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7"}, ""),
 		},
 		"multiple tracing systems": {
 			Header:   "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE",
-			Expected: w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"},
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}, ""),
+		},
+		"only an Instana list member": {
+			Header:   "in=fa2375d711a4ca0f;02468acefdb97531",
+			Expected: w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531"),
+		},
+		"one other and one Instana list member": {
+			Header:   "rojo=00f067aa0ba902b7,in=fa2375d711a4ca0f;02468acefdb97531",
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7"}, "fa2375d711a4ca0f;02468acefdb97531"),
+		},
+		"one Instana and one other list member": {
+			Header:   "in=fa2375d711a4ca0f;02468acefdb97531,rojo=00f067aa0ba902b7",
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7"}, "fa2375d711a4ca0f;02468acefdb97531"),
+		},
+		"one Instana list member between two others": {
+			Header:   "rojo=00f067aa0ba902b7,in=fa2375d711a4ca0f;02468acefdb97531,congo=t61rcWkgMzE",
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}, "fa2375d711a4ca0f;02468acefdb97531"),
 		},
 		"with empty list items": {
 			Header:   "rojo=00f067aa0ba902b7,    ,,congo=t61rcWkgMzE",
-			Expected: w3ctrace.State{"rojo=00f067aa0ba902b7", "    ", "congo=t61rcWkgMzE"},
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7", "    ", "congo=t61rcWkgMzE"}, ""),
+		},
+		"with whitespace around the Instana list member": {
+			Header:   "rojo=00f067aa0ba902b7,  in   =   fa2375d711a4ca0f;02468acefdb97531    ,congo=t61rcWkgMzE",
+			Expected: w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}, "fa2375d711a4ca0f;02468acefdb97531"),
 		},
 		"with 33 list items": {
 			Header:   strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs+1), ","),
-			Expected: strings.Split(strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs), ","), ","),
+			Expected: w3ctrace.NewState(strings.Split(strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs), ","), ","), "")},
+		"with too many list members and an Instana list member at the end": {
+			Header:   strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs+1), ",") + ",in=fa2375d711a4ca0f;02468acefdb97531",
+			Expected: w3ctrace.NewState(strings.Split(strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs-1), ","), ","), "fa2375d711a4ca0f;02468acefdb97531"),
 		},
 		"with 34 list items, with long one at the beginning": {
-			Header:   "rojo=" + strings.Repeat("a", 129) + "," + strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs+1), ","),
-			Expected: strings.Split(strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs), ","), ","),
+			Header: "rojo=" + strings.Repeat("a", 129) + "," + strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs+1), ","),
+			Expected: w3ctrace.NewState(
+				strings.Split(strings.TrimRight(strings.Repeat("rojo=00f067aa0ba902b7,", maxKVPairs), ","), ","),
+				"",
+			),
 		},
 		"with 33 list items, each is more then 128 char long": {
-			Header:   strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs+1), ","),
-			Expected: strings.Split(strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs), ","), ","),
+			Header: strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs+1), ","),
+			Expected: w3ctrace.NewState(
+				strings.Split(strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs), ","), ","),
+				"",
+			),
 		},
 		"with 34 list items: one short and 33 long": {
-			Header:   "rojo=00f067aa0ba902b7," + strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs+1), ","),
-			Expected: strings.Split("rojo=00f067aa0ba902b7,"+strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs-1), ","), ","),
+			Header: "rojo=00f067aa0ba902b7," + strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs+1), ","),
+			Expected: w3ctrace.NewState(
+				strings.Split("rojo=00f067aa0ba902b7,"+strings.TrimRight(strings.Repeat("rojo="+strings.Repeat("a", 129)+",", maxKVPairs-1), ","), ","),
+				"",
+			),
 		},
 		"with 64 list items, mixed long and short values": {
-			Header:   strings.TrimRight(strings.Repeat("short="+strings.Repeat("b", 10)+","+"long="+strings.Repeat("a", 129)+",", maxKVPairs), ","),
-			Expected: strings.Split(strings.TrimRight(strings.Repeat("short="+strings.Repeat("b", 10)+",", maxKVPairs), ","), ","),
+			Header: strings.TrimRight(strings.Repeat("short="+strings.Repeat("b", 10)+","+"long="+strings.Repeat("a", 129)+",", maxKVPairs), ","),
+			Expected: w3ctrace.NewState(
+				strings.Split(strings.TrimRight(strings.Repeat("short="+strings.Repeat("b", 10)+",", maxKVPairs), ","), ","),
+				"",
+			),
 		},
 		"with empty header value": {
 			Header:   "",
-			Expected: w3ctrace.State{},
+			Expected: w3ctrace.NewState([]string{}, ""),
 		},
 		"with a lot of comas": {
 			Header:   strings.Repeat(",", 1024),
-			Expected: w3ctrace.State{},
+			Expected: w3ctrace.NewState([]string{}, ""),
 		},
 	}
 
@@ -74,87 +110,57 @@ func TestParseState(t *testing.T) {
 	}
 }
 
-func TestState_Add(t *testing.T) {
-	var st w3ctrace.State
-
-	st = st.Add("rojo", "00f067aa0ba902b7")
-	require.Equal(t, w3ctrace.State{"rojo=00f067aa0ba902b7"}, st)
-
-	st = st.Add("congo", "t61rcWkgMzE")
-	require.Equal(t, w3ctrace.State{"congo=t61rcWkgMzE", "rojo=00f067aa0ba902b7"}, st)
-
-	st = st.Add("", "data")
-	require.Equal(t, w3ctrace.State{"congo=t61rcWkgMzE", "rojo=00f067aa0ba902b7"}, st)
-
-	st = st.Add("rojo", "updated")
-	require.Equal(t, w3ctrace.State{"rojo=updated", "congo=t61rcWkgMzE"}, st)
-
-	st = st.Add("rojo", "updated again")
-	require.Equal(t, w3ctrace.State{"rojo=updated again", "congo=t61rcWkgMzE"}, st)
+func TestState_SetInstanaTraceStateValueIntoEmptyTraceState(t *testing.T) {
+	st := w3ctrace.NewState([]string{}, "")
+	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	require.Equal(t, w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531"), st)
 }
 
-func TestState_Add_MaximumReached(t *testing.T) {
-	var st w3ctrace.State
+func TestState_SetInstanaTraceStateValueIntoNonEmptyTraceState(t *testing.T) {
+	st := w3ctrace.NewState([]string{"key1=value1", "key2=value"}, "")
+	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	require.Equal(t, w3ctrace.NewState([]string{"key1=value1", "key2=value"}, "fa2375d711a4ca0f;02468acefdb97531"), st)
+}
 
-	for i := 0; i < w3ctrace.MaxStateEntries; i++ {
-		st = st.Add(fmt.Sprintf("vendor%d", i), "data")
+func TestState_SetInstanaTraceStateValueOverwriteExistingValue(t *testing.T) {
+	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
+	st = st.SetInstanaTraceStateValue("aaabbccddeeff012;123456789abcdef0")
+	require.Equal(t, w3ctrace.NewState([]string{}, "aaabbccddeeff012;123456789abcdef0"), st)
+}
+
+func TestState_SetInstanaTraceStateValueResetExistingValue(t *testing.T) {
+	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
+	st = st.SetInstanaTraceStateValue("")
+	require.Equal(t, w3ctrace.NewState([]string{}, ""), st)
+}
+
+func TestState_SetInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMembers(t *testing.T) {
+	listMembers := []string{}
+	for i := 0; i < maxKVPairs; i++ {
+		listMembers = append(listMembers, fmt.Sprintf("key%d=value%d", i, i))
 	}
 
-	require.Len(t, st, w3ctrace.MaxStateEntries)
-	require.Equal(t, st[w3ctrace.MaxStateEntries-1], "vendor0=data")
-
-	st = st.Add("newVendor", "data")
-	require.Len(t, st, w3ctrace.MaxStateEntries)
-	assert.Equal(t, st[0], "newVendor=data")
-	assert.Equal(t, st[w3ctrace.MaxStateEntries-1], "vendor1=data")
+	// initially, we are just under the allowed number of list members
+	st := w3ctrace.NewState(listMembers, "")
+	require.Equal(t, w3ctrace.NewState(listMembers, ""), st)
+	// now we also add an Instana list member, which brings us over the limit
+	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	// so we expect the right-most list member to be dropped
+	require.Equal(t, w3ctrace.NewState(listMembers[:maxKVPairs-1], "fa2375d711a4ca0f;02468acefdb97531"), st)
 }
 
-func TestState_Fetch(t *testing.T) {
-	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
-
-	t.Run("existing", func(t *testing.T) {
-		if vd, ok := st.Fetch("rojo"); assert.True(t, ok) {
-			assert.Equal(t, "00f067aa0ba902b7", vd)
-		}
-
-		if vd, ok := st.Fetch("congo"); assert.True(t, ok) {
-			assert.Equal(t, "t61rcWkgMzE", vd)
-		}
-	})
-
-	t.Run("non-existing", func(t *testing.T) {
-		_, ok := st.Fetch("vendor")
-		assert.False(t, ok)
-	})
+func TestState_FetchInstanaTraceStateValueNotPresent(t *testing.T) {
+	st := w3ctrace.NewState([]string{}, "")
+	instanaTraceStateValue, ok := st.FetchInstanaTraceStateValue()
+	require.False(t, ok)
+	require.Equal(t, "", instanaTraceStateValue)
 }
 
-func TestState_Index(t *testing.T) {
-	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
-
-	t.Run("existing", func(t *testing.T) {
-		assert.Equal(t, 0, st.Index("rojo"))
-		assert.Equal(t, 1, st.Index("congo"))
-	})
-
-	t.Run("non-existing", func(t *testing.T) {
-		assert.Equal(t, -1, st.Index("vendor"))
-	})
-}
-
-func TestState_Remove(t *testing.T) {
-	st := w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}
-
-	st = st.Remove("congo")
-	require.Equal(t, w3ctrace.State{"rojo=00f067aa0ba902b7"}, st)
-
-	st = st.Remove("")
-	require.Equal(t, w3ctrace.State{"rojo=00f067aa0ba902b7"}, st)
-
-	st = st.Remove("vendor")
-	require.Equal(t, w3ctrace.State{"rojo=00f067aa0ba902b7"}, st)
-
-	st = st.Remove("rojo")
-	require.Empty(t, st)
+func TestState_FetchInstanaTraceStateValuePresent(t *testing.T) {
+	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
+	instanaTraceStateValue, ok := st.FetchInstanaTraceStateValue()
+	require.True(t, ok)
+	require.Equal(t, "fa2375d711a4ca0f;02468acefdb97531", instanaTraceStateValue)
 }
 
 func TestState_String(t *testing.T) {
@@ -164,12 +170,20 @@ func TestState_String(t *testing.T) {
 	}{
 		"empty": {},
 		"single tracing system": {
-			State:    w3ctrace.State{"rojo=00f067aa0ba902b7"},
+			State:    w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7"}, ""),
 			Expected: "rojo=00f067aa0ba902b7",
 		},
-		"multiple tracing systems": {
-			State:    w3ctrace.State{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"},
+		"only an Instana list member": {
+			State:    w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531"),
+			Expected: "in=fa2375d711a4ca0f;02468acefdb97531",
+		},
+		"multiple tracing systems, without Instana list member": {
+			State:    w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}, ""),
 			Expected: "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE",
+		},
+		"multiple tracing systems plus an Instana list member": {
+			State:    w3ctrace.NewState([]string{"rojo=00f067aa0ba902b7", "congo=t61rcWkgMzE"}, "fa2375d711a4ca0f;02468acefdb97531"),
+			Expected: "in=fa2375d711a4ca0f;02468acefdb97531,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE",
 		},
 	}
 


### PR DESCRIPTION
Previously, when more than 32 list members were in the incoming
tracestate header value, and the Instana-specific list member (in=...)
was at position 33 or later, we would drop it together with the other
list members that need to be droppped. With this change, we give the
Instana list member higher priority than list members from other
vendors.

We also keep it separate in the TraceState struct.

Furthermore, this simplifies/reduces the API of the TraceState module.
We do not have a use case for adding/removing list members for arbitrary
vendors - we only need to propagate the list members we received and
make sure that the Instana trace state value is added in the left-most
position.