### PR TITLE
Add fmtcheck and importcheck targets to Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,14 @@ jobs:
       - run:
           command: apt-get --allow-releaseinfo-change-suite update -y && apt-get install ca-certificates libgnutls30 -y || true
       - run:
+          command: go install golang.org/x/tools/cmd/goimports@latest || true
+      - run:
+          name: Check fmt
+          command: make fmtcheck
+      - run:
+          name: Check imports
+          command: make importcheck
+      - run:
           name: Run unit tests
           environment:
             RUN_LINTER: yes

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,9 @@ instrumentation/% :
 	printf '// (c) Copyright IBM Corp. %s\n// (c) Copyright Instana Inc. %s\n\npackage %s\n\nconst Version = "0.0.0"\n' $(shell date +%Y) $(shell date +%Y) $(notdir $@) > $@/version.go
 
 fmtcheck:
-	@gofmt -l .
 	@test -z $(shell gofmt -l . && exit 1)
 
 importcheck:
-	@goimports -l .
 	@test -z $(shell goimports -l . && exit 1)
 
 .PHONY: test install legal fmtcheck importcheck $(MODULES) $(INTEGRATION_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,13 @@ instrumentation/% :
 	printf "VERSION_TAG_PREFIX ?= $@/v\nGO_MODULE_NAME ?= github.com/instana/go-sensor/$@\n\ninclude ../../Makefile.release\n" > $@/Makefile
 	printf '// (c) Copyright IBM Corp. %s\n// (c) Copyright Instana Inc. %s\n\npackage %s\n\nconst Version = "0.0.0"\n' $(shell date +%Y) $(shell date +%Y) $(notdir $@) > $@/version.go
 
-.PHONY: test install legal $(MODULES) $(INTEGRATION_TESTS)
+fmtcheck:
+	@test -z $(shell gofmt -l . && exit 1)
+
+importcheck:
+	@test -z $(shell goimports -l . && exit 1)
+
+.PHONY: test install legal fmtcheck importcheck $(MODULES) $(INTEGRATION_TESTS)
 
 # Release targets
 include Makefile.release

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,11 @@ instrumentation/% :
 	printf '// (c) Copyright IBM Corp. %s\n// (c) Copyright Instana Inc. %s\n\npackage %s\n\nconst Version = "0.0.0"\n' $(shell date +%Y) $(shell date +%Y) $(notdir $@) > $@/version.go
 
 fmtcheck:
+	@gofmt -l .
 	@test -z $(shell gofmt -l . && exit 1)
 
 importcheck:
+	@goimports -l .
 	@test -z $(shell goimports -l . && exit 1)
 
 .PHONY: test install legal fmtcheck importcheck $(MODULES) $(INTEGRATION_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ instrumentation/% :
 	printf '// (c) Copyright IBM Corp. %s\n// (c) Copyright Instana Inc. %s\n\npackage %s\n\nconst Version = "0.0.0"\n' $(shell date +%Y) $(shell date +%Y) $(notdir $@) > $@/version.go
 
 fmtcheck:
+	@gofmt -l .
 	@test -z $(shell gofmt -l . && exit 1)
 
 importcheck:

--- a/autoprofile/internal/pprof/profile/legacy_profile.go
+++ b/autoprofile/internal/pprof/profile/legacy_profile.go
@@ -335,11 +335,12 @@ func addTracebackSample(l []*Location, s []string, p *Profile) {
 //
 // The general format for profilez samples is a sequence of words in
 // binary format. The first words are a header with the following data:
-//   1st word -- 0
-//   2nd word -- 3
-//   3rd word -- 0 if a c++ application, 1 if a java application.
-//   4th word -- Sampling period (in microseconds).
-//   5th word -- Padding.
+//
+//	1st word -- 0
+//	2nd word -- 3
+//	3rd word -- 0 if a c++ application, 1 if a java application.
+//	4th word -- Sampling period (in microseconds).
+//	5th word -- Padding.
 func parseCPU(b []byte) (*Profile, error) {
 	var parse func([]byte) (uint64, []byte)
 	var n1, n2, n3, n4, n5 uint64
@@ -410,15 +411,18 @@ func cpuProfile(b []byte, period int64, parse func(b []byte) (uint64, []byte)) (
 //
 // profilez samples are a repeated sequence of stack frames of the
 // form:
-//    1st word -- The number of times this stack was encountered.
-//    2nd word -- The size of the stack (StackSize).
-//    3rd word -- The first address on the stack.
-//    ...
-//    StackSize + 2 -- The last address on the stack
+//
+//	1st word -- The number of times this stack was encountered.
+//	2nd word -- The size of the stack (StackSize).
+//	3rd word -- The first address on the stack.
+//	...
+//	StackSize + 2 -- The last address on the stack
+//
 // The last stack trace is of the form:
-//   1st word -- 0
-//   2nd word -- 1
-//   3rd word -- 0
+//
+//	1st word -- 0
+//	2nd word -- 1
+//	3rd word -- 0
 //
 // Addresses from stack traces may point to the next instruction after
 // each call. Optionally adjust by -1 to land somewhere on the actual

--- a/env_config.go
+++ b/env_config.go
@@ -14,7 +14,7 @@ import (
 // parseInstanaTags parses the tags string passed via INSTANA_TAGS.
 // The tag string is a comma-separated list of keys optionally followed by an '=' character and a string value:
 //
-//     INSTANA_TAGS := key1[=value1][,key2[=value2],...]
+//	INSTANA_TAGS := key1[=value1][,key2[=value2],...]
 //
 // The leading and trailing space is truncated from key names, values are used as-is. If a key does not have
 // value associated, it's considered to be nil.
@@ -47,7 +47,7 @@ func parseInstanaTags(s string) map[string]interface{} {
 // parseInstanaSecrets parses the tags string passed via INSTANA_SECRETS.
 // The secrets matcher configuration string is expected to have the following format:
 //
-//     INSTANA_SECRETS := <matcher>:<secret>[,<secret>]
+//	INSTANA_SECRETS := <matcher>:<secret>[,<secret>]
 //
 // Where `matcher` is one of:
 // * `equals` - matches a string if it's contained in the secrets list
@@ -75,7 +75,7 @@ func parseInstanaSecrets(s string) (Matcher, error) {
 // parseInstanaExtraHTTPHeaders parses the tags string passed via INSTANA_EXTRA_HTTP_HEADERS.
 // The header names are expected to come in a semicolon-separated list:
 //
-//     INSTANA_EXTRA_HTTP_HEADERS := header1[;header2;...]
+//	INSTANA_EXTRA_HTTP_HEADERS := header1[;header2;...]
 //
 // Any leading and trailing whitespace characters will be trimmed from header names.
 func parseInstanaExtraHTTPHeaders(s string) []string {

--- a/instrumentation/instagrpc/server.go
+++ b/instrumentation/instagrpc/server.go
@@ -18,10 +18,10 @@ import (
 // This interceptor is responsible for extracting the Instana OpenTracing headers from incoming requests
 // and staring a new span that can later be accessed inside the handler:
 //
-// 	if parent, ok := instana.SpanFromContext(ctx); ok {
-// 		sp := parent.Tracer().StartSpan("child-span")
-// 		defer sp.Finish()
-// 	}
+//	if parent, ok := instana.SpanFromContext(ctx); ok {
+//		sp := parent.Tracer().StartSpan("child-span")
+//		defer sp.Finish()
+//	}
 //
 // If the handler returns an error or panics, the error message is then attached to the span logs.
 func UnaryServerInterceptor(sensor *instana.Sensor) grpc.UnaryServerInterceptor {
@@ -51,10 +51,10 @@ func UnaryServerInterceptor(sensor *instana.Sensor) grpc.UnaryServerInterceptor 
 // This interceptor is responsible for extracting the Instana OpenTracing headers from incoming streaming
 // requests and starting a new span that can later be accessed inside the handler:
 //
-// 	if parent, ok := instana.SpanFromContext(srv.Context()); ok {
-// 		sp := parent.Tracer().StartSpan("child-span")
-// 		defer sp.Finish()
-// 	}
+//	if parent, ok := instana.SpanFromContext(srv.Context()); ok {
+//		sp := parent.Tracer().StartSpan("child-span")
+//		defer sp.Finish()
+//	}
 //
 // If the handler returns an error or panics, the error message is then attached to the span logs.
 func StreamServerInterceptor(sensor *instana.Sensor) grpc.StreamServerInterceptor {

--- a/instrumentation/instasarama/sync_producer.go
+++ b/instrumentation/instasarama/sync_producer.go
@@ -92,27 +92,27 @@ func (p *SyncProducer) SendMessage(msg *sarama.ProducerMessage) (int32, int64, e
 // In case you want your batch publish operation to be a part of a specific trace, make sure that
 // you inject the parent span of this trace explicitly before calling `SendMessages()`, i.e.
 //
-// type MessageCollector struct {
-// 	CollectedMessages []*sarama.ProducerMessage
-// 	producer *instasarama.SyncProducer
-// 	// ...
-// }
+//	type MessageCollector struct {
+//		CollectedMessages []*sarama.ProducerMessage
+//		producer *instasarama.SyncProducer
+//		// ...
+//	}
 //
-// func (c MessageCollector) Flush(ctx context.Context) error {
-// 	// extract the parent span from context and use it to continue the trace
-// 	if parentSpan, ok := instana.SpanFromContext(ctx); ok {
-// 		// start a new span for the batch send job
-//		sp := parentSpan.Tracer().StartSpan("batch-send", ot.ChilfOf(parentSpan.Context()))
-// 		defer sp.Finish()
+//	func (c MessageCollector) Flush(ctx context.Context) error {
+//		// extract the parent span from context and use it to continue the trace
+//		if parentSpan, ok := instana.SpanFromContext(ctx); ok {
+//			// start a new span for the batch send job
+//			sp := parentSpan.Tracer().StartSpan("batch-send", ot.ChilfOf(parentSpan.Context()))
+//			defer sp.Finish()
 //
-// 		// inject the trace context into every collected message, overriding the existing one
-//		for i, msg := range c.CollectedMessages {
-// 			c.CollectedMessages = instasarama.ProducerMessageWithSpan(msg, sp)
-// 		}
-// 	}
+//			// inject the trace context into every collected message, overriding the existing one
+//			for i, msg := range c.CollectedMessages {
+//				c.CollectedMessages = instasarama.ProducerMessageWithSpan(msg, sp)
+//			}
+//		}
 //
-// 	return c.producer.SendMessages(c.CollectedMessages)
-// }
+//		return c.producer.SendMessages(c.CollectedMessages)
+//	}
 func (p *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
 	if len(msgs) == 0 {
 		return nil

--- a/recorder.go
+++ b/recorder.go
@@ -81,7 +81,8 @@ func (r *Recorder) RecordSpan(span *spanS) {
 }
 
 // QueuedSpansCount returns the number of queued spans
-//   Used only in tests currently.
+//
+//	Used only in tests currently.
 func (r *Recorder) QueuedSpansCount() int {
 	r.RLock()
 	defer r.RUnlock()
@@ -124,10 +125,11 @@ func (r *Recorder) Flush(ctx context.Context) error {
 }
 
 // clearQueuedSpans brings the span queue to empty/0/nada
-//   This function doesn't take the Lock so make sure to have
-//   the write lock before calling.
-//   This is meant to be called from GetQueuedSpans which handles
-//   locking.
+//
+//	This function doesn't take the Lock so make sure to have
+//	the write lock before calling.
+//	This is meant to be called from GetQueuedSpans which handles
+//	locking.
 func (r *Recorder) clearQueuedSpans() {
 	r.spans = r.spans[:0]
 }

--- a/secrets/matchers.go
+++ b/secrets/matchers.go
@@ -149,10 +149,10 @@ func NewRegexpMatcher(terms ...*regexp.Regexp) (RegexpMatcher, error) {
 // Match returns true if a string fully matches any of matcher's regular expessions. If an expression matches only
 // a part of string, this method returns false:
 //
-//     m := NewRegexpMatcher(regexp.MustCompile(`aaa`), regexp.MustCompile(`bbb`))
-//     m.Match("aaa") // returns true
-//     m.Match("bbb") // returns true
-//     m.Match("aaabbb") // returns false, as both regular expressions match only a part of the string
+//	m := NewRegexpMatcher(regexp.MustCompile(`aaa`), regexp.MustCompile(`bbb`))
+//	m.Match("aaa") // returns true
+//	m.Match("bbb") // returns true
+//	m.Match("aaabbb") // returns false, as both regular expressions match only a part of the string
 func (m RegexpMatcher) Match(s string) bool {
 	return m.re.MatchString(s)
 }

--- a/sensor.go
+++ b/sensor.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/instana/go-sensor/logger"
+
 	"github.com/instana/go-sensor/acceptor"
 	"github.com/instana/go-sensor/autoprofile"
 	"github.com/instana/go-sensor/aws"
-	"github.com/instana/go-sensor/logger"
 )
 
 const (

--- a/sensor.go
+++ b/sensor.go
@@ -13,11 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/instana/go-sensor/logger"
-
 	"github.com/instana/go-sensor/acceptor"
 	"github.com/instana/go-sensor/autoprofile"
 	"github.com/instana/go-sensor/aws"
+	"github.com/instana/go-sensor/logger"
 )
 
 const (


### PR DESCRIPTION
This PR adds `fmt` and `imports` steps to the CI config and Makefile.