### PR TITLE
Better matcher of excluded matches for the instrumentation list

### DIFF
--- a/instrumentations.sh
+++ b/instrumentations.sh
@@ -33,7 +33,7 @@ CORE_VERSION=latest
 
 # List of folders to be excluded from the instrumentation list
 # If new matches must be added, use regular expressions. eg:
-# EXCLUDED_DIRS="/.*/example|/new_match"
+# EXCLUDED_DIRS="\/.*\/example|\/new_match"
 EXCLUDED_DIRS="\/.*\/example"
 
 # List of instrumentation folders

--- a/instrumentations.sh
+++ b/instrumentations.sh
@@ -31,8 +31,13 @@ fi
 CORE_VERSION=latest
 # CORE_VERSION=v1.45.0
 
+# List of folders to be excluded from the instrumentation list
+# If new matches must be added, use regular expressions. eg:
+# EXCLUDED_DIRS="/.*/example|/new_match"
+EXCLUDED_DIRS="\/.*\/example"
+
 # List of instrumentation folders
-LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -v "/instasarama/example")
+LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$EXCLUDED_DIRS")
 
 # Updates all instrumentations to use the @latest version of the core module
 run_update() {


### PR DESCRIPTION
This PR improves the way that instrumentation directories are filtered in the instrumentations.sh script.
There are cases when an instrumentation folder has subdirectories with examples or test code with a go.mod that mistakenly matches the instrumentation list.

This change attempts to offer a more accurate and flexible way to filter unwanted matches.