### PR TITLE
Add wrappers for the AWSSDK session's constructors

### DIFF
--- a/instrumentation/instaawssdk/instaawssdk.go
+++ b/instrumentation/instaawssdk/instaawssdk.go
@@ -25,6 +25,38 @@ var errMethodNotInstrumented = errors.New("method not instrumented")
 
 const maxClientContextLen = 3582
 
+// New is a wrapper for `session.New`
+func New(cfgs *aws.Config, sensor *instana.Sensor) *session.Session {
+	sess := session.New(cfgs)
+	InstrumentSession(sess, sensor)
+
+	return sess
+}
+
+// NewSession is a wrapper for `session.NewSession`
+func NewSession(cfgs *aws.Config, sensor *instana.Sensor) (*session.Session, error) {
+	sess, err := session.NewSession(cfgs)
+	if err != nil {
+		return sess, err
+	}
+
+	InstrumentSession(sess, sensor)
+
+	return sess, nil
+}
+
+// NewSessionWithOptions is a wrapper for `session.NewSessionWithOptions`
+func NewSessionWithOptions(opts session.Options, sensor *instana.Sensor) (*session.Session, error) {
+	sess, err := session.NewSessionWithOptions(opts)
+	if err != nil {
+		return sess, err
+	}
+
+	InstrumentSession(sess, sensor)
+
+	return sess, nil
+}
+
 // InstrumentSession instruments github.com/aws/aws-sdk-go/aws/session.Session by
 // injecting handlers to create and finalize Instana spans
 func InstrumentSession(sess *session.Session, sensor *instana.Sensor) {

--- a/instrumentation/instaawssdk/instaawssdk.go
+++ b/instrumentation/instaawssdk/instaawssdk.go
@@ -26,16 +26,16 @@ var errMethodNotInstrumented = errors.New("method not instrumented")
 const maxClientContextLen = 3582
 
 // New is a wrapper for `session.New`
-func New(cfgs *aws.Config, sensor *instana.Sensor) *session.Session {
-	sess := session.New(cfgs)
+func New(sensor *instana.Sensor, cfgs ...*aws.Config) *session.Session {
+	sess := session.New(cfgs...)
 	InstrumentSession(sess, sensor)
 
 	return sess
 }
 
 // NewSession is a wrapper for `session.NewSession`
-func NewSession(cfgs *aws.Config, sensor *instana.Sensor) (*session.Session, error) {
-	sess, err := session.NewSession(cfgs)
+func NewSession(sensor *instana.Sensor, cfgs ...*aws.Config) (*session.Session, error) {
+	sess, err := session.NewSession(cfgs...)
 	if err != nil {
 		return sess, err
 	}
@@ -46,7 +46,7 @@ func NewSession(cfgs *aws.Config, sensor *instana.Sensor) (*session.Session, err
 }
 
 // NewSessionWithOptions is a wrapper for `session.NewSessionWithOptions`
-func NewSessionWithOptions(opts session.Options, sensor *instana.Sensor) (*session.Session, error) {
+func NewSessionWithOptions(sensor *instana.Sensor, opts session.Options) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(opts)
 	if err != nil {
 		return sess, err

--- a/instrumentation/instaawssdk/instaawssdk_test.go
+++ b/instrumentation/instaawssdk/instaawssdk_test.go
@@ -1,0 +1,38 @@
+package instaawssdk_test
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	instana "github.com/instana/go-sensor"
+	"github.com/instana/go-sensor/instrumentation/instaawssdk"
+	"github.com/instana/testify/assert"
+	"testing"
+)
+
+func TestNew1(t *testing.T) {
+	sess := instaawssdk.New(instana.NewSensor("test"), &aws.Config{Region: aws.String("region")}, &aws.Config{Endpoint: aws.String("somestring")})
+	assert.IsType(t, &session.Session{}, sess)
+}
+
+func TestNew2(t *testing.T) {
+	sess := instaawssdk.New(instana.NewSensor("test"), []*aws.Config{{Region: aws.String("region")}, &aws.Config{Endpoint: aws.String("somestring")}}...)
+	assert.IsType(t, &session.Session{}, sess)
+}
+
+func TestNewSession1(t *testing.T) {
+	sess, err := instaawssdk.NewSession(instana.NewSensor("test"), &aws.Config{Region: aws.String("region")}, &aws.Config{Endpoint: aws.String("somestring")})
+	assert.IsType(t, &session.Session{}, sess)
+	assert.NoError(t, err)
+}
+
+func TestNewSession2(t *testing.T) {
+	sess, err := instaawssdk.NewSession(instana.NewSensor("test"), []*aws.Config{{Region: aws.String("region")}, &aws.Config{Endpoint: aws.String("somestring")}}...)
+	assert.IsType(t, &session.Session{}, sess)
+	assert.NoError(t, err)
+}
+
+func TestNewSessionWithOptions(t *testing.T) {
+	sess, err := instaawssdk.NewSessionWithOptions(instana.NewSensor("test"), session.Options{})
+	assert.IsType(t, &session.Session{}, sess)
+	assert.NoError(t, err)
+}

--- a/instrumentation/instaawssdk/instaawssdk_test.go
+++ b/instrumentation/instaawssdk/instaawssdk_test.go
@@ -1,3 +1,5 @@
+// (c) Copyright IBM Corp. 2021
+
 package instaawssdk_test
 
 import (


### PR DESCRIPTION
This PR adds new wrappers to the AWSSDK instrumentation package. It does not extend existing functionality, it is just an alternative method to get an instrumented session.