### PR TITLE
Added fix for setting the priority for custom headers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -364,7 +364,9 @@ func (agent *agentS) applyHostAgentSettings(resp agentResponse) {
 		}
 	}
 
-	sensor.options.Tracer.CollectableHTTPHeaders = resp.getExtraHTTPHeaders()
+	if len(sensor.options.Tracer.CollectableHTTPHeaders) == 0 {
+		sensor.options.Tracer.CollectableHTTPHeaders = resp.getExtraHTTPHeaders()
+	}
 }
 
 func (agent *agentS) setHost(host string) {

--- a/agent_test.go
+++ b/agent_test.go
@@ -106,3 +106,20 @@ func Test_agentResponse_getExtraHTTPHeaders(t *testing.T) {
 		})
 	}
 }
+
+func Test_agentApplyHostSettings(t *testing.T) {
+	agent := &agentS{}
+	response := agentResponse{
+		Pid:    37892,
+		HostID: "myhost",
+		Tracing: struct {
+			ExtraHTTPHeaders []string `json:"extra-http-headers"`
+		}{
+			ExtraHTTPHeaders: []string{"my-unwanted-custom-headers"},
+		},
+	}
+
+	agent.applyHostAgentSettings(response)
+
+	assert.NotContains(t, sensor.options.Tracer.CollectableHTTPHeaders, "my-unwanted-custom-headers")
+}


### PR DESCRIPTION
This PR contains the fix for giving preference to the user set custom headers over the ones coming from the agent. So with this change the preference of custom headers will be in the following order: agent < developer set < env values