### PR TITLE
Safe checking Instana type when calling Tracer.StartSpanWithOptions

### DIFF
--- a/span.go
+++ b/span.go
@@ -16,6 +16,8 @@ import (
 
 const minSpanLogLevel = logger.WarnLevel
 
+var _ ot.Span = (*spanS)(nil)
+
 type spanS struct {
 	Service     string
 	Operation   string

--- a/tracer.go
+++ b/tracer.go
@@ -15,6 +15,9 @@ const (
 	MaxLogsPerSpan = 2
 )
 
+var _ ot.Tracer = (*tracerS)(nil)
+var _ Tracer = (*tracerS)(nil)
+
 type tracerS struct {
 	recorder SpanRecorder
 }
@@ -93,10 +96,11 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 	sc := NewRootSpanContext()
 	for _, ref := range opts.References {
 		if ref.Type == ot.ChildOfRef || ref.Type == ot.FollowsFromRef {
-			parent := ref.ReferencedContext.(SpanContext)
-			corrData = parent.Correlation
-			sc = NewSpanContext(parent)
-			break
+			if parent, ok := ref.ReferencedContext.(SpanContext); ok {
+				corrData = parent.Correlation
+				sc = NewSpanContext(parent)
+				break
+			}
 		}
 	}
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -67,12 +67,6 @@ type strangeContext struct{}
 func (c *strangeContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 
 func TestTracer_NonInstanaSpan(t *testing.T) {
-	defer func() {
-		if rec := recover(); rec != nil {
-			t.Fatalf("failed to start span with panic: %v", rec)
-		}
-	}()
-
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, nil)
 
 	ref := ot.SpanReference{
@@ -86,5 +80,7 @@ func TestTracer_NonInstanaSpan(t *testing.T) {
 		},
 	}
 
-	tracer.StartSpanWithOptions("my_operation", opts)
+	assert.NotPanics(t, func() {
+		tracer.StartSpanWithOptions("my_operation", opts)
+	})
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -61,3 +61,30 @@ func TestTracer_StartSpan_WithCorrelationData(t *testing.T) {
 	sc := sp.Context().(instana.SpanContext)
 	assert.Equal(t, instana.EUMCorrelationData{}, sc.Correlation)
 }
+
+type strangeContext struct{}
+
+func (c *strangeContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+func TestTracer_NonInstanaSpan(t *testing.T) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("failed to start span with panic: %v", rec)
+		}
+	}()
+
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, nil)
+
+	ref := ot.SpanReference{
+		Type:              ot.ChildOfRef,
+		ReferencedContext: &strangeContext{},
+	}
+
+	opts := ot.StartSpanOptions{
+		References: []ot.SpanReference{
+			ref,
+		},
+	}
+
+	tracer.StartSpanWithOptions("my_operation", opts)
+}


### PR DESCRIPTION
This PR adds a type verification in the Tracer when a new span is created via `StartSpanWithOptions`.
Currently, if a SpanContext is provided with an implementation of `opentracing.Span` that is not Instana specific, the application panics.

This PR fixes this issue.