### PR TITLE
SQL Instrumentation: Handling drivers that don't implement the CheckNamedValue method

### DIFF
--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -231,12 +231,12 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 		return c.CheckNamedValue(d)
 	}
 
-	// stmt, err := conn.Prepare("select name from table where name = ?")
-	stmt, err := conn.Prepare("select * from tbl")
-	// stmt, err := conn.Prepare("select 1")
+	q := "drop table tbl"
+
+	stmt, err := conn.Prepare(q)
 
 	if err != nil {
-		return err
+		sensor.logger.Debug("Database does not support temporary statement: ", q)
 	}
 
 	if s, ok := stmt.(driver.NamedValueChecker); ok {
@@ -293,10 +293,13 @@ func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	// return nil
-
 	var err error
 	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d.Value)
+
+	if err != nil {
+		sensor.logger.Debug("Swallowing DefaultParameterConverter error: ", err.Error())
+		return nil
+	}
 
 	return err
 }

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -231,7 +231,21 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 		return c.CheckNamedValue(d)
 	}
 
-	return nil
+	// stmt, err := conn.Prepare("select name from table where name = ?")
+	stmt, err := conn.Prepare("select * from tbl")
+	// stmt, err := conn.Prepare("select 1")
+
+	if err != nil {
+		return err
+	}
+
+	if s, ok := stmt.(driver.NamedValueChecker); ok {
+		return s.CheckNamedValue(d)
+	}
+
+	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d.Value)
+
+	return err
 }
 
 type wrappedSQLStmt struct {
@@ -279,7 +293,12 @@ func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
 		return s.CheckNamedValue(d)
 	}
 
-	return nil
+	// return nil
+
+	var err error
+	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d.Value)
+
+	return err
 }
 
 func (stmt *wrappedSQLStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -245,6 +245,11 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 
 	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d.Value)
 
+	if err != nil {
+		sensor.logger.Debug("Swallowing DefaultParameterConverter error: ", err.Error())
+		return nil
+	}
+
 	return err
 }
 

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -253,11 +253,6 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 
 	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d.Value)
 
-	if err != nil {
-		sensor.logger.Debug("Swallowing DefaultParameterConverter error: ", err.Error())
-		return nil
-	}
-
 	return err
 }
 
@@ -314,11 +309,6 @@ func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
 
 	var err error
 	d.Value, err = driver.DefaultParameterConverter.ConvertValue(d.Value)
-
-	if err != nil {
-		sensor.logger.Debug("Swallowing DefaultParameterConverter error: ", err.Error())
-		return nil
-	}
 
 	return err
 }

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -231,13 +231,15 @@ func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
 		return c.CheckNamedValue(d)
 	}
 
-	q := "drop table tbl"
+	q := "create table instanatemp (a varchar(1))"
 
 	stmt, err := conn.Prepare(q)
 
 	if err != nil {
 		sensor.logger.Debug("Database does not support temporary statement: ", q)
 	}
+
+	defer stmt.Close()
 
 	if s, ok := stmt.(driver.NamedValueChecker); ok {
 		return s.CheckNamedValue(d)

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -227,6 +227,12 @@ func (conn *wrappedSQLConn) ExecContext(ctx context.Context, query string, args 
 }
 
 func (conn *wrappedSQLConn) CheckNamedValue(d *driver.NamedValue) error {
+	defer func() {
+		if err := recover(); err != nil {
+			sensor.logger.Debug("Swallowing error: ", err)
+		}
+	}()
+
 	if c, ok := conn.Conn.(driver.NamedValueChecker); ok {
 		return c.CheckNamedValue(d)
 	}
@@ -296,6 +302,12 @@ func (stmt *wrappedSQLStmt) ExecContext(ctx context.Context, args []driver.Named
 }
 
 func (stmt *wrappedSQLStmt) CheckNamedValue(d *driver.NamedValue) error {
+	defer func() {
+		if err := recover(); err != nil {
+			sensor.logger.Debug("Swallowing error: ", err)
+		}
+	}()
+
 	if s, ok := stmt.Stmt.(driver.NamedValueChecker); ok {
 		return s.CheckNamedValue(d)
 	}


### PR DESCRIPTION
This PR fixes an issue in the SQL instrumentation for when the method `CheckNamedValue` implementation is not found in the driver for both `driver.Conn` and `driver.Stmt` interfaces.
When this scenario is matched, we fallback to the Go standard lib method `driver.DefaultParameterConverter.ConvertValue` to deal with the value check.