### PR TITLE
Instrumenting sql.Out

### DIFF
--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -231,20 +231,7 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 		return c.CheckNamedValue(d)
 	}
 
-	// If driver.Conn doesn't implement the CheckNamedValue method, we attempt to borrow the method from driver.Stmt.
-	stmt, err := conn.Prepare("select name from table where name = ?")
-
-	if err != nil {
-		return err
-	}
-
-	if s, ok := stmt.(driver.NamedValueChecker); ok {
-		return s.CheckNamedValue(d)
-	}
-
-	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d)
-
-	return err
+	return nil
 }
 
 type wrappedSQLStmt struct {
@@ -292,10 +279,7 @@ func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	var err error
-	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d)
-
-	return err
+	return nil
 }
 
 func (stmt *wrappedSQLStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -242,7 +242,9 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	return errors.New("no named check provided for driver.Conn")
+	_, err = driver.DefaultParameterConverter.ConvertValue(d)
+
+	return err
 }
 
 type wrappedSQLStmt struct {
@@ -290,7 +292,9 @@ func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	return errors.New("no named check provided for driver.Stmt")
+	_, err := driver.DefaultParameterConverter.ConvertValue(d)
+
+	return err
 }
 
 func (stmt *wrappedSQLStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -242,7 +242,7 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	_, err = driver.DefaultParameterConverter.ConvertValue(d)
+	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d)
 
 	return err
 }
@@ -292,7 +292,8 @@ func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	_, err := driver.DefaultParameterConverter.ConvertValue(d)
+	var err error
+	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d)
 
 	return err
 }

--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -236,6 +236,23 @@ func TestNoPanicWithNotParsableConnectionString(t *testing.T) {
 	})
 }
 
+func TestProcedureWithCheckerOnStmt(t *testing.T) {
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
+		Service: "go-sensor-test",
+	}, instana.NewTestRecorder()))
+
+	instana.InstrumentSQLDriver(s, "test_driver2", sqlDriver2{})
+	db, err := instana.SQLOpen("test_driver2", "some datasource")
+
+	assert.NoError(t, err)
+
+	var outValue string
+	_, err = db.Exec("CALL SOME_PROCEDURE(?)", sql.Out{Dest: &outValue})
+
+	// Here we expect the instrumentation to look for stmt.CheckNamedValue since conn.CheckNamedValue is not implemented.
+	assert.NoError(t, err)
+}
+
 type sqlDriver struct{ Error error }
 
 func (drv sqlDriver) Open(name string) (driver.Conn, error) { return sqlConn{drv.Error}, nil } //nolint:gosimple
@@ -243,8 +260,8 @@ func (drv sqlDriver) Open(name string) (driver.Conn, error) { return sqlConn{drv
 type sqlConn struct{ Error error }
 
 func (conn sqlConn) Prepare(query string) (driver.Stmt, error) { return sqlStmt{conn.Error}, nil } //nolint:gosimple
-func (sqlConn) Close() error                                   { return driver.ErrSkip }
-func (sqlConn) Begin() (driver.Tx, error)                      { return nil, driver.ErrSkip }
+func (s sqlConn) Close() error                                 { return driver.ErrSkip }
+func (s sqlConn) Begin() (driver.Tx, error)                    { return nil, driver.ErrSkip }
 
 func (conn sqlConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	return sqlResult{}, conn.Error
@@ -271,3 +288,47 @@ type sqlRows struct{}
 func (sqlRows) Columns() []string              { return []string{"col1", "col2"} }
 func (sqlRows) Close() error                   { return nil }
 func (sqlRows) Next(dest []driver.Value) error { return io.EOF }
+
+// Driver use case:
+// * driver.Conn doesn't implement Exec or ExecContext
+// * driver.Conn doesn't implement the driver.NamedValueChecker interface (CheckNamedValue method)
+// * driver.Stmt DOES implement the driver.NamedValueChecker interface (CheckNamedValue method)
+// * The wrapper ALWAYS implements ExecContext, no matter what
+
+type sqlDriver2 struct{ Error error }
+
+func (drv sqlDriver2) Open(name string) (driver.Conn, error) { return sqlConn2{drv.Error}, nil } //nolint:gosimple
+
+type sqlConn2 struct{ Error error }
+
+func (conn sqlConn2) Prepare(query string) (driver.Stmt, error) {
+	return sqlStmt2{conn.Error}, nil //nolint:gosimple
+}
+func (s sqlConn2) Close() error { return driver.ErrSkip }
+
+func (s sqlConn2) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
+
+type sqlStmt2 struct{ Error error }
+
+func (sqlStmt2) Close() error  { return nil }
+func (sqlStmt2) NumInput() int { return -1 }
+func (stmt sqlStmt2) Exec(args []driver.Value) (driver.Result, error) {
+	return sqlResult2{}, stmt.Error
+}
+
+func (stmt sqlStmt2) Query(args []driver.Value) (driver.Rows, error) {
+	return sqlRows2{}, stmt.Error
+}
+
+func (stmt sqlStmt2) CheckNamedValue(d *driver.NamedValue) error { return nil }
+
+type sqlResult2 struct{}
+
+func (sqlResult2) LastInsertId() (int64, error) { return 42, nil }
+func (sqlResult2) RowsAffected() (int64, error) { return 100, nil }
+
+type sqlRows2 struct{}
+
+func (sqlRows2) Columns() []string              { return []string{"col1", "col2"} }
+func (sqlRows2) Close() error                   { return nil }
+func (sqlRows2) Next(dest []driver.Value) error { return io.EOF }


### PR DESCRIPTION
## What
This PR enhances the SQL instrumentation by implementing the [driver.NamedValueChecker](https://pkg.go.dev/database/sql/driver@go1.19.1#NamedValueChecker) interface.

## Why
When a stored procedure with an "out" (`sql.Out{...}`) parameter is provided, the sql package will try to [validate special argument types](https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/database/sql/convert.go;l=124).
This validation is optional by the driver developer, or else sql will fallback to a [default checker](https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/database/sql/convert.go;l=166).

## Attention points
In some drivers, there may be the case where a driver specific checker will not be called if only the Statement (`driver.Stmt`) implements the method `CheckNamedValue(d *driver.NamedValue) error`. We need to document this case in our public docs.

Although this PR fixes the problem with DB2 AND instruments stored procedures, we should instrument  [ibmdb](https://github.com/ibmdb/go_ibm_db) in the future.
