### PR TITLE
Add delayed spans buffer

### DIFF
--- a/adapters_test.go
+++ b/adapters_test.go
@@ -4,10 +4,10 @@
 package instana_test
 
 import (
+	instana "github.com/instana/go-sensor"
 	"net/http/httptest"
 	"testing"
 
-	instana "github.com/instana/go-sensor"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ import (
 
 func TestWithTracingSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
@@ -52,7 +52,7 @@ func TestWithTracingSpan(t *testing.T) {
 
 func TestWithTracingSpan_PanicHandling(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
@@ -104,7 +104,7 @@ func TestWithTracingSpan_PanicHandling(t *testing.T) {
 
 func TestWithTracingSpan_WithActiveParentSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	s := instana.NewSensorWithTracer(tracer)
 	defer instana.ShutdownSensor()
 
@@ -126,7 +126,7 @@ func TestWithTracingSpan_WithActiveParentSpan(t *testing.T) {
 
 func TestWithTracingSpan_WithWireContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	rec := httptest.NewRecorder()
@@ -145,5 +145,3 @@ func TestWithTracingSpan_WithWireContext(t *testing.T) {
 	assert.Equal(t, int64(1234567890), spans[0].TraceID)
 	assert.Equal(t, int64(1), spans[0].ParentID)
 }
-
-func TestWithTracingContext(t *testing.T) {}

--- a/agent_test.go
+++ b/agent_test.go
@@ -4,7 +4,10 @@ package instana
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"github.com/instana/go-sensor/acceptor"
+	"github.com/instana/go-sensor/autoprofile"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -124,6 +127,7 @@ func Test_agentApplyHostSettings(t *testing.T) {
 		Tracer: TracerOptions{
 			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
 		},
+		AgentClient: alwaysReadyClient{},
 	}
 
 	sensor = newSensor(opts)
@@ -135,3 +139,12 @@ func Test_agentApplyHostSettings(t *testing.T) {
 
 	assert.NotContains(t, sensor.options.Tracer.CollectableHTTPHeaders, "my-unwanted-custom-headers")
 }
+
+type alwaysReadyClient struct{}
+
+func (alwaysReadyClient) Ready() bool                                       { return true }
+func (alwaysReadyClient) SendMetrics(data acceptor.Metrics) error           { return nil }
+func (alwaysReadyClient) SendEvent(event *EventData) error                  { return nil }
+func (alwaysReadyClient) SendSpans(spans []Span) error                      { return nil }
+func (alwaysReadyClient) SendProfiles(profiles []autoprofile.Profile) error { return nil }
+func (alwaysReadyClient) Flush(context.Context) error                       { return nil }

--- a/context_test.go
+++ b/context_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSpanFromContext_WithActiveSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	span := tracer.StartSpan("test")

--- a/delayed_spans.go
+++ b/delayed_spans.go
@@ -3,89 +3,107 @@
 package instana
 
 import (
-	ot "github.com/opentracing/opentracing-go"
-	"net/http"
 	"net/url"
-	"sync"
+	"strings"
 )
 
 const maxDelayedSpans = 500
 
-var delayed = delayedSpans{
-	mu:    sync.Mutex{},
-	spans: make(map[int64]delayedSpan),
-}
-
-type delayedSpan struct {
-	span            ot.Span
-	requestHeaders  http.Header
-	responseHeaders http.Header
-	httpParams      url.Values
+var delayed = &delayedSpans{
+	spans: make(chan *spanS, maxDelayedSpans),
 }
 
 type delayedSpans struct {
-	mu    sync.Mutex
-	spans map[int64]delayedSpan
+	spans chan *spanS
 }
 
-func (ds *delayedSpans) append(dSpan delayedSpan) {
-	ds.mu.Lock()
-	defer ds.mu.Unlock()
+func (ds *delayedSpans) append(span *spanS) bool {
+	select {
+	case ds.spans <- span:
+		return true
+	default:
+		return false
+	}
+}
 
-	if len(ds.spans) <= maxDelayedSpans {
-		if s, ok := dSpan.span.(*spanS); ok {
+func (ds *delayedSpans) process(stop chan struct{}) <-chan *spanS {
+	c := make(chan *spanS)
 
-			if dSpan.span == nil {
+	go func() {
+		defer close(c)
+		var s *spanS
+
+		for {
+			select {
+			case <-stop:
 				return
+			default:
+				select {
+				case s = <-ds.spans:
+					if t, ok := s.Tracer().(Tracer); ok {
+						opts := t.Options()
+
+						newParams := url.Values{}
+						if httpParamsI, ok := s.Tags["http.params"]; ok {
+							if httpParams, ok := httpParamsI.(string); ok {
+								p := strings.Split(httpParams, "&")
+								for _, pair := range p {
+									kv := strings.Split(pair, "=")
+
+									if len(kv) == 2 {
+										key, value := kv[0], kv[1]
+										if opts.Secrets.Match(key) {
+											newParams.Set(key, "<redacted>")
+										} else {
+											newParams.Set(key, value)
+										}
+									}
+								}
+							}
+						}
+
+						if len(newParams) > 0 {
+							s.SetTag("http.params", newParams.Encode())
+						}
+
+						c <- s
+					}
+				default:
+					return
+				}
 			}
 
-			spanID := s.context.SpanID
-			ds.spans[spanID] = dSpan
 		}
-	}
+
+	}()
+
+	return c
 }
 
 func (ds *delayedSpans) flush() {
-	ds.mu.Lock()
-	defer ds.mu.Unlock()
+	stop := make(chan struct{}, 1)
+	c := ds.process(stop)
+	for {
+		s, ok := <-c
+		agentReady := sensor.Agent().Ready()
+		if ok && agentReady {
+			s.tracer.recorder.RecordSpan(s)
 
-	if sensor.Agent().Ready() && len(ds.spans) > 0 {
-		for sid, s := range ds.spans {
-			if t, ok := s.span.Tracer().(Tracer); ok {
-				opts := t.Options()
-
-				setHeaders(s.requestHeaders, s.responseHeaders, opts.CollectableHTTPHeaders, s.span)
-
-				params := collectHTTPParams(s.httpParams, opts.Secrets)
-				if len(params) > 0 {
-					s.span.SetTag("http.params", params.Encode())
-				}
-
-				if sp, ok := s.span.(*spanS); ok {
-					sp.tracer.recorder.RecordSpan(sp)
-					sp.sendOpenTracingLogRecords()
-				}
-			}
-
-			delete(ds.spans, sid)
+			continue
 		}
 
-	}
-}
+		if !agentReady || !ok {
+			stop <- struct{}{}
 
-func (ds *delayedSpans) setSpan(s *spanS) {
-	ds.mu.Lock()
-	defer ds.mu.Unlock()
+			if s != nil {
+				ds.append(s)
+			}
 
-	spanID := s.context.SpanID
+			for spanToDelayAgain := range c {
+				ds.append(spanToDelayAgain)
+			}
 
-	if _, ok := ds.spans[spanID]; ok {
-		return
-	}
-
-	if len(ds.spans) <= maxDelayedSpans {
-		ds.spans[spanID] = delayedSpan{
-			span: s,
+			break
 		}
 	}
 }

--- a/delayed_spans.go
+++ b/delayed_spans.go
@@ -25,87 +25,53 @@ func (ds *delayedSpans) append(span *spanS) bool {
 	}
 }
 
-func (ds *delayedSpans) process(stop chan struct{}) <-chan *spanS {
-	c := make(chan *spanS)
-
-	go func() {
-		defer close(c)
-		var s *spanS
-
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				select {
-				case s = <-ds.spans:
-					if t, ok := s.Tracer().(Tracer); ok {
-						opts := t.Options()
-
-						newParams := url.Values{}
-						if paramsTag, ok := s.Tags["http.params"]; ok {
-							if httpParams, ok := paramsTag.(string); ok {
-								p, err := url.ParseQuery(httpParams)
-								if err != nil {
-									continue
-								}
-
-								for key, value := range p {
-									if opts.Secrets.Match(key) {
-										newParams[key] = []string{"<redacted>"}
-									} else {
-										newParams[key] = value
-									}
-								}
-							}
-						}
-
-						if len(newParams) > 0 {
-							s.SetTag("http.params", newParams.Encode())
-						}
-
-						c <- s
-					}
-				default:
-					return
-				}
+func (ds *delayedSpans) flush() {
+	for {
+		select {
+		case s := <-ds.spans:
+			t, ok := s.Tracer().(Tracer)
+			if !ok {
+				continue
 			}
 
+			if err := ds.processSpan(s, t.Options()); err != nil {
+				continue
+			}
+
+			if sensor.Agent().Ready() {
+				s.tracer.recorder.RecordSpan(s)
+			} else {
+				ds.append(s)
+				return
+			}
+		default:
+			return
 		}
-
-	}()
-
-	return c
+	}
 }
 
-func (ds *delayedSpans) flush() {
-	stop := make(chan struct{}, 1)
-	c := ds.process(stop)
-	for {
-		s, ok := <-c
-		agentReady := sensor.Agent().Ready()
-		if ok && agentReady {
-			s.tracer.recorder.RecordSpan(s)
+func (ds *delayedSpans) processSpan(s *spanS, opts TracerOptions) error {
+	newParams := url.Values{}
+	if paramsTag, ok := s.Tags["http.params"]; ok {
+		if httpParams, ok := paramsTag.(string); ok {
+			p, err := url.ParseQuery(httpParams)
+			if err != nil {
+				return err
+			}
 
-			continue
+			for key, value := range p {
+				if opts.Secrets.Match(key) {
+					newParams[key] = []string{"<redacted>"}
+				} else {
+					newParams[key] = value
+				}
+			}
 		}
-
-		if !agentReady {
-			stop <- struct{}{}
-		}
-
-		if !ok {
-			break
-		}
-
-		// put back in the queue
-		ds.append(s)
-
-		for spanToDelayAgain := range c {
-			ds.append(spanToDelayAgain)
-		}
-
-		break
-
 	}
+
+	if len(newParams) > 0 {
+		s.SetTag("http.params", newParams.Encode())
+	}
+
+	return nil
 }

--- a/delayed_spans.go
+++ b/delayed_spans.go
@@ -1,0 +1,91 @@
+// (c) Copyright IBM Corp. 2022
+
+package instana
+
+import (
+	ot "github.com/opentracing/opentracing-go"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+const maxDelayedSpans = 500
+
+var delayed = delayedSpans{
+	mu:    sync.Mutex{},
+	spans: make(map[int64]delayedSpan),
+}
+
+type delayedSpan struct {
+	span            ot.Span
+	requestHeaders  http.Header
+	responseHeaders http.Header
+	httpParams      url.Values
+}
+
+type delayedSpans struct {
+	mu    sync.Mutex
+	spans map[int64]delayedSpan
+}
+
+func (ds *delayedSpans) append(dSpan delayedSpan) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	if len(ds.spans) <= maxDelayedSpans {
+		if s, ok := dSpan.span.(*spanS); ok {
+
+			if dSpan.span == nil {
+				return
+			}
+
+			spanID := s.context.SpanID
+			ds.spans[spanID] = dSpan
+		}
+	}
+}
+
+func (ds *delayedSpans) flush() {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	if sensor.Agent().Ready() && len(ds.spans) > 0 {
+		for sid, s := range ds.spans {
+			if t, ok := s.span.Tracer().(Tracer); ok {
+				opts := t.Options()
+
+				setHeaders(s.requestHeaders, s.responseHeaders, opts.CollectableHTTPHeaders, s.span)
+
+				params := collectHTTPParams(s.httpParams, opts.Secrets)
+				if len(params) > 0 {
+					s.span.SetTag("http.params", params.Encode())
+				}
+
+				if sp, ok := s.span.(*spanS); ok {
+					sp.tracer.recorder.RecordSpan(sp)
+					sp.sendOpenTracingLogRecords()
+				}
+			}
+
+			delete(ds.spans, sid)
+		}
+
+	}
+}
+
+func (ds *delayedSpans) setSpan(s *spanS) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	spanID := s.context.SpanID
+
+	if _, ok := ds.spans[spanID]; ok {
+		return
+	}
+
+	if len(ds.spans) <= maxDelayedSpans {
+		ds.spans[spanID] = delayedSpan{
+			span: s,
+		}
+	}
+}

--- a/delayed_spans.go
+++ b/delayed_spans.go
@@ -31,10 +31,12 @@ func (ds *delayedSpans) flush() {
 		case s := <-ds.spans:
 			t, ok := s.Tracer().(Tracer)
 			if !ok {
+				sensor.logger.Debug("span tracer has unexpected type")
 				continue
 			}
 
 			if err := ds.processSpan(s, t.Options()); err != nil {
+				sensor.logger.Debug("error while processing spans:", err.Error())
 				continue
 			}
 

--- a/delayed_spans.go
+++ b/delayed_spans.go
@@ -16,6 +16,7 @@ type delayedSpans struct {
 	spans chan *spanS
 }
 
+// append add a span to the buffer if buffer is not full yet
 func (ds *delayedSpans) append(span *spanS) bool {
 	select {
 	case ds.spans <- span:
@@ -25,6 +26,7 @@ func (ds *delayedSpans) append(span *spanS) bool {
 	}
 }
 
+// flush processes buffered spans and move them from the delayed buffer to the recorder if agent is ready
 func (ds *delayedSpans) flush() {
 	for {
 		select {
@@ -52,6 +54,7 @@ func (ds *delayedSpans) flush() {
 	}
 }
 
+// processSpan applies secret filtering to the buffered http span http.params tag
 func (ds *delayedSpans) processSpan(s *spanS, opts TracerOptions) error {
 	newParams := url.Values{}
 	if paramsTag, ok := s.Tags["http.params"]; ok {

--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -1,0 +1,224 @@
+package instana
+
+import (
+	"context"
+	"fmt"
+	"github.com/instana/go-sensor/acceptor"
+	"github.com/instana/go-sensor/autoprofile"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAppendALotDelayedSpans(t *testing.T) {
+	ds := &delayedSpans{
+		spans: make(chan *spanS, maxDelayedSpans),
+	}
+
+	i := 0
+	for i <= 2*maxDelayedSpans {
+		ds.append(&spanS{})
+		i++
+	}
+
+	assert.Len(t, ds.spans, maxDelayedSpans)
+}
+
+func resetDelayedSpans() {
+	delayed = &delayedSpans{
+		spans: make(chan *spanS, maxDelayedSpans),
+	}
+}
+
+func TestProcessDelayedSpans(t *testing.T) {
+	defer resetDelayedSpans()
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service: "go-sensor-test",
+		Tracer: TracerOptions{
+			Secrets: DefaultSecretsMatcher(),
+		},
+	}, recorder))
+	defer ShutdownSensor()
+
+	generateSomeTraffic(s, 2*maxDelayedSpans)
+
+	assert.Len(t, delayed.spans, maxDelayedSpans)
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	c := delayed.process(stop)
+
+	var spansProcessed []*spanS
+	for s := range c {
+		spansProcessed = append(spansProcessed, s)
+	}
+
+	assert.Len(t, spansProcessed, maxDelayedSpans)
+
+	for _, s := range spansProcessed {
+		assert.Equal(t, "q=term&secret=%3Credacted%3E", s.Tags["http.params"])
+	}
+}
+
+func TestParallelProcessDelayedSpans(t *testing.T) {
+	defer resetDelayedSpans()
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service: "go-sensor-test",
+		Tracer: TracerOptions{
+			Secrets: DefaultSecretsMatcher(),
+		},
+	}, recorder))
+	defer ShutdownSensor()
+
+	generateSomeTraffic(s, maxDelayedSpans*100)
+
+	assert.Len(t, delayed.spans, maxDelayedSpans)
+
+	workers := 15
+	worker := 0
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+
+	var ops uint64
+
+	for worker < workers {
+		go func() {
+			stop := make(chan struct{})
+			c := delayed.process(stop)
+
+			for range c {
+				atomic.AddUint64(&ops, 1)
+			}
+
+			wg.Done()
+		}()
+		worker++
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, uint64(maxDelayedSpans), ops)
+}
+
+func TestPartiallyFlushDelayedSpans(t *testing.T) {
+	defer resetDelayedSpans()
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service: "go-sensor-test",
+		Tracer: TracerOptions{
+			Secrets: DefaultSecretsMatcher(),
+		},
+	}, recorder))
+	defer ShutdownSensor()
+
+	generateSomeTraffic(s, maxDelayedSpans)
+
+	assert.Len(t, delayed.spans, maxDelayedSpans)
+
+	notReadyAfter := maxDelayedSpans / 10
+	sensor.agent = &eventuallyNotReadyClient{
+		notReadyAfter: uint64(notReadyAfter),
+	}
+
+	delayed.flush()
+
+	assert.Len(t, delayed.spans, maxDelayedSpans-notReadyAfter)
+}
+
+func TestFlushDelayedSpans(t *testing.T) {
+	defer resetDelayedSpans()
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service: "go-sensor-test",
+		Tracer: TracerOptions{
+			Secrets: DefaultSecretsMatcher(),
+		},
+	}, recorder))
+	defer ShutdownSensor()
+
+	generateSomeTraffic(s, maxDelayedSpans)
+
+	assert.Len(t, delayed.spans, maxDelayedSpans)
+
+	sensor.agent = alwaysReadyClient{}
+
+	delayed.flush()
+
+	assert.Len(t, delayed.spans, 0)
+}
+
+func TestParallelFlushDelayedSpans(t *testing.T) {
+	defer resetDelayedSpans()
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service: "go-sensor-test",
+		Tracer: TracerOptions{
+			Secrets: DefaultSecretsMatcher(),
+		},
+	}, recorder))
+	defer ShutdownSensor()
+
+	generateSomeTraffic(s, maxDelayedSpans*100)
+
+	assert.Len(t, delayed.spans, maxDelayedSpans)
+
+	workers := 15
+	worker := 0
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+
+	sensor.agent = alwaysReadyClient{}
+
+	for worker < workers {
+		go func() {
+			delayed.flush()
+			wg.Done()
+		}()
+		worker++
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, maxDelayedSpans, len(recorder.GetQueuedSpans()))
+}
+
+type eventuallyNotReadyClient struct {
+	notReadyAfter uint64
+	ops           uint64
+}
+
+func (e *eventuallyNotReadyClient) Ready() bool {
+	n := atomic.AddUint64(&e.ops, 1)
+	return n <= e.notReadyAfter
+}
+
+func (*eventuallyNotReadyClient) SendMetrics(data acceptor.Metrics) error           { return nil }
+func (*eventuallyNotReadyClient) SendEvent(event *EventData) error                  { return nil }
+func (*eventuallyNotReadyClient) SendSpans(spans []Span) error                      { return nil }
+func (*eventuallyNotReadyClient) SendProfiles(profiles []autoprofile.Profile) error { return nil }
+func (*eventuallyNotReadyClient) Flush(context.Context) error                       { return nil }
+
+func generateSomeTraffic(s *Sensor, amount int) {
+	h := TracingNamedHandlerFunc(s, "action", "/{action}", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintln(w, "Ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test?q=term&secret=mypassword", nil)
+
+	rec := httptest.NewRecorder()
+
+	for i := 0; i < amount; i++ {
+		h.ServeHTTP(rec, req)
+	}
+}

--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -1,3 +1,5 @@
+// (c) Copyright IBM Corp. 2022
+
 package instana
 
 import (

--- a/env_config.go
+++ b/env_config.go
@@ -56,7 +56,7 @@ func parseInstanaTags(s string) map[string]interface{} {
 // * `contains-ignore-case` is a case-insensitive version of `contains`
 // * `regex` matches a string if it fully matches any of the regular expressions provided in the secrets list
 //
-// This function returns DefaultSecretsMatcher() if there is no matcher configuration provided.
+// This function returns an error if there is no matcher configuration provided.
 func parseInstanaSecrets(s string) (Matcher, error) {
 	if s == "" {
 		return nil, errors.New("empty value for secret matcher configuration")

--- a/env_config.go
+++ b/env_config.go
@@ -4,6 +4,7 @@
 package instana
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -58,7 +59,7 @@ func parseInstanaTags(s string) map[string]interface{} {
 // This function returns DefaultSecretsMatcher() if there is no matcher configuration provided.
 func parseInstanaSecrets(s string) (Matcher, error) {
 	if s == "" {
-		return DefaultSecretsMatcher(), nil
+		return nil, errors.New("empty value for secret matcher configuration")
 	}
 
 	ind := strings.Index(s, ":")

--- a/env_config_internal_test.go
+++ b/env_config_internal_test.go
@@ -4,6 +4,7 @@
 package instana
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 	"time"
@@ -40,6 +41,22 @@ func TestParseInstanaTags(t *testing.T) {
 		})
 	}
 }
+func TestParseInstanaEmptySecrets(t *testing.T) {
+	examples := map[string]struct {
+		Value    string
+		Expected error
+	}{
+		"empty": {"", errors.New("empty value for secret matcher configuration")},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseInstanaSecrets(example.Value)
+			require.Error(t, err)
+			assert.Equal(t, example.Expected, err)
+		})
+	}
+}
 
 func TestParseInstanaSecrets(t *testing.T) {
 	regexMatcher, err := secrets.NewRegexpMatcher(regexp.MustCompile("a|b|c"), regexp.MustCompile("d"))
@@ -49,7 +66,6 @@ func TestParseInstanaSecrets(t *testing.T) {
 		Value    string
 		Expected Matcher
 	}{
-		"empty":                {"", DefaultSecretsMatcher()},
 		"equals":               {"equals:a,b,c", secrets.NewEqualsMatcher("a", "b", "c")},
 		"equals-ignore-case":   {"equals-ignore-case:a,b,c", secrets.NewEqualsIgnoreCaseMatcher("a", "b", "c")},
 		"contains":             {"contains:a,b,c", secrets.NewContainsMatcher("a", "b", "c")},

--- a/event_internal_test.go
+++ b/event_internal_test.go
@@ -18,14 +18,17 @@ func TestEventBasic(t *testing.T) {
 func TestEventDefault(t *testing.T) {
 	SendDefaultServiceEvent("microservice-14c", "These are event details",
 		SeverityCritical, 5000*time.Millisecond)
+	defer ShutdownSensor()
 }
 
 func TestSendServiceEvent(t *testing.T) {
 	SendServiceEvent("microservice-14c", "Oh No!", "Pull the cable now!",
 		SeverityChange, 1000*time.Millisecond)
+	defer ShutdownSensor()
 }
 
 func TestSendHostEvent(t *testing.T) {
 	SendHostEvent("microservice-14c", "r u listening?",
 		SeverityWarning, 500*time.Millisecond)
+	defer ShutdownSensor()
 }

--- a/fsm.go
+++ b/fsm.go
@@ -73,6 +73,7 @@ func newFSM(agent fsmAgent, logger LeveledLogger) *fsmS {
 			"init":              ret.lookupAgentHost,
 			"enter_unannounced": ret.announceSensor,
 			"enter_announced":   ret.testAgent,
+			"ready":             ret.ready,
 		})
 	ret.fsm.Event(eInit)
 
@@ -262,6 +263,10 @@ func (r *fsmS) testAgent(e *f.Event) {
 func (r *fsmS) reset() {
 	r.retriesLeft = maximumRetries
 	r.fsm.Event(eInit)
+}
+
+func (r *fsmS) ready(e *f.Event) {
+	go delayed.flush()
 }
 
 func (r *fsmS) cpuSetFileContent(pid int) string {

--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/instana/go-sensor/acceptor"
+	"github.com/instana/go-sensor/autoprofile"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +23,8 @@ import (
 func BenchmarkTracingNamedHandlerFunc(b *testing.B) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -46,6 +49,7 @@ func TestTracingNamedHandlerFunc_Write(t *testing.T) {
 		Tracer: instana.TracerOptions{
 			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
 		},
+		AgentClient: alwaysReadyClient{},
 	}
 
 	recorder := instana.NewTestRecorder()
@@ -164,7 +168,8 @@ func TestTracingNamedHandlerFunc_InstanaFieldLPriorityOverTraceParentHeader(t *t
 
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -184,7 +189,7 @@ func TestTracingNamedHandlerFunc_InstanaFieldLPriorityOverTraceParentHeader(t *t
 
 func TestTracingNamedHandlerFunc_WriteHeaders(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
@@ -238,7 +243,7 @@ func TestTracingNamedHandlerFunc_WriteHeaders(t *testing.T) {
 
 func TestTracingNamedHandlerFunc_W3CTraceContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
@@ -305,7 +310,8 @@ func TestTracingNamedHandlerFunc_W3CTraceContext(t *testing.T) {
 func TestTracingHandlerFunc_SecretsFiltering(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -351,7 +357,7 @@ func TestTracingHandlerFunc_SecretsFiltering(t *testing.T) {
 
 func TestTracingHandlerFunc_Error(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
@@ -402,7 +408,7 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 
 func TestTracingHandlerFunc_SyntheticCall(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test-handler", "/", func(w http.ResponseWriter, req *http.Request) {
@@ -425,7 +431,7 @@ func TestTracingHandlerFunc_SyntheticCall(t *testing.T) {
 
 func TestTracingHandlerFunc_EUMCall(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test-handler", "/", func(w http.ResponseWriter, req *http.Request) {
@@ -449,7 +455,7 @@ func TestTracingHandlerFunc_EUMCall(t *testing.T) {
 
 func TestTracingHandlerFunc_PanicHandling(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	h := instana.TracingNamedHandlerFunc(s, "test", "/test", func(w http.ResponseWriter, req *http.Request) {
@@ -506,10 +512,11 @@ func TestRoundTripper(t *testing.T) {
 		Tracer: instana.TracerOptions{
 			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
 		},
+		AgentClient: alwaysReadyClient{},
 	}
 	tracer := instana.NewTracerWithEverything(opts, recorder)
-	defer instana.ShutdownSensor()
 	s := instana.NewSensorWithTracer(tracer)
+	defer instana.ShutdownSensor()
 
 	parentSpan := tracer.StartSpan("parent")
 
@@ -568,7 +575,7 @@ func TestRoundTripper(t *testing.T) {
 
 func TestRoundTripper_WithoutParentSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	rt := instana.RoundTripper(s, testRoundTripper(func(req *http.Request) (*http.Response, error) {
@@ -592,7 +599,7 @@ func TestRoundTripper_Error(t *testing.T) {
 	serverErr := errors.New("something went wrong")
 
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	rt := instana.RoundTripper(s, testRoundTripper(func(req *http.Request) (*http.Response, error) {
@@ -641,7 +648,7 @@ func TestRoundTripper_Error(t *testing.T) {
 
 func TestRoundTripper_DefaultTransport(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{}, recorder))
+	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder))
 	defer instana.ShutdownSensor()
 
 	var numCalls int
@@ -688,3 +695,12 @@ type testRoundTripper func(*http.Request) (*http.Response, error)
 func (rt testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return rt(req)
 }
+
+type alwaysReadyClient struct{}
+
+func (alwaysReadyClient) Ready() bool                                       { return true }
+func (alwaysReadyClient) SendMetrics(data acceptor.Metrics) error           { return nil }
+func (alwaysReadyClient) SendEvent(event *instana.EventData) error          { return nil }
+func (alwaysReadyClient) SendSpans(spans []instana.Span) error              { return nil }
+func (alwaysReadyClient) SendProfiles(profiles []autoprofile.Profile) error { return nil }
+func (alwaysReadyClient) Flush(context.Context) error                       { return nil }

--- a/instrumentation_sql_go1.10_test.go
+++ b/instrumentation_sql_go1.10_test.go
@@ -20,7 +20,8 @@ import (
 func TestWrapSQLConnector_Exec(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -61,7 +62,8 @@ func TestWrapSQLConnector_Exec(t *testing.T) {
 func TestWrapSQLConnector_Exec_Error(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -101,7 +103,8 @@ func TestWrapSQLConnector_Exec_Error(t *testing.T) {
 func TestWrapSQLConnector_Query(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -142,7 +145,8 @@ func TestWrapSQLConnector_Query(t *testing.T) {
 func TestWrapSQLConnector_Query_Error(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 

--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -20,8 +20,10 @@ import (
 func TestInstrumentSQLDriver(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
+
 	defer instana.ShutdownSensor()
 
 	instana.InstrumentSQLDriver(s, "test_register_driver", sqlDriver{})
@@ -33,7 +35,8 @@ func TestInstrumentSQLDriver(t *testing.T) {
 func TestOpenSQLDB(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -113,7 +116,8 @@ func TestOpenSQLDB(t *testing.T) {
 func TestOpenSQLDB_URIConnString(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -152,7 +156,8 @@ func TestOpenSQLDB_URIConnString(t *testing.T) {
 func TestOpenSQLDB_PostgresKVConnString(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -191,7 +196,8 @@ func TestOpenSQLDB_PostgresKVConnString(t *testing.T) {
 func TestOpenSQLDB_MySQLKVConnString(t *testing.T) {
 	recorder := instana.NewTestRecorder()
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, recorder))
 	defer instana.ShutdownSensor()
 
@@ -229,7 +235,8 @@ func TestOpenSQLDB_MySQLKVConnString(t *testing.T) {
 
 func TestNoPanicWithNotParsableConnectionString(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, instana.NewTestRecorder()))
 	defer instana.ShutdownSensor()
 
@@ -244,7 +251,8 @@ func TestNoPanicWithNotParsableConnectionString(t *testing.T) {
 
 func TestProcedureWithCheckerOnStmt(t *testing.T) {
 	s := instana.NewSensorWithTracer(instana.NewTracerWithEverything(&instana.Options{
-		Service: "go-sensor-test",
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
 	}, instana.NewTestRecorder()))
 	defer instana.ShutdownSensor()
 

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -45,7 +45,7 @@ func TestSpanKind_String(t *testing.T) {
 
 func TestNewSDKSpanData(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("sdk",
@@ -78,7 +78,7 @@ func TestNewSDKSpanData(t *testing.T) {
 
 func TestSpanData_CustomTags(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("g.http", opentracing.Tags{

--- a/options.go
+++ b/options.go
@@ -42,6 +42,8 @@ type Options struct {
 	// Tracer contains tracer-specific configuration used by all tracers
 	Tracer TracerOptions
 
+	AgentClient AgentClient
+
 	disableW3CTraceCorrelation bool
 }
 

--- a/options.go
+++ b/options.go
@@ -41,7 +41,8 @@ type Options struct {
 	IncludeProfilerFrames bool
 	// Tracer contains tracer-specific configuration used by all tracers
 	Tracer TracerOptions
-
+	// AgentClient client to communicate with the agent. In most cases, there is no need to provide it.
+	// If it is nil the default implementation will be used.
 	AgentClient AgentClient
 
 	disableW3CTraceCorrelation bool

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -92,7 +92,7 @@ func TestTracer_Inject_HTTPHeaders(t *testing.T) {
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			require.NoError(t, tracer.Inject(example.SpanContext, ot.HTTPHeaders, ot.HTTPHeadersCarrier(example.Headers)))
@@ -213,7 +213,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 			headers := http.Header{}
 
@@ -225,7 +225,7 @@ func TestTracer_Inject_HTTPHeaders_W3CTraceContext(t *testing.T) {
 
 func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	headers := http.Header{
@@ -253,7 +253,7 @@ func TestTracer_Inject_HTTPHeaders_SuppressedTracing(t *testing.T) {
 
 func TestTracer_Inject_HTTPHeaders_WithExistingServerTiming(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	headers := http.Header{
@@ -372,7 +372,7 @@ func TestTracer_Extract_HTTPHeaders(t *testing.T) {
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			headers := http.Header{}
@@ -410,7 +410,7 @@ func TestTracer_Extract_HTTPHeaders_WithEUMCorrelation(t *testing.T) {
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			headers := http.Header{}
@@ -433,7 +433,7 @@ func TestTracer_Extract_HTTPHeaders_WithEUMCorrelation(t *testing.T) {
 
 func TestTracer_Extract_HTTPHeaders_NoContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	headers := http.Header{
@@ -469,7 +469,7 @@ func TestTracer_Extract_HTTPHeaders_CorruptedContext(t *testing.T) {
 	for name, headers := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			_, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(headers))
@@ -480,7 +480,7 @@ func TestTracer_Extract_HTTPHeaders_CorruptedContext(t *testing.T) {
 
 func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
@@ -509,7 +509,7 @@ func TestTracer_Inject_TextMap_AddValues(t *testing.T) {
 
 func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
@@ -542,7 +542,7 @@ func TestTracer_Inject_TextMap_UpdateValues(t *testing.T) {
 
 func TestTracer_Inject_TextMap_SuppressedTracing(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{
@@ -619,7 +619,7 @@ func TestTracer_Extract_TextMap(t *testing.T) {
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			sc, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(example.Carrier))
@@ -632,7 +632,7 @@ func TestTracer_Extract_TextMap(t *testing.T) {
 
 func TestTracer_Extract_TextMap_NoContext(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	carrier := map[string]string{
@@ -668,7 +668,7 @@ func TestTracer_Extract_TextMap_CorruptedContext(t *testing.T) {
 	for name, carrier := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			_, err := tracer.Extract(ot.TextMap, ot.TextMapCarrier(carrier))
@@ -689,7 +689,7 @@ func (c *textMapWithRemoveAll) RemoveAll() {
 
 func TestTracer_Inject_CarrierWithRemoveAll_SuppressedTrace(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sc := instana.SpanContext{

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRecorderBasics(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	span := tracer.StartSpan("http-client")
@@ -32,7 +32,7 @@ func TestRecorderBasics(t *testing.T) {
 
 func TestRecorder_BatchSpan(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	tracer.StartSpan("test-span", instana.BatchSize(2)).Finish()
@@ -46,7 +46,7 @@ func TestRecorder_BatchSpan(t *testing.T) {
 
 func TestRecorder_BatchSpan_Single(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	tracer.StartSpan("test-span", instana.BatchSize(1)).Finish()

--- a/registered_span_test.go
+++ b/registered_span_test.go
@@ -87,7 +87,7 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 	for name, example := range examples {
 		t.Run(name, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			sp := tracer.StartSpan(example.Operation)
@@ -305,7 +305,7 @@ func TestNewAWSLambdaSpanData(t *testing.T) {
 	for trigger, example := range examples {
 		t.Run(trigger, func(t *testing.T) {
 			recorder := instana.NewTestRecorder()
-			tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+			tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 			defer instana.ShutdownSensor()
 
 			sp := tracer.StartSpan("aws.lambda.entry", opentracing.Tags{

--- a/span.go
+++ b/span.go
@@ -78,8 +78,13 @@ func (r *spanS) FinishWithOptions(opts ot.FinishOptions) {
 
 	r.Duration = duration
 	if !r.context.Suppressed {
-		r.tracer.recorder.RecordSpan(r)
-		r.sendOpenTracingLogRecords()
+		if sensor.Agent().Ready() {
+			r.tracer.recorder.RecordSpan(r)
+			r.sendOpenTracingLogRecords()
+		} else {
+			delayed.setSpan(r)
+		}
+
 	}
 }
 

--- a/span.go
+++ b/span.go
@@ -82,7 +82,8 @@ func (r *spanS) FinishWithOptions(opts ot.FinishOptions) {
 			r.tracer.recorder.RecordSpan(r)
 			r.sendOpenTracingLogRecords()
 		} else {
-			delayed.setSpan(r)
+			r.sendOpenTracingLogRecords()
+			delayed.append(r)
 		}
 
 	}

--- a/span.go
+++ b/span.go
@@ -80,12 +80,10 @@ func (r *spanS) FinishWithOptions(opts ot.FinishOptions) {
 	if !r.context.Suppressed {
 		if sensor.Agent().Ready() {
 			r.tracer.recorder.RecordSpan(r)
-			r.sendOpenTracingLogRecords()
 		} else {
-			r.sendOpenTracingLogRecords()
 			delayed.append(r)
 		}
-
+		r.sendOpenTracingLogRecords()
 	}
 }
 

--- a/span_context_test.go
+++ b/span_context_test.go
@@ -88,7 +88,7 @@ func TestNewSpanContext_EmptyParent(t *testing.T) {
 	for name, parent := range examples {
 		t.Run(name, func(t *testing.T) {
 
-			instana.NewTracerWithEverything(&instana.Options{}, nil)
+			instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, nil)
 			defer instana.ShutdownSensor()
 
 			c := instana.NewSpanContext(parent)
@@ -113,7 +113,7 @@ func TestNewSpanContext_FromW3CTraceContext(t *testing.T) {
 		},
 	}
 
-	instana.NewTracerWithEverything(&instana.Options{}, nil)
+	instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, nil)
 	defer instana.ShutdownSensor()
 
 	c := instana.NewSpanContext(parent)

--- a/span_test.go
+++ b/span_test.go
@@ -22,11 +22,12 @@ func TestBasicSpan(t *testing.T) {
 		Tracer: instana.TracerOptions{
 			CollectableHTTPHeaders: []string{"x-custom-header-1", "x-custom-header-2"},
 		},
+		AgentClient: alwaysReadyClient{},
 	})
 	defer instana.ShutdownSensor()
 
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 
 	start := time.Now()
 	sp := tracer.StartSpan("test")
@@ -56,7 +57,7 @@ func TestBasicSpan(t *testing.T) {
 
 func TestSpanHeritage(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	parentSpan := tracer.StartSpan("parent")
@@ -95,7 +96,7 @@ func TestSpanHeritage(t *testing.T) {
 func TestSpanBaggage(t *testing.T) {
 	const op = "test"
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan(op)
@@ -115,7 +116,7 @@ func TestSpanBaggage(t *testing.T) {
 func TestSpanTags(t *testing.T) {
 	const op = "test"
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan(op)
@@ -134,7 +135,7 @@ func TestSpanTags(t *testing.T) {
 
 func TestOTLogError(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")
@@ -157,7 +158,7 @@ func TestOTLogError(t *testing.T) {
 
 func TestSpanErrorLogKV(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")
@@ -189,7 +190,7 @@ func TestSpanErrorLogKV(t *testing.T) {
 
 func TestSpan_LogFields(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	examples := map[string]struct {
@@ -261,7 +262,7 @@ func TestSpan_LogFields(t *testing.T) {
 
 func TestSpan_Suppressed_StartSpanOption(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test", instana.SuppressTracing())
@@ -272,7 +273,7 @@ func TestSpan_Suppressed_StartSpanOption(t *testing.T) {
 
 func TestSpan_Suppressed_SetTag(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test")

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -17,16 +17,16 @@ func TestTracerAPI(t *testing.T) {
 
 	recorder := instana.NewTestRecorder()
 
-	tracer = instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer = instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 	assert.NotNil(t, tracer)
 
-	tracer = instana.NewTracerWithOptions(&instana.Options{})
+	tracer = instana.NewTracerWithOptions(&instana.Options{AgentClient: alwaysReadyClient{}})
 	assert.NotNil(t, tracer)
 }
 
 func TestTracerBasics(t *testing.T) {
-	opts := instana.Options{LogLevel: instana.Debug}
+	opts := instana.Options{LogLevel: instana.Debug, AgentClient: alwaysReadyClient{}}
 	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&opts, recorder)
 	defer instana.ShutdownSensor()
@@ -41,7 +41,7 @@ func TestTracerBasics(t *testing.T) {
 
 func TestTracer_StartSpan_SuppressTracing(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test", instana.SuppressTracing())
@@ -52,7 +52,7 @@ func TestTracer_StartSpan_SuppressTracing(t *testing.T) {
 
 func TestTracer_StartSpan_WithCorrelationData(t *testing.T) {
 	recorder := instana.NewTestRecorder()
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, recorder)
 	defer instana.ShutdownSensor()
 
 	sp := tracer.StartSpan("test", ot.ChildOf(instana.SpanContext{
@@ -71,7 +71,7 @@ type strangeContext struct{}
 func (c *strangeContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 
 func TestTracer_NonInstanaSpan(t *testing.T) {
-	tracer := instana.NewTracerWithEverything(&instana.Options{}, nil)
+	tracer := instana.NewTracerWithEverything(&instana.Options{AgentClient: alwaysReadyClient{}}, nil)
 	defer instana.ShutdownSensor()
 
 	ref := ot.SpanReference{


### PR DESCRIPTION
This PR introduces a buffer for captured spans before agent configuration is received.

Important:
1. Change in the spanS implementation
2. Change the sensor Options
3. Fix in the setting of the secrets configuration
4. FSM change
5. Delayed spans buffer implementation