### PR TITLE
Added ShutdownSensor() function

### DIFF
--- a/adapters_test.go
+++ b/adapters_test.go
@@ -17,6 +17,7 @@ import (
 func TestWithTracingSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
@@ -52,6 +53,7 @@ func TestWithTracingSpan(t *testing.T) {
 func TestWithTracingSpan_PanicHandling(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
@@ -104,6 +106,7 @@ func TestWithTracingSpan_WithActiveParentSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 	s := instana.NewSensorWithTracer(tracer)
+	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
@@ -124,6 +127,7 @@ func TestWithTracingSpan_WithActiveParentSpan(t *testing.T) {
 func TestWithTracingSpan_WithWireContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)

--- a/agent_test.go
+++ b/agent_test.go
@@ -119,6 +119,18 @@ func Test_agentApplyHostSettings(t *testing.T) {
 		},
 	}
 
+	opts := &Options{
+		Service: "test_service",
+		Tracer: TracerOptions{
+			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
+		},
+	}
+
+	sensor = newSensor(opts)
+	defer func() {
+		sensor = nil
+	}()
+
 	agent.applyHostAgentSettings(response)
 
 	assert.NotContains(t, sensor.options.Tracer.CollectableHTTPHeaders, "my-unwanted-custom-headers")

--- a/context_test.go
+++ b/context_test.go
@@ -15,6 +15,7 @@ import (
 func TestSpanFromContext_WithActiveSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	span := tracer.StartSpan("test")
 	ctx := instana.ContextWithSpan(context.Background(), span)

--- a/event.go
+++ b/event.go
@@ -22,7 +22,7 @@ type EventData struct {
 
 type severity int
 
-//Severity values for events sent to the instana agent
+// Severity values for events sent to the instana agent
 const (
 	SeverityChange   severity = -1
 	SeverityWarning  severity = 5

--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -23,6 +23,7 @@ func BenchmarkTracingNamedHandlerFunc(b *testing.B) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "action", "/{action}", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
@@ -40,10 +41,16 @@ func BenchmarkTracingNamedHandlerFunc(b *testing.B) {
 }
 
 func TestTracingNamedHandlerFunc_Write(t *testing.T) {
-	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
+	opts := &instana.Options{
 		Service: "go-sensor-test",
-	}, recorder))
+		Tracer: instana.TracerOptions{
+			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
+		},
+	}
+
+	recorder := instana.NewTestRecorder()
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(opts, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "action", "/{action}", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("X-Response", "true")
@@ -159,6 +166,7 @@ func TestTracingNamedHandlerFunc_InstanaFieldLPriorityOverTraceParentHeader(t *t
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "action", "/test", func(w http.ResponseWriter, req *http.Request) {})
 
@@ -177,6 +185,7 @@ func TestTracingNamedHandlerFunc_InstanaFieldLPriorityOverTraceParentHeader(t *t
 func TestTracingNamedHandlerFunc_WriteHeaders(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -230,6 +239,7 @@ func TestTracingNamedHandlerFunc_WriteHeaders(t *testing.T) {
 func TestTracingNamedHandlerFunc_W3CTraceContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
@@ -297,6 +307,7 @@ func TestTracingHandlerFunc_SecretsFiltering(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "action", "/{action}", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
@@ -341,6 +352,7 @@ func TestTracingHandlerFunc_SecretsFiltering(t *testing.T) {
 func TestTracingHandlerFunc_Error(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "something went wrong", http.StatusInternalServerError)
@@ -391,6 +403,7 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 func TestTracingHandlerFunc_SyntheticCall(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test-handler", "/", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
@@ -413,6 +426,7 @@ func TestTracingHandlerFunc_SyntheticCall(t *testing.T) {
 func TestTracingHandlerFunc_EUMCall(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test-handler", "/", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
@@ -436,6 +450,7 @@ func TestTracingHandlerFunc_EUMCall(t *testing.T) {
 func TestTracingHandlerFunc_PanicHandling(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
 		panic("something went wrong")
@@ -486,7 +501,14 @@ func TestTracingHandlerFunc_PanicHandling(t *testing.T) {
 
 func TestRoundTripper(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	opts := &instana.Options{
+		Service: TestServiceName,
+		Tracer: instana.TracerOptions{
+			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
+		},
+	}
+	tracer := instana.NewTracerWithEverything(opts, recorder)
+	defer instana.ShutdownSensor()
 	s := instana.NewSensorWithTracer(tracer)
 
 	parentSpan := tracer.StartSpan("parent")
@@ -547,6 +569,7 @@ func TestRoundTripper(t *testing.T) {
 func TestRoundTripper_WithoutParentSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	rt := instana.RoundTripper(s, testRoundTripper(func(req *http.Request) (*http.Response, error) {
 		assert.Empty(t, req.Header.Get(instana.FieldT))
@@ -570,6 +593,7 @@ func TestRoundTripper_Error(t *testing.T) {
 
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	rt := instana.RoundTripper(s, testRoundTripper(func(req *http.Request) (*http.Response, error) {
 		return nil, serverErr
@@ -618,6 +642,7 @@ func TestRoundTripper_Error(t *testing.T) {
 func TestRoundTripper_DefaultTransport(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	defer instana.ShutdownSensor()
 
 	var numCalls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/instrumentation_sql_go1.10_test.go
+++ b/instrumentation_sql_go1.10_test.go
@@ -1,6 +1,7 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
+//go:build go1.10
 // +build go1.10
 
 package instana_test
@@ -24,6 +25,7 @@ func TestWrapSQLConnector_Exec(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	db := sql.OpenDB(instana.WrapSQLConnector(s, "connection string", sqlConnector{}))
 
@@ -64,6 +66,7 @@ func TestWrapSQLConnector_Exec_Error(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	db := sql.OpenDB(instana.WrapSQLConnector(s, "connection string", sqlConnector{
 		Error: errors.New("something went wrong"),
@@ -103,6 +106,7 @@ func TestWrapSQLConnector_Query(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	db := sql.OpenDB(instana.WrapSQLConnector(s, "connection string", sqlConnector{}))
 
@@ -143,6 +147,7 @@ func TestWrapSQLConnector_Query_Error(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	dbErr := errors.New("something went wrong")
 	db := sql.OpenDB(instana.WrapSQLConnector(s, "connection string", sqlConnector{

--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -22,6 +22,7 @@ func TestInstrumentSQLDriver(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "test_register_driver", sqlDriver{})
 	assert.NotPanics(t, func() {
@@ -34,6 +35,7 @@ func TestOpenSQLDB(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "test_driver", sqlDriver{})
 	require.Contains(t, sql.Drivers(), "test_driver_with_instana")
@@ -113,6 +115,7 @@ func TestOpenSQLDB_URIConnString(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "fake_db_driver", sqlDriver{})
 	require.Contains(t, sql.Drivers(), "test_driver_with_instana")
@@ -151,6 +154,7 @@ func TestOpenSQLDB_PostgresKVConnString(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "fake_postgres_driver", sqlDriver{})
 	require.Contains(t, sql.Drivers(), "fake_postgres_driver_with_instana")
@@ -189,6 +193,7 @@ func TestOpenSQLDB_MySQLKVConnString(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, recorder))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "fake_mysql_driver", sqlDriver{})
 	require.Contains(t, sql.Drivers(), "fake_mysql_driver_with_instana")
@@ -226,6 +231,7 @@ func TestNoPanicWithNotParsableConnectionString(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, instana.NewTestRecorder()))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "test_driver", sqlDriver{})
 	require.Contains(t, sql.Drivers(), "test_driver_with_instana")
@@ -240,6 +246,7 @@ func TestProcedureWithCheckerOnStmt(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
 		Service: "go-sensor-test",
 	}, instana.NewTestRecorder()))
+	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "test_driver2", sqlDriver2{})
 	db, err := instana.SQLOpen("test_driver2", "some datasource")

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -46,6 +46,7 @@ func TestSpanKind_String(t *testing.T) {
 func TestNewSDKSpanData(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("sdk",
 		ext.SpanKindRPCServer,
@@ -78,6 +79,7 @@ func TestNewSDKSpanData(t *testing.T) {
 func TestSpanData_CustomTags(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("g.http", opentracing.Tags{
 		"http.host":   "localhost",

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -140,9 +140,6 @@ func (l *Logger) SetPrefix(prefix string) {
 
 // Debug appends a debug message to the log
 func (l *Logger) Debug(v ...interface{}) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
 	if l.lvl < DebugLevel {
 		return
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -65,16 +65,16 @@ type Logger struct {
 // New initializes a new instance of Logger that uses provided printer as a backend to
 // output the log messages. The stdlib log.Logger satisfies logger.Printer interface:
 //
-// 	logger := logger.New(logger.WarnLevel, log.New(os.Stderr, "instana:", log.LstdFlags))
-// 	logger.SetLevel(logger.WarnLevel)
+//	logger := logger.New(logger.WarnLevel, log.New(os.Stderr, "instana:", log.LstdFlags))
+//	logger.SetLevel(logger.WarnLevel)
 //
-// 	logger.Debug("this is a debug message") // won't be printed
-// 	logger.Error("this is an  message") // ... while this one will
+//	logger.Debug("this is a debug message") // won't be printed
+//	logger.Error("this is an  message") // ... while this one will
 //
 // In case  there is no printer provided, logger.Logger will use a new instance of log.Logger
 // initialized with log.Lstdflags that writes to os.Stderr:
 //
-// 	log.New(os.Stderr, "", log.Lstdflags)
+//	log.New(os.Stderr, "", log.Lstdflags)
 //
 // The default logging level for a new logger instance is logger.ErrorLevel.
 func New(printer Printer) *Logger {
@@ -140,6 +140,9 @@ func (l *Logger) SetPrefix(prefix string) {
 
 // Debug appends a debug message to the log
 func (l *Logger) Debug(v ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	if l.lvl < DebugLevel {
 		return
 	}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -93,6 +93,7 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			require.NoError(t, tracer.Inject(example.SpanContext, ot.HTTPHeaders, ot.HTTPHeadersCarrier(example.Headers)))
 			assert.Equal(t, example.Expected, example.Headers)
@@ -213,6 +214,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 			headers := http.Header{}
 
 			require.NoError(t, tracer.Inject(example.SpanContext, ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers)))
@@ -224,6 +226,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	headers := http.Header{
 		"Authorization": {"Basic 123"},
@@ -251,6 +254,7 @@ func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 func TestTracer_Inject_HTTPHeaders_WithExistingServerTiming(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	headers := http.Header{
 		"x-instana-t":   {"0000000000001314"},
@@ -369,6 +373,7 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			headers := http.Header{}
 			for k, v := range example.Headers {
@@ -406,6 +411,7 @@ func TestTracer_Extract_HTTPHeaders_WithEUMCorrelation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			headers := http.Header{}
 			for k, v := range example.Headers {
@@ -428,6 +434,7 @@ func TestTracer_Extract_HTTPHeaders_WithEUMCorrelation(t *testing.T) {
 func TestTracer_Extract_HTTPHeaders_NoContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	headers := http.Header{
 		"Authorization": {"Basic 123"},
@@ -463,6 +470,7 @@ func TestTracer_Extract_HTTPHeaders_CorruptedContext(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			_, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
 			assert.Equal(t, ot.ErrSpanContextCorrupted, err)
@@ -473,6 +481,7 @@ func TestTracer_Extract_HTTPHeaders_CorruptedContext(t *testing.T) {
 func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
 		TraceIDHi: 0x1,
@@ -501,6 +510,7 @@ func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
 func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
 		TraceIDHi: 0x1,
@@ -533,6 +543,7 @@ func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 func TestTracer_Inject_TextMap_SuppressedTracing(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
 		TraceIDHi:  0x1,
@@ -609,6 +620,7 @@ func TestTracer_Extract_TextMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			sc, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(example.Carrier))
 			require.NoError(t, err)
@@ -621,6 +633,7 @@ func TestTracer_Extract_TextMap(t *testing.T) {
 func TestTracer_Extract_TextMap_NoContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	carrier := map[string]string{
 		"key": "value",
@@ -656,6 +669,7 @@ func TestTracer_Extract_TextMap_CorruptedContext(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			_, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
 			assert.Equal(t, ot.ErrSpanContextCorrupted, err)
@@ -676,6 +690,7 @@ func (c *textMapWithRemoveAll) RemoveAll() {
 func TestTracer_Inject_CarrierWithRemoveAll_SuppressedTrace(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
 		TraceIDHi:  0x1,

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -15,6 +15,7 @@ import (
 func TestRecorderBasics(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	span := tracer.StartSpan("http-client")
 	span.SetTag(string(ext.SpanKind), "exit")
@@ -32,6 +33,7 @@ func TestRecorderBasics(t *testing.T) {
 func TestRecorder_BatchSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	tracer.StartSpan("test-span", instana.BatchSize(2)).Finish()
 
@@ -45,6 +47,7 @@ func TestRecorder_BatchSpan(t *testing.T) {
 func TestRecorder_BatchSpan_Single(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	tracer.StartSpan("test-span", instana.BatchSize(1)).Finish()
 

--- a/registered_span_test.go
+++ b/registered_span_test.go
@@ -88,6 +88,7 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			sp := tracer.StartSpan(example.Operation)
 			sp.Finish()
@@ -305,6 +306,7 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 		t.Run(trigger, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
 			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			defer instana.ShutdownSensor()
 
 			sp := tracer.StartSpan("aws.lambda.entry", opentracing.Tags{
 				"lambda.arn":       "lambda-arn-1",

--- a/sensor.go
+++ b/sensor.go
@@ -220,6 +220,14 @@ func Flush(ctx context.Context) error {
 	return sensor.Agent().Flush(ctx)
 }
 
+// ShutdownSensor cleans up the internal global sensor reference. The next time that instana.InitSensor is called,
+// directly or indirectly, the internal sensor will be reinitialized.
+func ShutdownSensor() {
+	if sensor != nil {
+		sensor = nil
+	}
+}
+
 func newServerlessAgent(serviceName, agentEndpoint, agentKey string, client *http.Client, logger LeveledLogger) agentClient {
 	switch {
 	case os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE" && os.Getenv("ECS_CONTAINER_METADATA_URI") != "":

--- a/sensor.go
+++ b/sensor.go
@@ -59,6 +59,7 @@ type sensorS struct {
 
 var (
 	sensor           *sensorS
+	muSensor         sync.Mutex
 	binaryName       = filepath.Base(os.Args[0])
 	processStartedAt = time.Now()
 )
@@ -223,9 +224,11 @@ func Flush(ctx context.Context) error {
 // ShutdownSensor cleans up the internal global sensor reference. The next time that instana.InitSensor is called,
 // directly or indirectly, the internal sensor will be reinitialized.
 func ShutdownSensor() {
+	muSensor.Lock()
 	if sensor != nil {
 		sensor = nil
 	}
+	muSensor.Unlock()
 }
 
 func newServerlessAgent(serviceName, agentEndpoint, agentKey string, client *http.Client, logger LeveledLogger) agentClient {

--- a/sensor.go
+++ b/sensor.go
@@ -168,7 +168,9 @@ func InitSensor(options *Options) {
 		options = DefaultOptions()
 	}
 
+	muSensor.Lock()
 	sensor = newSensor(options)
+	muSensor.Unlock()
 
 	// configure auto-profiling
 	autoprofile.SetLogger(sensor.logger)

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -3,21 +3,21 @@
 
 package instana_test
 
-import (
-	instana "github.com/instana/go-sensor"
-	"os"
-	"testing"
-)
+// import (
+// 	instana "github.com/instana/go-sensor"
+// 	"os"
+// 	"testing"
+// )
 
 const TestServiceName = "test_service"
 
-func TestMain(m *testing.M) {
-	instana.InitSensor(&instana.Options{
-		Service: TestServiceName,
-		Tracer: instana.TracerOptions{
-			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
-		},
-	})
+// func TestMain(m *testing.M) {
+// 	instana.InitSensor(&instana.Options{
+// 		Service: TestServiceName,
+// 		Tracer: instana.TracerOptions{
+// 			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
+// 		},
+// 	})
 
-	os.Exit(m.Run())
-}
+// 	os.Exit(m.Run())
+// }

--- a/sensor_test.go
+++ b/sensor_test.go
@@ -3,21 +3,4 @@
 
 package instana_test
 
-// import (
-// 	instana "github.com/instana/go-sensor"
-// 	"os"
-// 	"testing"
-// )
-
 const TestServiceName = "test_service"
-
-// func TestMain(m *testing.M) {
-// 	instana.InitSensor(&instana.Options{
-// 		Service: TestServiceName,
-// 		Tracer: instana.TracerOptions{
-// 			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
-// 		},
-// 	})
-
-// 	os.Exit(m.Run())
-// }

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -87,6 +87,10 @@ func TestNewSpanContext_EmptyParent(t *testing.T) {
 
 	for name, parent := range examples {
 		t.Run(name, func(t *testing.T) {
+
+			instana.NewTracerWithEverything(&instana.Options{}, nil)
+			defer instana.ShutdownSensor()
+
 			c := instana.NewSpanContext(parent)
 
 			assert.NotEmpty(t, c.TraceID)
@@ -108,6 +112,9 @@ func TestNewSpanContext_FromW3CTraceContext(t *testing.T) {
 			RawState:  "in=1234;5678,vendor1=data",
 		},
 	}
+
+	instana.NewTracerWithEverything(&instana.Options{}, nil)
+	defer instana.ShutdownSensor()
 
 	c := instana.NewSpanContext(parent)
 

--- a/span_test.go
+++ b/span_test.go
@@ -17,6 +17,14 @@ import (
 )
 
 func TestBasicSpan(t *testing.T) {
+	instana.InitSensor(&instana.Options{
+		Service: TestServiceName,
+		Tracer: instana.TracerOptions{
+			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
+		},
+	})
+	defer instana.ShutdownSensor()
+
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
 
@@ -49,6 +57,7 @@ func TestBasicSpan(t *testing.T) {
 func TestSpanHeritage(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	parentSpan := tracer.StartSpan("parent")
 
@@ -87,6 +96,7 @@ func TestSpanBaggage(t *testing.T) {
 	const op = "test"
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan(op)
 	sp.SetBaggageItem("foo", "bar")
@@ -106,6 +116,7 @@ func TestSpanTags(t *testing.T) {
 	const op = "test"
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan(op)
 	sp.SetTag("foo", "bar")
@@ -124,6 +135,7 @@ func TestSpanTags(t *testing.T) {
 func TestOTLogError(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")
 	ext.Error.Set(sp, true)
@@ -146,6 +158,7 @@ func TestOTLogError(t *testing.T) {
 func TestSpanErrorLogKV(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")
 	sp.LogKV("error", "simulated error")
@@ -177,6 +190,7 @@ func TestSpanErrorLogKV(t *testing.T) {
 func TestSpan_LogFields(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	examples := map[string]struct {
 		Fields             []log.Field
@@ -248,6 +262,7 @@ func TestSpan_LogFields(t *testing.T) {
 func TestSpan_Suppressed_StartSpanOption(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test", instana.SuppressTracing())
 	sp.Finish()
@@ -258,6 +273,7 @@ func TestSpan_Suppressed_StartSpanOption(t *testing.T) {
 func TestSpan_Suppressed_SetTag(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")
 	instana.SuppressTracing().Set(sp)

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -18,6 +18,7 @@ func TestTracerAPI(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 
 	tracer = instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 	assert.NotNil(t, tracer)
 
 	tracer = instana.NewTracerWithOptions(&instana.Options{})
@@ -28,6 +29,7 @@ func TestTracerBasics(t *testing.T) {
 	opts := instana.Options{LogLevel: instana.Debug}
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&opts, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")
 	sp.SetBaggageItem("foo", "bar")
@@ -40,6 +42,7 @@ func TestTracerBasics(t *testing.T) {
 func TestTracer_StartSpan_SuppressTracing(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test", instana.SuppressTracing())
 
@@ -50,6 +53,7 @@ func TestTracer_StartSpan_SuppressTracing(t *testing.T) {
 func TestTracer_StartSpan_WithCorrelationData(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test", ot.ChildOf(instana.SpanContext{
 		Correlation: instana.EUMCorrelationData{
@@ -68,6 +72,7 @@ func (c *strangeContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 
 func TestTracer_NonInstanaSpan(t *testing.T) {
 	tracer := instana.NewTracerWithEverything(&instana.Options{}, nil)
+	defer instana.ShutdownSensor()
 
 	ref := ot.SpanReference{
 		Type:              ot.ChildOfRef,


### PR DESCRIPTION
This PR introduces a new public `instana.ShutdownSensor()` function, responsible for cleaning up the internal global sensor reference.

This is the first phase of a two phase refactoring.

### Why
Although we want the global internal sensor to be available at all times in a real case scenario, the same global sensor compromises our tests, since we are blindly using always the same instance of it, which comes together with an agent client instance, as well as a fsm instance. All with an initial setup.

With a cleanup of this sensor, we can assure that no tests are passing with a false positive, and potentially uncover hidden issues in the tracer.

Later on, once this new function is merged into the master branch and a new release of the tracer is done, the second phase of the refactoring comes in: to update all instrumentations to the new version, and making usage of the new function to cleanup the sensor after each test.