### PR TITLE
go-redis improved tests: mocked redis replaced by mocked go-redis API

### DIFF
--- a/instrumentation/instaredis/instaredis.go
+++ b/instrumentation/instaredis/instaredis.go
@@ -161,7 +161,7 @@ func WrapClient(client InstanaRedisClient, sensor *instana.Sensor) InstanaRedisC
 	return client
 }
 
-// WrapClient wraps the Redis client instance in order to add the instrumentation
+// WrapClusterClient wraps the Redis client instance in order to add the instrumentation
 func WrapClusterClient(clusterClient InstanaRedisClusterClient, sensor *instana.Sensor) InstanaRedisClusterClient {
 	opts := clusterClient.Options()
 	clusterClient.AddHook(newCommandCapture(*sensor, nil, opts))

--- a/instrumentation/instaredis/instaredis.go
+++ b/instrumentation/instaredis/instaredis.go
@@ -144,15 +144,25 @@ func (h commandCaptureHook) AfterProcessPipeline(ctx context.Context, cmds []red
 	return nil
 }
 
+type InstanaRedisClient interface {
+	AddHook(hook redis.Hook)
+	Options() *redis.Options
+}
+
+type InstanaRedisClusterClient interface {
+	AddHook(hook redis.Hook)
+	Options() *redis.ClusterOptions
+}
+
 // WrapClient wraps the Redis client instance in order to add the instrumentation
-func WrapClient(client *redis.Client, sensor *instana.Sensor) *redis.Client {
+func WrapClient(client InstanaRedisClient, sensor *instana.Sensor) InstanaRedisClient {
 	opts := client.Options()
 	client.AddHook(newCommandCapture(*sensor, opts, nil))
 	return client
 }
 
 // WrapClient wraps the Redis client instance in order to add the instrumentation
-func WrapClusterClient(clusterClient *redis.ClusterClient, sensor *instana.Sensor) *redis.ClusterClient {
+func WrapClusterClient(clusterClient InstanaRedisClusterClient, sensor *instana.Sensor) InstanaRedisClusterClient {
 	opts := clusterClient.Options()
 	clusterClient.AddHook(newCommandCapture(*sensor, nil, opts))
 	return clusterClient


### PR DESCRIPTION
This PR replaces the mocked Redis server - which was too complex and hard to maintain - by a mock around go-redis API instead.
This refactoring caused a small change in the wrappers signature, there is no incompatibility to the current usage of the instrumentation.