### PR TITLE
Add region to the dynamo db span

### DIFF
--- a/instrumentation/instaawssdk/dynamodb_tags.go
+++ b/instrumentation/instaawssdk/dynamodb_tags.go
@@ -11,47 +11,52 @@ import (
 )
 
 func extractDynamoDBTags(req *request.Request) (opentracing.Tags, error) {
+	var tags opentracing.Tags
 	switch params := req.Params.(type) {
 	case *dynamodb.CreateTableInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "create",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	case *dynamodb.ListTablesInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp: "list",
-		}, nil
+		}
 	case *dynamodb.GetItemInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "get",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	case *dynamodb.PutItemInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "put",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	case *dynamodb.UpdateItemInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "update",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	case *dynamodb.DeleteItemInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "delete",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	case *dynamodb.QueryInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "query",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	case *dynamodb.ScanInput:
-		return opentracing.Tags{
+		tags = opentracing.Tags{
 			dynamodbOp:    "scan",
 			dynamodbTable: aws.StringValue(params.TableName),
-		}, nil
+		}
 	default:
 		return nil, errMethodNotInstrumented
 	}
+
+	tags[dynamodbRegion] = aws.StringValue(req.Config.Region)
+
+	return tags, nil
 }

--- a/instrumentation/instaawssdk/dynamodb_test.go
+++ b/instrumentation/instaawssdk/dynamodb_test.go
@@ -57,6 +57,7 @@ func TestStartDynamoDBSpan(t *testing.T) {
 	assert.Equal(t, instana.AWSDynamoDBSpanTags{
 		Operation: "get",
 		Table:     "test-table",
+		Region:    "mock-region",
 	}, data.Tags)
 }
 
@@ -157,6 +158,7 @@ func TestFinalizeDynamoDBSpan_WithError(t *testing.T) {
 		Operation: "get",
 		Table:     "test-table",
 		Error:     req.Error.Error(),
+		Region:    "mock-region",
 	}, data.Tags)
 }
 

--- a/instrumentation/instaawssdk/dynamodb_test.go
+++ b/instrumentation/instaawssdk/dynamodb_test.go
@@ -136,8 +136,9 @@ func TestFinalizeDynamoDBSpan_WithError(t *testing.T) {
 	)
 
 	sp := sensor.Tracer().StartSpan("dynamodb", opentracing.Tags{
-		"dynamodb.op":    "get",
-		"dynamodb.table": "test-table",
+		"dynamodb.op":     "get",
+		"dynamodb.table":  "test-table",
+		"dynamodb.region": "mock-region",
 	})
 
 	req := newDynamoDBRequest()
@@ -147,7 +148,7 @@ func TestFinalizeDynamoDBSpan_WithError(t *testing.T) {
 	instaawssdk.FinalizeDynamoDBSpan(req)
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 
 	dbSpan := spans[0]
 

--- a/instrumentation/instaawssdk/go.mod
+++ b/instrumentation/instaawssdk/go.mod
@@ -5,7 +5,7 @@ go 1.9
 require (
 	github.com/aws/aws-sdk-go v1.8.0
 	github.com/go-ini/ini v1.62.0 // indirect
-	github.com/instana/go-sensor v1.29.0
+	github.com/instana/go-sensor v1.44.0
 	github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/instrumentation/instaawssdk/go.sum
+++ b/instrumentation/instaawssdk/go.sum
@@ -8,6 +8,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/instana/go-sensor v1.29.0 h1:WoLxTJNjcPDfOYU4E+JCBqdQNcCpyQ2lJ2bYd5izND0=
 github.com/instana/go-sensor v1.29.0/go.mod h1:Uh9j3eF2mBw/FLk2MxISmVDIj8mtJBFRj2S19M6CVyQ=
+github.com/instana/go-sensor v1.44.0 h1:ZF0Cvr/jUe1jj5x7w9PMWGFW7WLPZZd32v/3BuuWb1w=
+github.com/instana/go-sensor v1.44.0/go.mod h1:E42MelHWFz11qqaLwvgt0j98v2s2O/bq22UDkGaG0Gg=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65 h1:T25FL3WEzgmKB0m6XCJNZ65nw09/QIp3T1yXr487D+A=
 github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65/go.mod h1:nYhEREG/B7HUY7P+LKOrqy53TpIqmJ9JyUShcaEKtGw=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/instrumentation/instaawssdk/invoke_lambda_test.go
+++ b/instrumentation/instaawssdk/invoke_lambda_test.go
@@ -152,7 +152,7 @@ func TestFinalizeInvokeLambdaSpan_WithError(t *testing.T) {
 	instaawssdk.FinalizeInvokeLambdaSpan(req)
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 
 	invokeSpan := spans[0]
 

--- a/instrumentation/instaawssdk/s3_test.go
+++ b/instrumentation/instaawssdk/s3_test.go
@@ -129,7 +129,7 @@ func TestFinalizeS3Span_WithError(t *testing.T) {
 	instaawssdk.FinalizeS3Span(req)
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 
 	s3Span := spans[0]
 

--- a/instrumentation/instaawssdk/sns_test.go
+++ b/instrumentation/instaawssdk/sns_test.go
@@ -201,7 +201,7 @@ func TestFinalizeSNSSpan_WithError(t *testing.T) {
 	instaawssdk.FinalizeSNSSpan(req)
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 
 	snsSpan := spans[0]
 

--- a/instrumentation/instaawssdk/sqs_test.go
+++ b/instrumentation/instaawssdk/sqs_test.go
@@ -462,7 +462,7 @@ func TestFinalizeSQSSpan_WithError(t *testing.T) {
 	instaawssdk.FinalizeSQSSpan(req)
 
 	spans := recorder.GetQueuedSpans()
-	require.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 
 	sqsSpan := spans[0]
 

--- a/instrumentation/instaawssdk/tags.go
+++ b/instrumentation/instaawssdk/tags.go
@@ -10,9 +10,10 @@ const (
 
 // dynamodb
 const (
-	dynamodbOp    = "dynamodb.op"
-	dynamodbTable = "dynamodb.table"
-	dynamodbError = "dynamodb.error"
+	dynamodbOp     = "dynamodb.op"
+	dynamodbTable  = "dynamodb.table"
+	dynamodbError  = "dynamodb.error"
+	dynamodbRegion = "dynamodb.region"
 )
 
 // lambda


### PR DESCRIPTION
This PR updates AWS SDK instrumentation. It extends DynamoDB span with a "region" tag.