### PR TITLE
[PoC] Splitting concerns between core module and instrumentations

### DIFF
--- a/delayed_spans.go
+++ b/delayed_spans.go
@@ -9,15 +9,15 @@ import (
 const maxDelayedSpans = 500
 
 var delayed = &delayedSpans{
-	spans: make(chan *spanS, maxDelayedSpans),
+	spans: make(chan *InstanaSpan, maxDelayedSpans),
 }
 
 type delayedSpans struct {
-	spans chan *spanS
+	spans chan *InstanaSpan
 }
 
 // append add a span to the buffer if buffer is not full yet
-func (ds *delayedSpans) append(span *spanS) bool {
+func (ds *delayedSpans) append(span *InstanaSpan) bool {
 	select {
 	case ds.spans <- span:
 		return true
@@ -55,7 +55,7 @@ func (ds *delayedSpans) flush() {
 }
 
 // processSpan applies secret filtering to the buffered http span http.params tag
-func (ds *delayedSpans) processSpan(s *spanS, opts TracerOptions) error {
+func (ds *delayedSpans) processSpan(s *InstanaSpan, opts TracerOptions) error {
 	newParams := url.Values{}
 	if paramsTag, ok := s.Tags["http.params"]; ok {
 		if httpParams, ok := paramsTag.(string); ok {

--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -18,12 +18,12 @@ import (
 
 func TestAppendALotDelayedSpans(t *testing.T) {
 	ds := &delayedSpans{
-		spans: make(chan *spanS, maxDelayedSpans),
+		spans: make(chan *InstanaSpan, maxDelayedSpans),
 	}
 
 	i := 0
 	for i <= 2*maxDelayedSpans {
-		ds.append(&spanS{})
+		ds.append(&InstanaSpan{})
 		i++
 	}
 
@@ -32,7 +32,7 @@ func TestAppendALotDelayedSpans(t *testing.T) {
 
 func resetDelayedSpans() {
 	delayed = &delayedSpans{
-		spans: make(chan *spanS, maxDelayedSpans),
+		spans: make(chan *InstanaSpan, maxDelayedSpans),
 	}
 }
 

--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -124,7 +124,7 @@ func TestParallelFlushDelayedSpans(t *testing.T) {
 	assert.Equal(t, maxDelayedSpans, len(recordedSpans))
 
 	for _, v := range recordedSpans {
-		if v, ok := v.Data.(HTTPSpanData); ok {
+		if v, ok := v.Data.(HTTPServerSpanData); ok {
 			assert.Equal(t, "q=%3Credacted%3E&secret=%3Credacted%3E", v.Tags.Params)
 		} else {
 			assert.Fail(t, "wrong span type")

--- a/instrumentation_http.go
+++ b/instrumentation_http.go
@@ -247,7 +247,7 @@ func processResponseStatus(response wrappedResponseWriter, span ot.Span) {
 		// Due to a design limitation, the graphql instrumentation doesn't have access to the instana.spanS struct. Plus,
 		// we are unable to control the span finishing from the graphql instrumentation, which leads us to add this workaround
 		// here.
-		if spS, ok := span.(*spanS); ok {
+		if spS, ok := span.(*InstanaSpan); ok {
 			if spS.Operation != "graphql.server" {
 				span.SetTag("http.status", response.Status())
 			}

--- a/instrumentation_http.go
+++ b/instrumentation_http.go
@@ -17,7 +17,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
-func NewHTTPSpanTags(span *spanS) HTTPServerSpanTags {
+func NewHTTPSpanTags(span *InstanaSpan) HTTPServerSpanTags {
 	var tags HTTPServerSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -93,7 +93,7 @@ func (d HTTPServerSpanData) Kind() SpanKind {
 	return EntrySpanKind
 }
 
-func (s *SpanHTTPServer) ExtractData(span *spanS) TypedSpanData {
+func (s *SpanHTTPServer) ExtractData(span *InstanaSpan) TypedSpanData {
 	data := HTTPServerSpanData{
 		SpanData: NewSpanData(span, RegisteredSpanType(span.Operation)),
 		Tags:     NewHTTPSpanTags(span),

--- a/instrumentation_http_test.go
+++ b/instrumentation_http_test.go
@@ -85,10 +85,10 @@ func TestTracingNamedHandlerFunc_Write(t *testing.T) {
 	assert.False(t, span.ForeignTrace)
 	assert.Empty(t, span.Ancestor)
 
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
-	data := span.Data.(instana.HTTPSpanData)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Host:   "example.com",
 		Status: http.StatusOK,
 		Method: "GET",
@@ -214,10 +214,10 @@ func TestTracingNamedHandlerFunc_WriteHeaders(t *testing.T) {
 	assert.False(t, span.ForeignTrace)
 	assert.Empty(t, span.Ancestor)
 
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
-	data := span.Data.(instana.HTTPSpanData)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Status:  http.StatusNotFound,
 		Method:  "GET",
 		Host:    "example.com",
@@ -281,10 +281,10 @@ func TestTracingNamedHandlerFunc_W3CTraceContext(t *testing.T) {
 		ParentID: "5678",
 	}, span.Ancestor)
 
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
-	data := span.Data.(instana.HTTPSpanData)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Host:    "example.com",
 		Status:  http.StatusOK,
 		Method:  "GET",
@@ -338,10 +338,10 @@ func TestTracingHandlerFunc_SecretsFiltering(t *testing.T) {
 	assert.Empty(t, span.CorrelationType)
 	assert.Empty(t, span.CorrelationID)
 
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
-	data := span.Data.(instana.HTTPSpanData)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Host:         "example.com",
 		Status:       http.StatusOK,
 		Method:       "GET",
@@ -378,10 +378,10 @@ func TestTracingHandlerFunc_Error(t *testing.T) {
 	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
 	assert.False(t, span.Synthetic)
 
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
-	data := span.Data.(instana.HTTPSpanData)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Status:  http.StatusInternalServerError,
 		Method:  "GET",
 		Host:    "example.com",
@@ -476,10 +476,10 @@ func TestTracingHandlerFunc_PanicHandling(t *testing.T) {
 	assert.EqualValues(t, instana.EntrySpanKind, span.Kind)
 	assert.False(t, span.Synthetic)
 
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
-	data := span.Data.(instana.HTTPSpanData)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Status:  http.StatusInternalServerError,
 		Method:  "GET",
 		Host:    "example.com",

--- a/json_span.go
+++ b/json_span.go
@@ -69,7 +69,7 @@ type Span struct {
 	ForeignTrace    bool
 }
 
-func newSpan(span *spanS) Span {
+func newSpan(span *InstanaSpan) Span {
 	st, ok := registeredSpans[span.Operation]
 	var data typedSpanData
 
@@ -224,7 +224,7 @@ type SpanData struct {
 }
 
 // NewSpanData initializes a new span data from tracer span
-func NewSpanData(span *spanS, st RegisteredSpanType) SpanData {
+func NewSpanData(span *InstanaSpan, st RegisteredSpanType) SpanData {
 	data := SpanData{
 		Service: span.Service,
 		st:      st,
@@ -254,7 +254,7 @@ type SDKSpanData struct {
 }
 
 // newSDKSpanData initializes a new SDK span data from a tracer span
-func newSDKSpanData(span *spanS) SDKSpanData {
+func newSDKSpanData(span *InstanaSpan) SDKSpanData {
 	sk := IntermediateSpanKind
 
 	switch span.Tags[string(ext.SpanKind)] {
@@ -296,7 +296,7 @@ type SDKSpanTags struct {
 }
 
 // newSDKSpanTags extracts SDK span tags from a tracer span
-func newSDKSpanTags(span *spanS, spanType string) SDKSpanTags {
+func newSDKSpanTags(span *InstanaSpan, spanType string) SDKSpanTags {
 	tags := SDKSpanTags{
 		Name:   span.Operation,
 		Type:   spanType,

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -93,11 +93,11 @@ func TestSpanData_CustomTags(t *testing.T) {
 	require.Len(t, spans, 1)
 
 	span := spans[0]
-	require.IsType(t, instana.HTTPSpanData{}, span.Data)
+	require.IsType(t, instana.HTTPServerSpanData{}, span.Data)
 
-	data := span.Data.(instana.HTTPSpanData)
+	data := span.Data.(instana.HTTPServerSpanData)
 
-	assert.Equal(t, instana.HTTPSpanTags{
+	assert.Equal(t, instana.HTTPServerSpanTags{
 		Host: "localhost",
 		Path: "/",
 	}, data.Tags)

--- a/recorder.go
+++ b/recorder.go
@@ -15,7 +15,7 @@ import (
 // the containing process and provides access to a straightforward tag map.
 type SpanRecorder interface {
 	// Implementations must determine whether and where to store `span`.
-	RecordSpan(span *spanS)
+	RecordSpan(span *InstanaSpan)
 	// Flush forces sending any buffered finished spans
 	Flush(context.Context) error
 }
@@ -54,7 +54,7 @@ func NewTestRecorder() *Recorder {
 
 // RecordSpan accepts spans to be recorded and added to the span queue
 // for eventual reporting to the host agent.
-func (r *Recorder) RecordSpan(span *spanS) {
+func (r *Recorder) RecordSpan(span *InstanaSpan) {
 	// If we're not announced and not in test mode then just
 	// return
 	if !r.testMode && !sensor.Agent().Ready() {

--- a/registered_span.go
+++ b/registered_span.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SpanRegistry interface {
-	ExtractData(span *spanS) TypedSpanData
+	ExtractData(span *InstanaSpan) TypedSpanData
 	TagsNames() map[string]struct{}
 }
 
@@ -76,7 +76,7 @@ const (
 type RegisteredSpanType string
 
 // extractData is a factory method to create the `data` section for a typed span
-func (st RegisteredSpanType) extractData(span *spanS) typedSpanData {
+func (st RegisteredSpanType) extractData(span *InstanaSpan) typedSpanData {
 	switch st {
 	// case HTTPServerSpanType, HTTPClientSpanType:
 	case HTTPClientSpanType:
@@ -304,7 +304,7 @@ type HTTPSpanData struct {
 }
 
 // newHTTPSpanData initializes a new HTTP span data from tracer span
-func newHTTPSpanData(span *spanS) HTTPSpanData {
+func newHTTPSpanData(span *InstanaSpan) HTTPSpanData {
 	data := HTTPSpanData{
 		SpanData: NewSpanData(span, RegisteredSpanType(span.Operation)),
 		Tags:     newHTTPSpanTags(span),
@@ -352,7 +352,7 @@ type HTTPSpanTags struct {
 }
 
 // newHTTPSpanTags extracts HTTP-specific span tags from a tracer span
-func newHTTPSpanTags(span *spanS) HTTPSpanTags {
+func newHTTPSpanTags(span *InstanaSpan) HTTPSpanTags {
 	var tags HTTPSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -395,7 +395,7 @@ type RPCSpanData struct {
 }
 
 // newRPCSpanData initializes a new RPC span data from tracer span
-func newRPCSpanData(span *spanS) RPCSpanData {
+func newRPCSpanData(span *InstanaSpan) RPCSpanData {
 	data := RPCSpanData{
 		SpanData: NewSpanData(span, RegisteredSpanType(span.Operation)),
 		Tags:     newRPCSpanTags(span),
@@ -433,7 +433,7 @@ type RPCSpanTags struct {
 }
 
 // newRPCSpanTags extracts RPC-specific span tags from a tracer span
-func newRPCSpanTags(span *spanS) RPCSpanTags {
+func newRPCSpanTags(span *InstanaSpan) RPCSpanTags {
 	var tags RPCSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -464,7 +464,7 @@ type KafkaSpanData struct {
 }
 
 // newKafkaSpanData initializes a new Kafka span data from tracer span
-func newKafkaSpanData(span *spanS) KafkaSpanData {
+func newKafkaSpanData(span *InstanaSpan) KafkaSpanData {
 	data := KafkaSpanData{
 		SpanData: NewSpanData(span, RegisteredSpanType(span.Operation)),
 		Tags:     newKafkaSpanTags(span),
@@ -494,7 +494,7 @@ type KafkaSpanTags struct {
 }
 
 // newKafkaSpanTags extracts Kafka-specific span tags from a tracer span
-func newKafkaSpanTags(span *spanS) KafkaSpanTags {
+func newKafkaSpanTags(span *InstanaSpan) KafkaSpanTags {
 	var tags KafkaSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -517,7 +517,7 @@ type RabbitMQSpanData struct {
 }
 
 // newRabbitMQSpanData initializes a new RabbitMQ span data from tracer span
-func newRabbitMQSpanData(span *spanS) RabbitMQSpanData {
+func newRabbitMQSpanData(span *InstanaSpan) RabbitMQSpanData {
 	data := RabbitMQSpanData{
 		SpanData: NewSpanData(span, RegisteredSpanType(span.Operation)),
 		Tags:     newRabbitMQSpanTags(span),
@@ -553,7 +553,7 @@ type RabbitMQSpanTags struct {
 }
 
 // newRabbitMQSpanTags extracts RabbitMQ-specific span tags from a tracer span
-func newRabbitMQSpanTags(span *spanS) RabbitMQSpanTags {
+func newRabbitMQSpanTags(span *InstanaSpan) RabbitMQSpanTags {
 	var tags RabbitMQSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -580,7 +580,7 @@ type GCPStorageSpanData struct {
 }
 
 // newGCPStorageSpanData initializes a new Google Cloud Storage span data from tracer span
-func newGCPStorageSpanData(span *spanS) GCPStorageSpanData {
+func newGCPStorageSpanData(span *InstanaSpan) GCPStorageSpanData {
 	data := GCPStorageSpanData{
 		SpanData: NewSpanData(span, GCPStorageSpanType),
 		Tags:     newGCPStorageSpanTags(span),
@@ -611,7 +611,7 @@ type GCPStorageSpanTags struct {
 }
 
 // newGCPStorageSpanTags extracts Google Cloud Storage span tags from a tracer span
-func newGCPStorageSpanTags(span *spanS) GCPStorageSpanTags {
+func newGCPStorageSpanTags(span *InstanaSpan) GCPStorageSpanTags {
 	var tags GCPStorageSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -652,7 +652,7 @@ type GCPPubSubSpanData struct {
 }
 
 // newGCPPubSubSpanData initializes a new Google Cloud Pub/Span span data from tracer span
-func newGCPPubSubSpanData(span *spanS) GCPPubSubSpanData {
+func newGCPPubSubSpanData(span *InstanaSpan) GCPPubSubSpanData {
 	data := GCPPubSubSpanData{
 		SpanData: NewSpanData(span, GCPPubSubSpanType),
 		Tags:     newGCPPubSubSpanTags(span),
@@ -681,7 +681,7 @@ type GCPPubSubSpanTags struct {
 }
 
 // newGCPPubSubSpanTags extracts Google Cloud Pub/Sub span tags from a tracer span
-func newGCPPubSubSpanTags(span *spanS) GCPPubSubSpanTags {
+func newGCPPubSubSpanTags(span *InstanaSpan) GCPPubSubSpanTags {
 	var tags GCPPubSubSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -708,7 +708,7 @@ type AWSLambdaCloudWatchSpanTags struct {
 }
 
 // newAWSLambdaCloudWatchSpanTags extracts CloudWatch tags for an AWS Lambda entry span
-func newAWSLambdaCloudWatchSpanTags(span *spanS) AWSLambdaCloudWatchSpanTags {
+func newAWSLambdaCloudWatchSpanTags(span *InstanaSpan) AWSLambdaCloudWatchSpanTags {
 	var tags AWSLambdaCloudWatchSpanTags
 
 	if events := newAWSLambdaCloudWatchEventTags(span); !events.IsZero() {
@@ -740,7 +740,7 @@ type AWSLambdaCloudWatchEventTags struct {
 // newAWSLambdaCloudWatchEventTags extracts CloudWatch event tags for an AWS Lambda entry span. It truncates
 // the resources list to the first 3 items, populating the `data.lambda.cw.events.more` tag and limits each
 // resource string to the first 200 characters to reduce the payload.
-func newAWSLambdaCloudWatchEventTags(span *spanS) AWSLambdaCloudWatchEventTags {
+func newAWSLambdaCloudWatchEventTags(span *InstanaSpan) AWSLambdaCloudWatchEventTags {
 	var tags AWSLambdaCloudWatchEventTags
 
 	if v, ok := span.Tags["cloudwatch.events.id"]; ok {
@@ -794,7 +794,7 @@ type AWSLambdaCloudWatchLogsTags struct {
 // newAWSLambdaCloudWatchLogsTags extracts CloudWatch Logs tags for an AWS Lambda entry span. It truncates
 // the log events list to the first 3 items, populating the `data.lambda.cw.logs.more` tag and limits each
 // log string to the first 200 characters to reduce the payload.
-func newAWSLambdaCloudWatchLogsTags(span *spanS) AWSLambdaCloudWatchLogsTags {
+func newAWSLambdaCloudWatchLogsTags(span *InstanaSpan) AWSLambdaCloudWatchLogsTags {
 	var tags AWSLambdaCloudWatchLogsTags
 
 	if v, ok := span.Tags["cloudwatch.logs.group"]; ok {
@@ -863,7 +863,7 @@ type AWSLambdaS3SpanTags struct {
 
 // newAWSLambdaS3SpanTags extracts S3 Event tags for an AWS Lambda entry span. It truncates
 // the events list to the first 3 items and limits each object names to the first 200 characters to reduce the payload.
-func newAWSLambdaS3SpanTags(span *spanS) AWSLambdaS3SpanTags {
+func newAWSLambdaS3SpanTags(span *InstanaSpan) AWSLambdaS3SpanTags {
 	var tags AWSLambdaS3SpanTags
 
 	if events, ok := span.Tags["s3.events"]; ok {
@@ -904,7 +904,7 @@ type AWSLambdaSQSSpanTags struct {
 
 // newAWSLambdaSQSSpanTags extracts SQS event tags for an AWS Lambda entry span. It truncates
 // the events list to the first 3 items to reduce the payload.
-func newAWSLambdaSQSSpanTags(span *spanS) AWSLambdaSQSSpanTags {
+func newAWSLambdaSQSSpanTags(span *InstanaSpan) AWSLambdaSQSSpanTags {
 	var tags AWSLambdaSQSSpanTags
 
 	if msgs, ok := span.Tags["sqs.messages"]; ok {
@@ -953,7 +953,7 @@ type AWSLambdaSpanTags struct {
 }
 
 // newAWSLambdaSpanTags extracts AWS Lambda entry span tags from a tracer span
-func newAWSLambdaSpanTags(span *spanS) AWSLambdaSpanTags {
+func newAWSLambdaSpanTags(span *InstanaSpan) AWSLambdaSpanTags {
 	tags := AWSLambdaSpanTags{Runtime: "go"}
 
 	if v, ok := span.Tags["lambda.arn"]; ok {
@@ -1006,7 +1006,7 @@ type AWSLambdaSpanData struct {
 }
 
 // newAWSLambdaSpanData initializes a new AWSLambdaSpanData from span
-func newAWSLambdaSpanData(span *spanS) AWSLambdaSpanData {
+func newAWSLambdaSpanData(span *InstanaSpan) AWSLambdaSpanData {
 	d := AWSLambdaSpanData{
 		Snapshot: newAWSLambdaSpanTags(span),
 	}
@@ -1037,7 +1037,7 @@ type AWSS3SpanData struct {
 }
 
 // newAWSS3SpanData initializes a new AWS S3 span data from tracer span
-func newAWSS3SpanData(span *spanS) AWSS3SpanData {
+func newAWSS3SpanData(span *InstanaSpan) AWSS3SpanData {
 	data := AWSS3SpanData{
 		SpanData: NewSpanData(span, AWSS3SpanType),
 		Tags:     newAWSS3SpanTags(span),
@@ -1066,7 +1066,7 @@ type AWSS3SpanTags struct {
 }
 
 // newAWSS3SpanTags extracts AWS S3 span tags from a tracer span
-func newAWSS3SpanTags(span *spanS) AWSS3SpanTags {
+func newAWSS3SpanTags(span *InstanaSpan) AWSS3SpanTags {
 	var tags AWSS3SpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1093,7 +1093,7 @@ type AWSSQSSpanData struct {
 }
 
 // newAWSSQSSpanData initializes a new AWS SQS span data from tracer span
-func newAWSSQSSpanData(span *spanS) AWSSQSSpanData {
+func newAWSSQSSpanData(span *InstanaSpan) AWSSQSSpanData {
 	data := AWSSQSSpanData{
 		SpanData: NewSpanData(span, AWSSQSSpanType),
 		Tags:     newAWSSQSSpanTags(span),
@@ -1131,7 +1131,7 @@ type AWSSQSSpanTags struct {
 }
 
 // newAWSSQSSpanTags extracts AWS SQS span tags from a tracer span
-func newAWSSQSSpanTags(span *spanS) AWSSQSSpanTags {
+func newAWSSQSSpanTags(span *InstanaSpan) AWSSQSSpanTags {
 	var tags AWSSQSSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1160,7 +1160,7 @@ type AWSSNSSpanData struct {
 }
 
 // newAWSSNSSpanData initializes a new AWS SNS span data from tracer span
-func newAWSSNSSpanData(span *spanS) AWSSNSSpanData {
+func newAWSSNSSpanData(span *InstanaSpan) AWSSNSSpanData {
 	data := AWSSNSSpanData{
 		SpanData: NewSpanData(span, AWSSNSSpanType),
 		Tags:     newAWSSNSSpanTags(span),
@@ -1189,7 +1189,7 @@ type AWSSNSSpanTags struct {
 }
 
 // newAWSSNSSpanTags extracts AWS SNS span tags from a tracer span
-func newAWSSNSSpanTags(span *spanS) AWSSNSSpanTags {
+func newAWSSNSSpanTags(span *InstanaSpan) AWSSNSSpanTags {
 	var tags AWSSNSSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1216,7 +1216,7 @@ type AWSDynamoDBSpanData struct {
 }
 
 // newAWSDynamoDBSpanData initializes a new AWS DynamoDB span data from tracer span
-func newAWSDynamoDBSpanData(span *spanS) AWSDynamoDBSpanData {
+func newAWSDynamoDBSpanData(span *InstanaSpan) AWSDynamoDBSpanData {
 	data := AWSDynamoDBSpanData{
 		SpanData: NewSpanData(span, AWSDynamoDBSpanType),
 		Tags:     newAWSDynamoDBSpanTags(span),
@@ -1243,7 +1243,7 @@ type AWSDynamoDBSpanTags struct {
 }
 
 // newAWSDynamoDBSpanTags extracts AWS DynamoDB span tags from a tracer span
-func newAWSDynamoDBSpanTags(span *spanS) AWSDynamoDBSpanTags {
+func newAWSDynamoDBSpanTags(span *InstanaSpan) AWSDynamoDBSpanTags {
 	var tags AWSDynamoDBSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1271,7 +1271,7 @@ type AWSInvokeSpanTags struct {
 	Error string `json:"error,omitempty"`
 }
 
-func newAWSDInvokeSpanTags(span *spanS) AWSInvokeSpanTags {
+func newAWSDInvokeSpanTags(span *InstanaSpan) AWSInvokeSpanTags {
 	var tags AWSInvokeSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1304,7 +1304,7 @@ func (d AWSLambdaInvokeSpanData) Type() RegisteredSpanType {
 }
 
 // newAWSLambdaInvokeSpanData initializes a new AWS Invoke span data from tracer span
-func newAWSLambdaInvokeSpanData(span *spanS) AWSLambdaInvokeSpanData {
+func newAWSLambdaInvokeSpanData(span *InstanaSpan) AWSLambdaInvokeSpanData {
 	data := AWSLambdaInvokeSpanData{
 		SpanData: NewSpanData(span, AWSLambdaInvokeSpanType),
 		Tags:     newAWSDInvokeSpanTags(span),
@@ -1320,7 +1320,7 @@ type LogSpanData struct {
 }
 
 // newLogSpanData initializes a new logging span data from tracer span
-func newLogSpanData(span *spanS) LogSpanData {
+func newLogSpanData(span *InstanaSpan) LogSpanData {
 	return LogSpanData{
 		SpanData: NewSpanData(span, LogSpanType),
 		Tags:     newLogSpanTags(span),
@@ -1344,7 +1344,7 @@ type LogSpanTags struct {
 	Error string `json:"parameters,omitempty"`
 }
 
-func newLogSpanTags(span *spanS) LogSpanTags {
+func newLogSpanTags(span *InstanaSpan) LogSpanTags {
 	var tags LogSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1369,7 +1369,7 @@ type MongoDBSpanData struct {
 }
 
 // newMongoDBSpanData initializes a new MongoDB clientspan data from tracer span
-func newMongoDBSpanData(span *spanS) MongoDBSpanData {
+func newMongoDBSpanData(span *InstanaSpan) MongoDBSpanData {
 	return MongoDBSpanData{
 		SpanData: NewSpanData(span, MongoDBSpanType),
 		Tags:     newMongoDBSpanTags(span),
@@ -1383,7 +1383,7 @@ type RedisSpanData struct {
 }
 
 // newRedisSpanData initializes a new Redis clientspan data from tracer span
-func newRedisSpanData(span *spanS) RedisSpanData {
+func newRedisSpanData(span *InstanaSpan) RedisSpanData {
 	return RedisSpanData{
 		SpanData: NewSpanData(span, RedisSpanType),
 		Tags:     newRedisSpanTags(span),
@@ -1418,7 +1418,7 @@ type MongoDBSpanTags struct {
 	Error string `json:"error,omitempty"`
 }
 
-func newMongoDBSpanTags(span *spanS) MongoDBSpanTags {
+func newMongoDBSpanTags(span *InstanaSpan) MongoDBSpanTags {
 	var tags MongoDBSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1449,7 +1449,7 @@ type PostgreSQLSpanData struct {
 }
 
 // newPostgreSQLSpanData initializes a new PostgreSQL client span data from tracer span
-func newPostgreSQLSpanData(span *spanS) PostgreSQLSpanData {
+func newPostgreSQLSpanData(span *InstanaSpan) PostgreSQLSpanData {
 	return PostgreSQLSpanData{
 		SpanData: NewSpanData(span, PostgreSQLSpanType),
 		Tags:     newPostgreSQLSpanTags(span),
@@ -1472,7 +1472,7 @@ type postgreSQLSpanTags struct {
 	Error string `json:"error,omitempty"`
 }
 
-func newPostgreSQLSpanTags(span *spanS) postgreSQLSpanTags {
+func newPostgreSQLSpanTags(span *InstanaSpan) postgreSQLSpanTags {
 	var tags postgreSQLSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1504,7 +1504,7 @@ type RedisSpanTags struct {
 	Error string `json:"error,omitempty"`
 }
 
-func newRedisSpanTags(span *spanS) RedisSpanTags {
+func newRedisSpanTags(span *InstanaSpan) RedisSpanTags {
 	var tags RedisSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1531,7 +1531,7 @@ type AZFSpanTags struct {
 	Error        string `json:"error,omitempty"`
 }
 
-func newAZFSpanTags(span *spanS) AZFSpanTags {
+func newAZFSpanTags(span *InstanaSpan) AZFSpanTags {
 	var tags AZFSpanTags
 	for k, v := range span.Tags {
 		switch k {
@@ -1556,7 +1556,7 @@ type AZFSpanData struct {
 	Tags AZFSpanTags `json:"azf"`
 }
 
-func newAZFSpanData(span *spanS) AZFSpanData {
+func newAZFSpanData(span *InstanaSpan) AZFSpanData {
 	return AZFSpanData{
 		SpanData: NewSpanData(span, AzureFunctionType),
 		Tags:     newAZFSpanTags(span),
@@ -1577,7 +1577,7 @@ type GraphQLSpanData struct {
 }
 
 // newGraphQLSpanData initializes a new HTTP span data from tracer span
-func newGraphQLSpanData(span *spanS) GraphQLSpanData {
+func newGraphQLSpanData(span *InstanaSpan) GraphQLSpanData {
 	data := GraphQLSpanData{
 		SpanData: NewSpanData(span, RegisteredSpanType(span.Operation)),
 		Tags:     newGraphQLSpanTags(span),
@@ -1608,7 +1608,7 @@ type GraphQLSpanTags struct {
 }
 
 // newGraphQLSpanTags extracts GraphQL-specific span tags from a tracer span
-func newGraphQLSpanTags(span *spanS) GraphQLSpanTags {
+func newGraphQLSpanTags(span *InstanaSpan) GraphQLSpanTags {
 	var tags GraphQLSpanTags
 	for k, v := range span.Tags {
 		switch k {

--- a/registered_span_test.go
+++ b/registered_span_test.go
@@ -20,7 +20,7 @@ func TestRegisteredSpanType_ExtractData(t *testing.T) {
 	}{
 		"net/http.Server": {
 			Operation: "g.http",
-			Expected:  instana.HTTPSpanData{},
+			Expected:  instana.HTTPServerSpanData{},
 		},
 		"net/http.Client": {
 			Operation: "http",

--- a/tracer.go
+++ b/tracer.go
@@ -109,16 +109,18 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 		delete(opts.Tags, suppressTracingTag)
 	}
 
-	return &spanS{
-		context:     sc,
-		tracer:      r,
-		Service:     sensor.options.Service,
-		Operation:   operationName,
-		Start:       startTime,
-		Duration:    -1,
-		Correlation: corrData,
-		Tags:        opts.Tags,
-	}
+	sp := &InstanaSpan{}
+	sp.context = sc
+
+	sp.tracer = r
+	sp.Service = sensor.options.Service
+	sp.Operation = operationName
+	sp.Start = startTime
+	sp.Duration = -1
+	sp.Correlation = corrData
+	sp.Tags = opts.Tags
+
+	return sp
 }
 
 // Options returns current tracer options


### PR DESCRIPTION
This PoC aims to redesign how instrumentations relate to the core module in such a way that instrumentations can be released faster and reducing coupling between instrumentations and the core module.

**Keep in mind that this is a PoC. Some names are not ideal and some code is duplicated in order to assure that the tracer works both in the old way and the new one. This known duplication is important to assure that we can gradually update the tracer with smaller releases if we ever decide to go for this approach in Production.**

Some highlights of the PoC (so far):

1. The conversion of `instana.spanS` to a public version `instana.InstanaSpan`
1. The conversion of `instana.typedSpanData` to a public version `instana.TypedSpanData`
1. The separation of the HTTP Server instrumentation from the core module to the API instrumentation
1. The introduction of a new concept: dynamically registered spans in the core module. This is supposed to replace the manual hard coded inclusion of new spans into the core module
1. The ability to work with both legacy registered spans and new dynamic registered spans
2. The conversion of the "readXXXTag" functions to be public (currently, only `ReadStringTag`).