### PR TITLE
Added instrumentation for the builtin handler

### DIFF
--- a/instrumentation/instagraphql/example/go.mod
+++ b/instrumentation/instagraphql/example/go.mod
@@ -8,9 +8,8 @@ require (
 )
 
 require (
+	github.com/graphql-go/handler v0.2.3
 	github.com/instana/go-sensor v1.50.0
-	github.com/looplab/fsm v0.1.0 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
 )
 
 replace github.com/instana/go-sensor/instrumentation/instagraphql => ../

--- a/instrumentation/instagraphql/example/go.sum
+++ b/instrumentation/instagraphql/example/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/graphql-go/graphql v0.8.0 h1:JHRQMeQjofwqVvGwYnr8JnPTY0AxgVy1HpHSGPLdH0I=
 github.com/graphql-go/graphql v0.8.0/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
+github.com/graphql-go/handler v0.2.3 h1:CANh8WPnl5M9uA25c2GBhPqJhE53Fg0Iue/fRNla71E=
+github.com/graphql-go/handler v0.2.3/go.mod h1:leLF6RpV5uZMN1CdImAxuiayrYYhOk33bZciaUGaXeU=
 github.com/instana/go-sensor v1.50.0 h1:08lPyTHpXxvI/7AVSYONT6StMptCjGe3SBxV43THh4U=
 github.com/instana/go-sensor v1.50.0/go.mod h1:vy4pjjaQ8XnhzDdKmtBX41uIIetfPaEHEzLKeIpYT/w=
 github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=
@@ -18,6 +20,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/instrumentation/instagraphql/example_test.go
+++ b/instrumentation/instagraphql/example_test.go
@@ -6,13 +6,15 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/handler"
 	instana "github.com/instana/go-sensor"
 	"github.com/instana/go-sensor/instrumentation/instagraphql"
 )
 
-func Example() {
+func ExampleDo() {
 	// create an instance of the Instana sensor
 	sensor := instana.NewSensor("go-graphql")
 
@@ -43,4 +45,46 @@ func Example() {
 	r := instagraphql.Do(context.Background(), sensor, params)
 
 	fmt.Println("do something with the result", r)
+}
+
+func ExampleResultCallbackFn() {
+	// create an instance of the Instana sensor
+	sensor := instana.NewSensor("go-graphql")
+
+	// setup GraphQL normally
+	fields := graphql.Fields{
+		"myfield": &graphql.Field{
+			Type: graphql.String,
+		},
+	}
+
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: fields}
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+
+	schema, err := graphql.NewSchema(schemaConfig)
+
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Setup the handler
+
+	// The original ResultCallbackFn function if you have one. Otherwise, just pass nil
+	var fn handler.ResultCallbackFn = func(ctx context.Context, params *graphql.Params, result *graphql.Result, responseBody []byte) {
+		fmt.Println("Original callback function")
+	}
+
+	h := handler.New(&handler.Config{
+		Schema:   &schema,
+		Pretty:   true,
+		GraphiQL: true,
+		// instagraphql.ResultCallbackFn instruments the code and returns the original function, if any.
+		ResultCallbackFn: instagraphql.ResultCallbackFn(sensor, fn),
+	})
+
+	http.Handle("/graphql", h)
+
+	if err := http.ListenAndServe("0.0.0.0:9191", nil); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/instrumentation/instagraphql/go.mod
+++ b/instrumentation/instagraphql/go.mod
@@ -8,4 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 )
 
-require github.com/opentracing/opentracing-go v1.1.0
+require (
+	github.com/graphql-go/handler v0.2.3
+	github.com/opentracing/opentracing-go v1.1.0
+)

--- a/instrumentation/instagraphql/go.sum
+++ b/instrumentation/instagraphql/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/graphql-go/graphql v0.8.0 h1:JHRQMeQjofwqVvGwYnr8JnPTY0AxgVy1HpHSGPLdH0I=
 github.com/graphql-go/graphql v0.8.0/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
+github.com/graphql-go/handler v0.2.3 h1:CANh8WPnl5M9uA25c2GBhPqJhE53Fg0Iue/fRNla71E=
+github.com/graphql-go/handler v0.2.3/go.mod h1:leLF6RpV5uZMN1CdImAxuiayrYYhOk33bZciaUGaXeU=
 github.com/instana/go-sensor v1.50.0 h1:08lPyTHpXxvI/7AVSYONT6StMptCjGe3SBxV43THh4U=
 github.com/instana/go-sensor v1.50.0/go.mod h1:vy4pjjaQ8XnhzDdKmtBX41uIIetfPaEHEzLKeIpYT/w=
 github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=


### PR DESCRIPTION
This PR adds support for the [builtin handler from the graphql API](https://github.com/graphql-go/handler).
The handler is an HTTP Handler that wraps the graphql API and provides features such as a GraphQL Playground.