### PR TITLE
fix checkHost function for fsm

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -126,6 +126,9 @@ func (r *fsmS) checkHost(e *f.Event, host string) {
 			return
 		}
 
+		header, err := r.agent.requestHeader(r.agent.makeHostURL(gateway, "/"), "GET", "Server")
+		found := err == nil && header == agentHeader
+
 		if found {
 			r.lookupSuccess(gateway)
 			return


### PR DESCRIPTION
Fix bug introduced https://github.com/instana/go-sensor/commit/601177eb79ab2090a826b122484ded9b4daae45b.

There was missed request in the case when we try to reach the agent via the gateway address.