### PR TITLE
Returned struct is now public visible

### DIFF
--- a/instrumentation/instahttprouter/router.go
+++ b/instrumentation/instahttprouter/router.go
@@ -13,50 +13,50 @@ import (
 
 // Wrap returns an instrumented instance of a httprouter.Router that
 // instruments HTTP handlers with Instana upon registration.
-func Wrap(r *httprouter.Router, sensor *instana.Sensor) *wrappedRouter {
-	return &wrappedRouter{
+func Wrap(r *httprouter.Router, sensor *instana.Sensor) *WrappedRouter {
+	return &WrappedRouter{
 		Router: r,
 		sensor: sensor,
 	}
 }
 
-type wrappedRouter struct {
+type WrappedRouter struct {
 	*httprouter.Router
 	sensor *instana.Sensor
 }
 
 // GET is a shortcut for router.Handle(http.MethodGet, path, handle)
-func (r *wrappedRouter) GET(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) GET(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodGet, path, handle)
 }
 
 // HEAD is a shortcut for router.Handle(http.MethodHead, path, handle)
-func (r *wrappedRouter) HEAD(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) HEAD(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodHead, path, handle)
 }
 
 // OPTIONS is a shortcut for router.Handle(http.MethodOptions, path, handle)
-func (r *wrappedRouter) OPTIONS(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) OPTIONS(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodOptions, path, handle)
 }
 
 // POST is a shortcut for router.Handle(http.MethodPost, path, handle)
-func (r *wrappedRouter) POST(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) POST(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodPost, path, handle)
 }
 
 // PUT is a shortcut for router.Handle(http.MethodPut, path, handle)
-func (r *wrappedRouter) PUT(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) PUT(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodPut, path, handle)
 }
 
 // PATCH is a shortcut for router.Handle(http.MethodPatch, path, handle)
-func (r *wrappedRouter) PATCH(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) PATCH(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodPatch, path, handle)
 }
 
 // DELETE is a shortcut for router.Handle(http.MethodDelete, path, handle)
-func (r *wrappedRouter) DELETE(path string, handle httprouter.Handle) {
+func (r *WrappedRouter) DELETE(path string, handle httprouter.Handle) {
 	r.Handle(http.MethodDelete, path, handle)
 }
 
@@ -64,7 +64,7 @@ func (r *wrappedRouter) DELETE(path string, handle httprouter.Handle) {
 //
 // For details please refer to the (*httprouter.Router).Handle() documentation:
 // https://pkg.go.dev/github.com/julienschmidt/httprouter#Router.Handle
-func (r *wrappedRouter) Handle(method, path string, handle httprouter.Handle) {
+func (r *WrappedRouter) Handle(method, path string, handle httprouter.Handle) {
 	r.Router.HandlerFunc(method, path, instana.TracingHandlerFunc(r.sensor, path, func(w http.ResponseWriter, req *http.Request) {
 		handle(w, req, httprouter.ParamsFromContext(req.Context()))
 	}))
@@ -73,7 +73,7 @@ func (r *wrappedRouter) Handle(method, path string, handle httprouter.Handle) {
 // Handler is an adapter which allows the usage of an uninstrumented http.Handler as a
 // request handle.
 // The Params are available in the request context under ParamsKey.
-func (r *wrappedRouter) Handler(method, path string, handler http.Handler) {
+func (r *WrappedRouter) Handler(method, path string, handler http.Handler) {
 	r.Handle(method, path,
 		func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 			if len(p) > 0 {
@@ -88,6 +88,6 @@ func (r *wrappedRouter) Handler(method, path string, handler http.Handler) {
 
 // HandlerFunc is an adapter which allows the usage of an uninstrumented http.HandlerFunc as a
 // request handle.
-func (r *wrappedRouter) HandlerFunc(method, path string, handler http.HandlerFunc) {
+func (r *WrappedRouter) HandlerFunc(method, path string, handler http.HandlerFunc) {
 	r.Handler(method, path, handler)
 }


### PR DESCRIPTION
This change essentially allows customers to declare variables in addition to type inference assignments.
The type returned by the instrumentation is now public, so customers can write something like this:

```go
var router *instahttprouter.WrappedRouter
```

That was not possible previously as `wrappedRouter` was private.