### PR TITLE
chore(sqs, sns): remove fallback to legacy headers

### DIFF
--- a/instrumentation/instaawssdk/propagation_test.go
+++ b/instrumentation/instaawssdk/propagation_test.go
@@ -45,26 +45,6 @@ func TestSpanContextFromSQSMessage(t *testing.T) {
 				},
 			},
 		},
-		"legacy keys": {
-			MessageAttributes: map[string]*sqs.MessageAttributeValue{
-				"Custom": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("custom attribute"),
-				},
-				"X_INSTANA_ST": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("00000000000000010000000000000002"),
-				},
-				"X_INSTANA_SS": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("0000000000000003"),
-				},
-				"X_INSTANA_SL": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("1"),
-				},
-			},
-		},
 	}
 
 	for name, msg := range examples {
@@ -86,45 +66,6 @@ func TestSpanContextFromSQSMessage(t *testing.T) {
 	})
 }
 
-func TestSpanContextFromSQSMessage_LegacyHeaders(t *testing.T) {
-	sensor := instana.NewSensorWithTracer(
-		instana.NewTracerWithEverything(
-			instana.DefaultOptions(),
-			instana.NewTestRecorder(),
-		),
-	)
-
-	msg := &sqs.Message{
-		MessageAttributes: map[string]*sqs.MessageAttributeValue{
-			"Custom": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("custom attribute"),
-			},
-			"X_INSTANA_T": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("00000000000000010000000000000002"),
-			},
-			"X_INSTANA_S": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000003"),
-			},
-			"X_INSTANA_L": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-		},
-	}
-
-	spCtx, ok := instaawssdk.SpanContextFromSQSMessage(msg, sensor)
-	require.True(t, ok)
-	assert.Equal(t, instana.SpanContext{
-		TraceIDHi: 0x01,
-		TraceID:   0x02,
-		SpanID:    0x03,
-		Baggage:   make(map[string]string),
-	}, spCtx)
-}
-
 func TestSQSMessageAttributesCarrier_Set_FieldT(t *testing.T) {
 	attrs := make(map[string]*sqs.MessageAttributeValue)
 	c := instaawssdk.SQSMessageAttributesCarrier(attrs)
@@ -142,12 +83,6 @@ func TestSQSMessageAttributesCarrier_Update_FieldT(t *testing.T) {
 	examples := map[string]map[string]*sqs.MessageAttributeValue{
 		"standard key": {
 			"X_INSTANA_T": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000000abcdef12abcdef12"),
-			},
-		},
-		"legacy key": {
-			"X_INSTANA_ST": {
 				DataType:    aws.String("String"),
 				StringValue: aws.String("0000000000000000abcdef12abcdef12"),
 			},
@@ -190,12 +125,6 @@ func TestSQSMessageAttributesCarrier_Update_FieldS(t *testing.T) {
 				StringValue: aws.String("abcdef12abcdef12"),
 			},
 		},
-		"legacy key": {
-			"X_INSTANA_SS": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("abcdef12abcdef12"),
-			},
-		},
 	}
 
 	for name, attrs := range examples {
@@ -230,12 +159,6 @@ func TestSQSMessageAttributesCarrier_Update_FieldL(t *testing.T) {
 	examples := map[string]map[string]*sqs.MessageAttributeValue{
 		"standard key": {
 			"X_INSTANA_L": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-		},
-		"legacy key": {
-			"X_INSTANA_SL": {
 				DataType:    aws.String("String"),
 				StringValue: aws.String("1"),
 			},
@@ -275,54 +198,6 @@ func TestSQSMessageAttributesCarrier_ForeachKey(t *testing.T) {
 			"X_INSTANA_L": {
 				DataType:    aws.String("String"),
 				StringValue: aws.String("1"),
-			},
-		},
-		"legacy keys": {
-			"Custom": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("custom attribute"),
-			},
-			"X_INSTANA_ST": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000001deadbeefdeadbeef"),
-			},
-			"X_INSTANA_SS": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("abcdef12abcdef12"),
-			},
-			"X_INSTANA_SL": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-		},
-		"legacy and standard keys": {
-			"Custom": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("custom attribute"),
-			},
-			"X_INSTANA_T": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000001deadbeefdeadbeef"),
-			},
-			"X_INSTANA_S": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("abcdef12abcdef12"),
-			},
-			"X_INSTANA_L": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-			"X_INSTANA_ST": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("00000000000000001212121212121212"),
-			},
-			"X_INSTANA_SS": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("2323232323232323"),
-			},
-			"X_INSTANA_SL": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0"),
 			},
 		},
 	}
@@ -372,12 +247,6 @@ func TestSNSMessageAttributesCarrier_Update_FieldT(t *testing.T) {
 				StringValue: aws.String("0000000000000000abcdef12abcdef12"),
 			},
 		},
-		"legacy key": {
-			"X_INSTANA_ST": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000000abcdef12abcdef12"),
-			},
-		},
 	}
 
 	for name, attrs := range examples {
@@ -412,12 +281,6 @@ func TestSNSMessageAttributesCarrier_Update_FieldS(t *testing.T) {
 	examples := map[string]map[string]*sns.MessageAttributeValue{
 		"standard key": {
 			"X_INSTANA_S": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("abcdef12abcdef12"),
-			},
-		},
-		"legacy key": {
-			"X_INSTANA_SS": {
 				DataType:    aws.String("String"),
 				StringValue: aws.String("abcdef12abcdef12"),
 			},
@@ -460,12 +323,6 @@ func TestSNSMessageAttributesCarrier_Update_FieldL(t *testing.T) {
 				StringValue: aws.String("1"),
 			},
 		},
-		"legacy key": {
-			"X_INSTANA_SL": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-		},
 	}
 
 	for name, attrs := range examples {
@@ -501,54 +358,6 @@ func TestSNSMessageAttributesCarrier_ForeachKey(t *testing.T) {
 			"X_INSTANA_L": {
 				DataType:    aws.String("String"),
 				StringValue: aws.String("1"),
-			},
-		},
-		"legacy keys": {
-			"Custom": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("custom attribute"),
-			},
-			"X_INSTANA_ST": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000001deadbeefdeadbeef"),
-			},
-			"X_INSTANA_SS": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("abcdef12abcdef12"),
-			},
-			"X_INSTANA_SL": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-		},
-		"legacy and standard keys": {
-			"Custom": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("custom attribute"),
-			},
-			"X_INSTANA_T": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0000000000000001deadbeefdeadbeef"),
-			},
-			"X_INSTANA_S": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("abcdef12abcdef12"),
-			},
-			"X_INSTANA_L": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("1"),
-			},
-			"X_INSTANA_ST": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("00000000000000001212121212121212"),
-			},
-			"X_INSTANA_SS": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("2323232323232323"),
-			},
-			"X_INSTANA_SL": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String("0"),
 			},
 		},
 	}

--- a/instrumentation/instaawssdk/sqs_test.go
+++ b/instrumentation/instaawssdk/sqs_test.go
@@ -493,23 +493,6 @@ func TestTraceSQSMessage_WithTraceContext(t *testing.T) {
 				},
 			},
 		},
-		"legacy keys": {
-			Body: aws.String("message body"),
-			MessageAttributes: map[string]*sqs.MessageAttributeValue{
-				"X_INSTANA_ST": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("00000000000000010000000000000002"),
-				},
-				"X_INSTANA_SS": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("0000000000000003"),
-				},
-				"X_INSTANA_SL": {
-					DataType:    aws.String("String"),
-					StringValue: aws.String("1"),
-				},
-			},
-		},
 		"sns notification": {
 			Body: aws.String(`{
   "Type" : "Notification",


### PR DESCRIPTION
This is the last step of a multi-year header migration from using X_INSTANA_T/X_INSTANA_S with signed long values over using X_INSTANA_ST/X_INSTANA_SS with string values back to X_INSTANA_T/X_INSTANA_S with string values.

In this final step, we remove the fallback to the legacy header names X_INSTANA_ST/X_INSTANA_SS on the consumer side. Tracers have been sending X_INSTANA_T and X_INSTANA_S with string values since approximately January 2020, so the grace period for updating has been a generous 22 months.