### PR TITLE
make recorder configurable and add option to queue traces when not ready

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -74,11 +74,9 @@ func NewRecorder(options ...RecorderOption) *Recorder {
 // NewTestRecorder initializes a new span recorder that keeps all collected
 // until they are requested. This recorder does not send spans to the agent (used for testing)
 func NewTestRecorder() *Recorder {
-	r := &Recorder{
+	return &Recorder{
 		testMode: true,
 	}
-
-	return r
 }
 
 // RecordSpan accepts spans to be recorded and added to the span queue


### PR DESCRIPTION
when our services start up, it will take a while till the instana sensor is ready to handle our traffic. however, we already make calls during that time to fetch configurations, roles, etc. 

we do not want to be blind for these calls and so we want to be able to queue calls when the sensor is not yet ready. 

this is a none-breaking change which does just that. 

Implementing my own recorder is unfortunately not an option as the interface contains an unexported struct. 