### PR TITLE
Simplify code

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -287,7 +287,7 @@ func (agent *agentS) fullRequestResponse(ctx context.Context, url string, method
 		if j != nil {
 			b := bytes.NewBuffer(j)
 			if b.Len() > maxContentLength {
-				sensor.logger.Warn(`A batch of spans has been rejected because it is too large to be sent to the agent.`)
+				agent.logger.Warn(`A batch of spans has been rejected because it is too large to be sent to the agent.`)
 
 				return "", payloadTooLargeErr
 			}

--- a/agent.go
+++ b/agent.go
@@ -360,6 +360,14 @@ func (agent *agentS) setHost(host string) {
 	agent.host = host
 }
 
+func (agent *agentS) log() LeveledLogger {
+	return agent.logger
+}
+
+func (agent *agentS) getHost() string {
+	return agent.host
+}
+
 func (agent *agentS) reset() {
 	agent.mu.Lock()
 	agent.fsm.reset()

--- a/agent.go
+++ b/agent.go
@@ -131,7 +131,7 @@ func newAgent(serviceName, host string, port int, logger LeveledLogger) *agentS 
 	}
 
 	agent.mu.Lock()
-	agent.fsm = newFSM(agent)
+	agent.fsm = newFSM(agent, logger)
 	agent.mu.Unlock()
 
 	return agent
@@ -358,10 +358,6 @@ func (agent *agentS) applyHostAgentSettings(resp agentResponse) {
 
 func (agent *agentS) setHost(host string) {
 	agent.host = host
-}
-
-func (agent *agentS) log() LeveledLogger {
-	return agent.logger
 }
 
 func (agent *agentS) getHost() string {

--- a/agent_test.go
+++ b/agent_test.go
@@ -4,7 +4,8 @@ package instana
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
+	"github.com/instana/testify/assert"
+
 	"io/ioutil"
 	"net/http"
 	"strings"

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1,3 +1,5 @@
+// (c) Copyright IBM Corp. 2022
+
 package instana
 
 import (

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -185,6 +185,7 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 			requestHeaderResponse: rCh,
 			requestHeaderErr:      errCh,
 		},
+		lookupAgentHostRetryPeriod: 0,
 		fsm: f.NewFSM(
 			"init",
 			f.Events{

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func Test_fsmS_testAgent(t *testing.T) {
+	// init channels for agent mock
 	rCh := make(chan string, 2)
 	errCh := make(chan error, 2)
 
@@ -37,6 +38,7 @@ func Test_fsmS_testAgent(t *testing.T) {
 		logger: defaultLogger,
 	}
 
+	// simulate errors and successful requests
 	rCh <- ""
 	errCh <- errors.New("some error")
 
@@ -52,6 +54,7 @@ func Test_fsmS_testAgent(t *testing.T) {
 }
 
 func Test_fsmS_testAgent_Error(t *testing.T) {
+	// init channels for agent mock
 	rCh := make(chan string, 3)
 	errCh := make(chan error, 3)
 
@@ -78,6 +81,7 @@ func Test_fsmS_testAgent_Error(t *testing.T) {
 		logger: defaultLogger,
 	}
 
+	// simulate errors
 	rCh <- ""
 	errCh <- errors.New("error #1")
 	rCh <- ""
@@ -94,6 +98,7 @@ func Test_fsmS_testAgent_Error(t *testing.T) {
 }
 
 func Test_fsmS_announceSensor(t *testing.T) {
+	// init channels for agent mock
 	rCh := make(chan string, 2)
 	errCh := make(chan error, 2)
 
@@ -120,6 +125,7 @@ func Test_fsmS_announceSensor(t *testing.T) {
 		logger: defaultLogger,
 	}
 
+	// simulate errors and successful requests
 	rCh <- ""
 	errCh <- errors.New("some error")
 
@@ -135,6 +141,7 @@ func Test_fsmS_announceSensor(t *testing.T) {
 }
 
 func Test_fsmS_announceSensor_Error(t *testing.T) {
+	// init channels for agent mock
 	rCh := make(chan string, 3)
 	errCh := make(chan error, 3)
 
@@ -161,6 +168,7 @@ func Test_fsmS_announceSensor_Error(t *testing.T) {
 		logger: defaultLogger,
 	}
 
+	// simulate errors
 	rCh <- ""
 	errCh <- errors.New("error #1")
 	rCh <- ""
@@ -177,6 +185,7 @@ func Test_fsmS_announceSensor_Error(t *testing.T) {
 }
 
 func Test_fsmS_lookupAgentHost(t *testing.T) {
+	// init channels for agent mock
 	rCh := make(chan string, 2)
 	errCh := make(chan error, 2)
 
@@ -204,6 +213,7 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 		logger: defaultLogger,
 	}
 
+	// simulate errors and successful requests
 	rCh <- ""
 	errCh <- errors.New("some error")
 

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1,0 +1,137 @@
+package instana
+
+import (
+	"errors"
+	"github.com/instana/testify/assert"
+	f "github.com/looplab/fsm"
+	"testing"
+	"time"
+)
+
+func Test_fsmS_testAgent(t *testing.T) {
+	rCh := make(chan string, 2)
+	errCh := make(chan error, 2)
+
+	res := make(chan bool, 1)
+
+	r := &fsmS{
+		agent: &mockFsmAgent{
+			headRequestResponse: rCh,
+			headRequestErr:      errCh,
+		},
+		fsm: f.NewFSM(
+			"announced",
+			f.Events{
+				{Name: eTest, Src: []string{"announced"}, Dst: "ready"}},
+			f.Callbacks{
+				"ready": func(event *f.Event) {
+					res <- true
+				},
+			}),
+		retriesLeft: maximumRetries,
+		expDelayFunc: func(retryNumber int) time.Duration {
+			return 0
+		},
+		logger: defaultLogger,
+	}
+
+	rCh <- ""
+	errCh <- errors.New("some error")
+
+	rCh <- "Hello"
+	errCh <- nil
+
+	r.testAgent(&f.Event{})
+
+	assert.True(t, <-res)
+	assert.Empty(t, rCh)
+	assert.Empty(t, errCh)
+	assert.Equal(t, maximumRetries, r.retriesLeft)
+}
+
+func Test_fsmS_testAgent_Error(t *testing.T) {
+	rCh := make(chan string, 3)
+	errCh := make(chan error, 3)
+
+	res := make(chan bool, 1)
+
+	r := &fsmS{
+		agent: &mockFsmAgent{
+			headRequestResponse: rCh,
+			headRequestErr:      errCh,
+		},
+		fsm: f.NewFSM(
+			"announced",
+			f.Events{
+				{Name: eInit, Src: []string{"announced"}, Dst: "init"}},
+			f.Callbacks{
+				"init": func(event *f.Event) {
+					res <- true
+				},
+			}),
+		retriesLeft: maximumRetries,
+		expDelayFunc: func(retryNumber int) time.Duration {
+			return 0
+		},
+		logger: defaultLogger,
+	}
+
+	rCh <- ""
+	errCh <- errors.New("error #1")
+	rCh <- ""
+	errCh <- errors.New("error #2")
+	rCh <- ""
+	errCh <- errors.New("error #3")
+
+	r.testAgent(&f.Event{})
+
+	assert.True(t, <-res)
+	assert.Empty(t, rCh)
+	assert.Empty(t, errCh)
+	assert.Equal(t, 0, r.retriesLeft)
+}
+
+type mockFsmAgent struct {
+	host string
+
+	requestHeaderResponse chan string
+	requestHeaderErr      chan error
+
+	announceRequestResponse chan string
+	announceRequestErr      chan error
+
+	headRequestResponse chan string
+	headRequestErr      chan error
+}
+
+func (a *mockFsmAgent) getHost() string {
+	return a.host
+}
+
+func (a *mockFsmAgent) setHost(host string) {
+	a.host = host
+}
+
+func (a *mockFsmAgent) requestHeader(url string, method string, header string) (string, error) {
+	return <-a.requestHeaderResponse, <-a.requestHeaderErr
+}
+
+func (a *mockFsmAgent) makeHostURL(host string, prefix string) string {
+	return "http://" + host + ":5555" + prefix
+}
+
+func (a *mockFsmAgent) applyHostAgentSettings(resp agentResponse) {
+	return
+}
+
+func (a *mockFsmAgent) announceRequest(url string, method string, data interface{}, ret *agentResponse) (string, error) {
+	return <-a.announceRequestResponse, <-a.announceRequestErr
+}
+
+func (a *mockFsmAgent) makeURL(prefix string) string {
+	return a.makeHostURL(a.getHost(), prefix)
+}
+
+func (a *mockFsmAgent) head(url string) (string, error) {
+	return <-a.headRequestResponse, <-a.headRequestErr
+}

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -4,10 +4,9 @@
 package instana_test
 
 import (
+	instana "github.com/instana/go-sensor"
 	"os"
 	"testing"
-
-	instana "github.com/instana/go-sensor"
 )
 
 const TestServiceName = "test_service"


### PR DESCRIPTION
This PR contains simplification to the state machine used in the code.

1. It makes `fsmS` testable by introducing `fsmAgent` interface, outgoing connection can be mocked.
2. FSM now uses its own logger.
3. Retries functions/delays are configurable (can be injected), which simplifies testing a lot.
4. Callbacks are removed from the `fsmS`.