### PR TITLE
Small update to the w3c headers handling

### DIFF
--- a/example/gin/go.mod
+++ b/example/gin/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/instana/go-sensor v1.30.0
 	github.com/instana/go-sensor/instrumentation/instagin v1.0.0
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 )

--- a/example/gin/go.sum
+++ b/example/gin/go.sum
@@ -54,8 +54,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/instrumentation/instagin/go.mod
+++ b/instrumentation/instagin/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/instana/go-sensor v1.30.0
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/opentracing/opentracing-go v1.2.0
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 )

--- a/instrumentation/instagin/go.sum
+++ b/instrumentation/instagin/go.sum
@@ -52,8 +52,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/instrumentation/instalogrus/go.mod
+++ b/instrumentation/instalogrus/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/sirupsen/logrus v1.5.0
 )
 
-require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+require golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect

--- a/instrumentation/instalogrus/go.sum
+++ b/instrumentation/instalogrus/go.sum
@@ -20,8 +20,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/propagation.go
+++ b/propagation.go
@@ -234,7 +234,7 @@ func addW3CTraceContext(h http.Header, sc SpanContext) {
 	// participate in w3c trace context if tracing is enabled
 	if !sc.Suppressed {
 		// propagate truncated trace ID downstream
-		trCtx.RawState = trCtx.State().SetInstanaTraceStateValue(FormatID(sc.TraceID)+";"+spanID).String()
+		trCtx.RawState = w3ctrace.FormStateWithInstanaTraceStateValue(trCtx.State(), FormatID(sc.TraceID)+";"+spanID).String()
 	}
 
 	w3ctrace.Inject(trCtx, h)

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -88,14 +88,8 @@ func Inject(trCtx Context, headers http.Header) {
 }
 
 // State parses RawState and returns the corresponding list.
-// It silently discards malformed state. To check errors use ParseState().
 func (c Context) State() State {
-	st, err := ParseState(c.RawState)
-	if err != nil {
-		return State{}
-	}
-
-	return st
+	return ParseState(c.RawState)
 }
 
 // Parent parses RawParent and returns the corresponding list.

--- a/w3ctrace/state_test.go
+++ b/w3ctrace/state_test.go
@@ -103,39 +103,38 @@ func TestParseState(t *testing.T) {
 
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
-			st, err := w3ctrace.ParseState(example.Header)
-			require.NoError(t, err)
+			st := w3ctrace.ParseState(example.Header)
 			assert.Equal(t, example.Expected, st)
 		})
 	}
 }
 
-func TestState_SetInstanaTraceStateValueIntoEmptyTraceState(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueIntoEmptyTraceState(t *testing.T) {
 	st := w3ctrace.NewState([]string{}, "")
-	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "fa2375d711a4ca0f;02468acefdb97531")
 	require.Equal(t, w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531"), st)
 }
 
-func TestState_SetInstanaTraceStateValueIntoNonEmptyTraceState(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueIntoNonEmptyTraceState(t *testing.T) {
 	st := w3ctrace.NewState([]string{"key1=value1", "key2=value"}, "")
-	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "fa2375d711a4ca0f;02468acefdb97531")
 	require.Equal(t, w3ctrace.NewState([]string{"key1=value1", "key2=value"}, "fa2375d711a4ca0f;02468acefdb97531"), st)
 }
 
-func TestState_SetInstanaTraceStateValueOverwriteExistingValue(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueOverwriteExistingValue(t *testing.T) {
 	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
-	st = st.SetInstanaTraceStateValue("aaabbccddeeff012;123456789abcdef0")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "aaabbccddeeff012;123456789abcdef0")
 	require.Equal(t, w3ctrace.NewState([]string{}, "aaabbccddeeff012;123456789abcdef0"), st)
 }
 
-func TestState_SetInstanaTraceStateValueResetExistingValue(t *testing.T) {
+func TestState_FormStateWithInstanaTraceStateValueResetExistingValue(t *testing.T) {
 	st := w3ctrace.NewState([]string{}, "fa2375d711a4ca0f;02468acefdb97531")
-	st = st.SetInstanaTraceStateValue("")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "")
 	require.Equal(t, w3ctrace.NewState([]string{}, ""), st)
 }
 
-func TestState_SetInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMembers(t *testing.T) {
-	listMembers := []string{}
+func TestState_FormStateWithInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMembers(t *testing.T) {
+	var listMembers []string
 	for i := 0; i < maxKVPairs; i++ {
 		listMembers = append(listMembers, fmt.Sprintf("key%d=value%d", i, i))
 	}
@@ -144,7 +143,7 @@ func TestState_SetInstanaTraceStateValueAddToTraceStateWithMaxNumberOfListMember
 	st := w3ctrace.NewState(listMembers, "")
 	require.Equal(t, w3ctrace.NewState(listMembers, ""), st)
 	// now we also add an Instana list member, which brings us over the limit
-	st = st.SetInstanaTraceStateValue("fa2375d711a4ca0f;02468acefdb97531")
+	st = w3ctrace.FormStateWithInstanaTraceStateValue(st, "fa2375d711a4ca0f;02468acefdb97531")
 	// so we expect the right-most list member to be dropped
 	require.Equal(t, w3ctrace.NewState(listMembers[:maxKVPairs-1], "fa2375d711a4ca0f;02468acefdb97531"), st)
 }


### PR DESCRIPTION
@basti1302, @willianpc  Thank you a lot for the original PR. 👍 Great job. 👏 

I think the original PR is good and do its job well. In this PR I want to propose some ideas/changes to it. Please check if they make sense for you:

1. There is an update for golang.org/x/sys to mitigate this issue https://github.com/golang/go/issues/49219.
2. I removed a duplicated constant for the "32" value in state.go file (same for the test).
3. Removed the second returned parameter from the "ParseState" method which is always nil.
4. Extracted the "searchInstanaHeader" function from the "ParseState" method to make it easier to read.
5. Replaced "SetInstanaTraceStateValue" method with a function "FormStateWithInstanaTraceStateValue" (not sure if the name is good enough). I did it because this function/method is doing more than setting the value. It changes the list of the members and acts more like a constructor, that returns a new object from the new data and data from the old state.
6. Removed the "NewState" function, because it was used only in the tests.