### PR TITLE
Handle new configuration received from the agent

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -53,6 +53,17 @@ type agentResponse struct {
 		List    []string `json:"list"`
 	} `json:"secrets"`
 	ExtraHTTPHeaders []string `json:"extraHeaders"`
+	Tracing          struct {
+		ExtraHTTPHeaders []string `json:"extra-http-headers"`
+	} `json:"tracing"`
+}
+
+func (a *agentResponse) getExtraHTTPHeaders() []string {
+	if len(a.Tracing.ExtraHTTPHeaders) == 0 {
+		return a.ExtraHTTPHeaders
+	}
+
+	return a.Tracing.ExtraHTTPHeaders
 }
 
 type discoveryS struct {
@@ -353,7 +364,7 @@ func (agent *agentS) applyHostAgentSettings(resp agentResponse) {
 		}
 	}
 
-	sensor.options.Tracer.CollectableHTTPHeaders = resp.ExtraHTTPHeaders
+	sensor.options.Tracer.CollectableHTTPHeaders = resp.getExtraHTTPHeaders()
 }
 
 func (agent *agentS) setHost(host string) {

--- a/agent_test.go
+++ b/agent_test.go
@@ -87,13 +87,13 @@ func Test_agentResponse_getExtraHTTPHeaders(t *testing.T) {
 	}{
 		{
 			name:         "old config",
-			originalJSON: `{"pid":37808,"agentUuid":"88:66:5a:ff:fe:05:a5:f0","extraHeaders":["x-loadtest-id"],"secrets":{"matcher":"contains-ignore-case","list":["key","pass","secret"]}}`,
-			want:         []string{"x-loadtest-id"},
+			originalJSON: `{"pid":37808,"agentUuid":"88:66:5a:ff:fe:05:a5:f0","extraHeaders":["expected-value"],"secrets":{"matcher":"contains-ignore-case","list":["key","pass","secret"]}}`,
+			want:         []string{"expected-value"},
 		},
 		{
 			name:         "new config",
-			originalJSON: `{"pid":38381,"agentUuid":"88:66:5a:ff:fe:05:a5:f0","tracing":{"extra-http-headers":["x-loadtest-id"]},"extraHeaders":["not-expected-value"],"secrets":{"matcher":"contains-ignore-case","list":["key","pass","secret"]}}`,
-			want:         []string{"x-loadtest-id"},
+			originalJSON: `{"pid":38381,"agentUuid":"88:66:5a:ff:fe:05:a5:f0","tracing":{"extra-http-headers":["expected-value"]},"extraHeaders":["non-expected-value"],"secrets":{"matcher":"contains-ignore-case","list":["key","pass","secret"]}}`,
+			want:         []string{"expected-value"},
 		},
 	}
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -5,7 +5,7 @@ package instana
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
+	"github.com/instana/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"strings"


### PR DESCRIPTION
This PR adds support to the new configuration format, that sensor receives during announcing requests.

