### PR TITLE
Limit the size of the payload that can be sent to the agent

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,67 @@
+// (c) Copyright IBM Corp. 2022
+
+package instana
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func Test_agentS_SendSpans(t *testing.T) {
+	tests := []struct {
+		name  string
+		spans []Span
+	}{
+		{
+			name: "big span",
+			spans: []Span{
+				{
+					Data: HTTPSpanData{
+						Tags: HTTPSpanTags{
+							URL: strings.Repeat("1", maxContentLength),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "not really a big span",
+			spans: []Span{
+				{
+					Data: HTTPSpanData{
+						Tags: HTTPSpanTags{
+							URL: strings.Repeat("1", maxContentLength/2),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &agentS{host: "", from: &fromS{}, logger: defaultLogger, client: &httpClientMock{
+				resp: &http.Response{
+					StatusCode: 200,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+				},
+			}}
+			err := agent.SendSpans(tt.spans)
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+type httpClientMock struct {
+	resp *http.Response
+	err  error
+}
+
+func (h httpClientMock) Do(req *http.Request) (*http.Response, error) {
+	return h.resp, h.err
+}

--- a/tracer.go
+++ b/tracer.go
@@ -126,7 +126,7 @@ func (r *tracerS) Options() TracerOptions {
 	return sensor.options.Tracer
 }
 
-// Flush forces sendind any queued finished spans to the agent
+// Flush forces sending any queued finished spans to the agent
 func (r *tracerS) Flush(ctx context.Context) error {
 	if err := r.recorder.Flush(ctx); err != nil {
 		return err


### PR DESCRIPTION
This PR prevents sending span batches to the agent if they exceed more than 5MB. In this case, a batch is dropped and a warning message is printed.

Implementation is inspired by https://github.com/instana/nodejs/blob/main/packages/collector/src/agentConnection.js#L33