### PR TITLE
Added docker-compose.yaml in the root folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
             done
             echo Failed waiting for Postgress && exit 1
 
-      - restore_cache:
-          keys:
-            - go-mod-v4-{{ checksum "go.sum" }}
+      # - restore_cache:
+      #     keys:
+      #       - go-mod-v4-{{ checksum "go.sum" }}
       - run:
           command: apt-get --allow-releaseinfo-change-suite update -y && apt-get install ca-certificates libgnutls30 -y || true
       - run:
@@ -63,10 +63,10 @@ jobs:
             GO111MODULE: << parameters.go111module >>
             VENDOR_DEPS: << parameters.vendor_deps >>
             EXCLUDE_DIRS: << parameters.exclude_dirs >>
-      - save_cache:
-          key: go-mod-v4-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
+      # - save_cache:
+      #     key: go-mod-v4-{{ checksum "go.sum" }}
+      #     paths:
+      #       - "/go/pkg/mod"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
             done
             echo Failed waiting for Postgress && exit 1
 
-      # - restore_cache:
-      #     keys:
-      #       - go-mod-v4-{{ checksum "go.sum" }}
+      - restore_cache:
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
       - run:
           command: apt-get --allow-releaseinfo-change-suite update -y && apt-get install ca-certificates libgnutls30 -y || true
       - run:
@@ -63,10 +63,10 @@ jobs:
             GO111MODULE: << parameters.go111module >>
             VENDOR_DEPS: << parameters.vendor_deps >>
             EXCLUDE_DIRS: << parameters.exclude_dirs >>
-      # - save_cache:
-      #     key: go-mod-v4-{{ checksum "go.sum" }}
-      #     paths:
-      #       - "/go/pkg/mod"
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
 
 workflows:
   version: 2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
 
-  postgre:
+  postgres:
     image: postgres:14
     ports:
       - 5432:5432

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+
+  postgre:
+    image: postgres:14
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+      - POSTGRES_PASSWORD=mysecretpassword


### PR DESCRIPTION
This PR introduces a `docker-compose.yaml` file in the root of the project, initially exposing only PostreSQL.
The idea is to be able to run integration tests locally, which currently are expected to happen only in Circle CI.

Once this PR is merged, the following steps can be followed to run pgx integration tests locally.

Run these commands from the root folder of the project:

```bash
$ docker-compose up -d postgres
$ make integration
$ docker-compose stop postgres
```