### PR TITLE
Shell script to release all instrumentations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,3 +8,21 @@ Release Steps
    - This would create a new commit updating the module version constant in `version.go`, tag and push it to GitHub.
    - If you have [GitHub CLI](https://cli.github.com/) installed, it will also create a draft release with the changelog
 3. Go to [Releases](https://github.com/instana/go-sensor/releases) page, review and publish the draft release created by `make`
+4. When releasing a new version of the core module - that is - releasing from the root directory only, make sure to follow the steps in the section below to update all instrumentations to reference to the new core module release.
+
+## Updating instrumentations after a core module release
+
+Releasing a new version of the core module doesn't automatically update and release a new version of each instrumentation, which we will cover in this section.
+
+Follow the steps below to release the updated instrumentations:
+
+1. Once a new version of the core module is released, update the master branch and create a new branch.
+1. In the new branch, run `./instrumentations.sh update` to update all instrumentations to the latest core module version.
+1. Run `make test` to assure that no instrumentation is broken after the update. If there are any issues, fix them accordingly.
+1. Once all tests pass, create a pull request with the changes and get it merged into the master branch.
+1. Switch to the master branch and pull the new changes.
+1. Make sure to have [gh](https://cli.github.com/) installed.
+1. Make sure to be [logged](https://cli.github.com/manual/gh_auth_login) into Github via `gh` command.
+1. Run `./instrumentations.sh release` to release every instrumentation.
+
+If everything goes well, you should be able to see the instrumentations released in the [release page](https://github.com/instana/go-sensor/releases).

--- a/instrumentations.sh
+++ b/instrumentations.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+# This script provides utilities to update all instrumentations to refer to the latest core module.
+#
+# Usage
+#
+# Update instrumentation phase
+#
+# 1. Run `./instrumentations.sh update`. This will update all instrumentations to refer to the latest core module.
+# 2. Run `make test` to ensure that all instrumentations work with the latest core.
+# 2.1. If any errors are detected in some instrumentation, fix them.
+# 3. Make sure that everything is ok before you commit.
+# 5. If everything is fine, commit your changes, open a PR and get it merged into the master branch.
+#
+# Release phase
+# 1. Run `./instrumentations.sh release` to create tags for each instrumentation with a new minor version, and update all version.go files.
+
+
+set -eo pipefail
+
+# Checks if gh is installed, otherwise it halts the script
+if ! [ -x "$(command -v gh)" ]; then
+  echo 'Error: gh is not installed.' >&2
+  exit 1
+fi
+
+# Checks if the user is logged into Github, otherwise it halts the script
+if gh auth status 2>&1 | grep -i "You are not logged"; then
+  echo "Error: You must log into Github"
+  exit 1
+fi
+
+# CORE_VERSION=latest
+CORE_VERSION=v1.45.0
+
+# List of instrumentation folders
+LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -v "/instasarama/example")
+
+# Updates all instrumentations to use the @latest version of the core module
+run_update() {
+  for lib in $LIB_LIST
+    do cd $lib && go get github.com/instana/go-sensor@$CORE_VERSION && go mod tidy && cd -;
+  done
+}
+
+# Updates version.go and creates a new tag for every instrumentation, incrementing minor version for all
+run_release() {
+  TAGS=""
+  for lib in $LIB_LIST
+    do LIB_PATH="$(echo $lib | sed 's/\.\///')"
+    VERSION=$(git tag -l "$LIB_PATH*" | sort -V | tail -n1 | sed "s/.*v//")
+
+    if [ -z $VERSION ]; then
+      VERSION="0.0.0"
+    fi
+
+    MINOR_VERSION=$(echo $VERSION | sed -En 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
+    MAJOR_VERSION=$(echo $VERSION | sed -En 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
+    MINOR_VERSION=$(($MINOR_VERSION+1))
+    NEW_VERSION="$MAJOR_VERSION.$MINOR_VERSION.0"
+
+    # Updates the minor version in version.go
+    sed -i '' -E "s/[0-9]+\.[0-9]+\.[0-9]+/${NEW_VERSION}/" $lib/version.go | tail -1
+
+    # Tags to be created after version.go is merged to the master branch with the new version
+    TAGS="$TAGS $LIB_PATH@v$MAJOR_VERSION.$MINOR_VERSION.0"
+  done
+
+  # Commit all version.go files to the master branch
+  git add ./instrumentation/**/version.go
+  git add ./instrumentation/**/**/version.go
+  git commit -m "Bumping new version of the instrumentation"
+  git push origin master
+
+  echo "Creating tags for each instrumentation"
+
+  for t in $TAGS
+    do git tag $t && git push origin $t
+  done
+
+  # git push --tags
+
+  # Release every instrumentation
+  for t in $TAGS
+    do gh release create $t \
+		--title $t \
+		--notes "Update instrumentations to the latest core module"
+  done
+}
+
+
+if [ "$1" = "update" ]; then
+  run_update
+fi
+
+if [ "$1" = "release" ]; then
+  run_release
+fi

--- a/instrumentations.sh
+++ b/instrumentations.sh
@@ -28,8 +28,8 @@ if gh auth status 2>&1 | grep -i "You are not logged"; then
   exit 1
 fi
 
-# CORE_VERSION=latest
-CORE_VERSION=v1.45.0
+CORE_VERSION=latest
+# CORE_VERSION=v1.45.0
 
 # List of instrumentation folders
 LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -v "/instasarama/example")
@@ -37,7 +37,7 @@ LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -v "/i
 # Updates all instrumentations to use the @latest version of the core module
 run_update() {
   for lib in $LIB_LIST
-    do cd $lib && go get github.com/instana/go-sensor@$CORE_VERSION && go mod tidy && cd -;
+    do cd "$lib" && go get github.com/instana/go-sensor@$CORE_VERSION && go mod tidy && cd -;
   done
 }
 
@@ -45,20 +45,20 @@ run_update() {
 run_release() {
   TAGS=""
   for lib in $LIB_LIST
-    do LIB_PATH="$(echo $lib | sed 's/\.\///')"
+    do LIB_PATH="$(echo "$lib" | sed 's/\.\///')"
     VERSION=$(git tag -l "$LIB_PATH*" | sort -V | tail -n1 | sed "s/.*v//")
 
-    if [ -z $VERSION ]; then
+    if [ -z "$VERSION" ]; then
       VERSION="0.0.0"
     fi
 
     MINOR_VERSION=$(echo $VERSION | sed -En 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
     MAJOR_VERSION=$(echo $VERSION | sed -En 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
-    MINOR_VERSION=$(($MINOR_VERSION+1))
+    MINOR_VERSION=$((MINOR_VERSION+1))
     NEW_VERSION="$MAJOR_VERSION.$MINOR_VERSION.0"
 
     # Updates the minor version in version.go
-    sed -i '' -E "s/[0-9]+\.[0-9]+\.[0-9]+/${NEW_VERSION}/" $lib/version.go | tail -1
+    sed -i '' -E "s/[0-9]+\.[0-9]+\.[0-9]+/${NEW_VERSION}/" "$lib"/version.go | tail -1
 
     # Tags to be created after version.go is merged to the master branch with the new version
     TAGS="$TAGS $LIB_PATH@v$MAJOR_VERSION.$MINOR_VERSION.0"
@@ -73,13 +73,13 @@ run_release() {
   echo "Creating tags for each instrumentation"
 
   for t in $TAGS
-    do git tag $t && git push origin $t
+    do git tag "$t" && git push origin "$t"
   done
 
   # Release every instrumentation
   for t in $TAGS
-    do gh release create $t \
-		--title $t \
+    do gh release create "$t" \
+		--title "$t" \
 		--notes "Update instrumentations to the latest core module"
   done
 }

--- a/instrumentations.sh
+++ b/instrumentations.sh
@@ -18,13 +18,13 @@ set -eo pipefail
 
 # Checks if gh is installed, otherwise stop the script
 if ! [ -x "$(command -v gh)" ]; then
-  echo 'Error: gh is not installed.' >&2
+  echo "Error: gh is not installed." >&2
   exit 1
 fi
 
 # Checks if the user is logged into Github, otherwise stop the script
 if gh auth status 2>&1 | grep -i "You are not logged"; then
-  echo "Error: You must log into Github"
+  echo "Error: You must log into Github." >&2
   exit 1
 fi
 

--- a/instrumentations.sh
+++ b/instrumentations.sh
@@ -6,25 +6,23 @@
 #
 # Update instrumentation phase
 #
-# 1. Run `./instrumentations.sh update`. This will update all instrumentations to refer to the latest core module.
+# 1. Run `./instrumentations.sh update`. This will update all instrumentations to reference the latest core module.
 # 2. Run `make test` to ensure that all instrumentations work with the latest core.
-# 2.1. If any errors are detected in some instrumentation, fix them.
-# 3. Make sure that everything is ok before you commit.
-# 5. If everything is fine, commit your changes, open a PR and get it merged into the master branch.
+# 3. If any errors are detected in some instrumentation, fix them.
+# 4. If everything is fine, commit your changes, open a PR and get it merged into the master branch.
 #
 # Release phase
 # 1. Run `./instrumentations.sh release` to create tags for each instrumentation with a new minor version, and update all version.go files.
 
-
 set -eo pipefail
 
-# Checks if gh is installed, otherwise it halts the script
+# Checks if gh is installed, otherwise stop the script
 if ! [ -x "$(command -v gh)" ]; then
   echo 'Error: gh is not installed.' >&2
   exit 1
 fi
 
-# Checks if the user is logged into Github, otherwise it halts the script
+# Checks if the user is logged into Github, otherwise stop the script
 if gh auth status 2>&1 | grep -i "You are not logged"; then
   echo "Error: You must log into Github"
   exit 1
@@ -43,7 +41,7 @@ run_update() {
   done
 }
 
-# Updates version.go and creates a new tag for every instrumentation, incrementing minor version for all
+# Updates version.go and creates a new tag for every instrumentation, incrementing the minor version
 run_release() {
   TAGS=""
   for lib in $LIB_LIST
@@ -78,8 +76,6 @@ run_release() {
     do git tag $t && git push origin $t
   done
 
-  # git push --tags
-
   # Release every instrumentation
   for t in $TAGS
     do gh release create $t \
@@ -87,7 +83,6 @@ run_release() {
 		--notes "Update instrumentations to the latest core module"
   done
 }
-
 
 if [ "$1" = "update" ]; then
   run_update


### PR DESCRIPTION
This PR introduces a shell script that helps to update all instrumentations to reference the latest core module being released.
It also provides utilities to release every instrumentation after they are up to date with the latest core module.

### What it actually does

#### For instrumentation update

1. Updates every instrumentation's `go.mod` and `go.sum` files by referencing the latest release core module.

#### For instrumentation release

1. Creates a new tag for every instrumentation by incrementing the minor version
2. Updates the `version.go` file of each instrumentation with the new version
3. Commits changes to master branch and push all new tags upstream
4. Releases every single instrumentation