### PR TITLE
Added go1.20 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,9 @@ workflows:
   build:
     jobs:
       - build:
+          name: "go1.20"
+          image: "cimg/go:1.20"
+      - build:
           name: "go1.19"
           image: "cimg/go:1.19"
       - build:


### PR DESCRIPTION
This PR adds the new version of Go, 1.20 to our CI