### PR TITLE
Improve performance for FormatID() function

### DIFF
--- a/util.go
+++ b/util.go
@@ -36,18 +36,8 @@ func randomID() int64 {
 func FormatID(id int64) string {
 	// FIXME: We're assuming LittleEndian here
 
-	// Write out _signed_ 64bit integer to byte buffer
-	buf := bytes.NewBuffer(nil)
-	// binary.Write() does not return an error for basic data types, neither does (*bytes.Buffer).Write()
-	binary.Write(buf, binary.LittleEndian, id)
-
-	// Read bytes back into _unsigned_ 64 bit integer
-	var unsigned uint64
-	// it's safe to ignore the error here, since the value in buffer is controlled by us
-	binary.Read(buf, binary.LittleEndian, &unsigned)
-
 	// Convert uint64 to hex string equivalent and return that
-	return padHexString(strconv.FormatUint(unsigned, 16), 64)
+	return padHexString(strconv.FormatUint(uint64(id), 16), 64)
 }
 
 // FormatLongID converts a 128-bit Instana ID passed in two quad words to an

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -181,3 +181,9 @@ eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0
 		}()
 	}
 }
+
+func BenchmarkFormatID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		FormatID(int64(i))
+	}
+}


### PR DESCRIPTION
This PR changes is how the value converts from int64 to uint64. It gives some performance benefits.

`BenchmarkFormatID-16                     4194214               264.2 ns/op           176 B/op          8 allocs/op
`
->
`BenchmarkFormatID-16                    10477688                98.68 ns/op           32 B/op          2 allocs/op
`