### PR TITLE
Change sarama instrumentation

### DIFF
--- a/instrumentation/instasarama/consumer_group.go
+++ b/instrumentation/instasarama/consumer_group.go
@@ -1,0 +1,48 @@
+// (c) Copyright IBM Corp. 2022
+
+package instasarama
+
+import (
+	"context"
+	"github.com/Shopify/sarama"
+	instana "github.com/instana/go-sensor"
+)
+
+func NewConsumerGroup(addrs []string, groupID string, config *sarama.Config, sensor *instana.Sensor) (sarama.ConsumerGroup, error) {
+	c, err := sarama.NewConsumerGroup(addrs, groupID, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return consumerGroup{c, sensor}, nil
+}
+
+func NewConsumerGroupFromClient(groupID string, client sarama.Client, sensor *instana.Sensor) (sarama.ConsumerGroup, error) {
+	c, err := sarama.NewConsumerGroupFromClient(groupID, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return consumerGroup{c, sensor}, nil
+}
+
+type consumerGroup struct {
+	cg     sarama.ConsumerGroup
+	sensor *instana.Sensor
+}
+
+func (c consumerGroup) Errors() <-chan error {
+	return c.cg.Errors()
+}
+
+func (c consumerGroup) Close() error {
+	return c.cg.Close()
+}
+
+func (c consumerGroup) Consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+	if _, ok := handler.(*ConsumerGroupHandler); ok {
+		return c.cg.Consume(ctx, topics, handler)
+	}
+
+	return c.cg.Consume(ctx, topics, WrapConsumerGroupHandler(handler, c.sensor))
+}

--- a/instrumentation/instasarama/consumer_group.go
+++ b/instrumentation/instasarama/consumer_group.go
@@ -4,10 +4,12 @@ package instasarama
 
 import (
 	"context"
+
 	"github.com/Shopify/sarama"
 	instana "github.com/instana/go-sensor"
 )
 
+// NewConsumerGroup creates an instrumented sarama.ConsumerGroup
 func NewConsumerGroup(addrs []string, groupID string, config *sarama.Config, sensor *instana.Sensor) (sarama.ConsumerGroup, error) {
 	c, err := sarama.NewConsumerGroup(addrs, groupID, config)
 	if err != nil {
@@ -17,6 +19,7 @@ func NewConsumerGroup(addrs []string, groupID string, config *sarama.Config, sen
 	return consumerGroup{c, sensor}, nil
 }
 
+// NewConsumerGroupFromClient creates an instrumented sarama.ConsumerGroup from sarama.Client
 func NewConsumerGroupFromClient(groupID string, client sarama.Client, sensor *instana.Sensor) (sarama.ConsumerGroup, error) {
 	c, err := sarama.NewConsumerGroupFromClient(groupID, client)
 	if err != nil {


### PR DESCRIPTION
This PR adds wrappers for `sarama.NewConsumerGroup` and `sarama.NewConsumerGroupFromClient` methods