### PR TITLE
feat: improve robustness of custom service naming

### DIFF
--- a/event.go
+++ b/event.go
@@ -39,7 +39,7 @@ const (
 func SendDefaultServiceEvent(title string, text string, sev severity, duration time.Duration) {
 	var service string
 	if sensor != nil {
-		service = sensor.serviceName
+		service = sensor.serviceOrBinaryName()
 	}
 
 	// If the sensor is not yet initialized, there is no default service (as

--- a/json_span_test.go
+++ b/json_span_test.go
@@ -4,6 +4,7 @@
 package instana_test
 
 import (
+	"os"
 	"testing"
 
 	instana "github.com/instana/go-sensor"
@@ -41,6 +42,61 @@ func TestSpanKind_String(t *testing.T) {
 			assert.Equal(t, example.Expected, example.Kind.String())
 		})
 	}
+}
+
+func TestServiceNameViaConfig(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(
+		&instana.Options{
+			AgentClient: alwaysReadyClient{},
+			Service:     "Service Name",
+		},
+		recorder,
+	)
+	defer instana.ShutdownSensor()
+	sp := tracer.StartSpan("g.http")
+	sp.Finish()
+	spans := recorder.GetQueuedSpans()
+
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "Service Name", span.Data.(instana.HTTPSpanData).SpanData.Service)
+	assert.Contains(t, spanToJson(t, span), "\"service\":\"Service Name\"")
+}
+
+func TestServiceNameViaEnvVar(t *testing.T) {
+	envVarOriginalValue, wasSet := os.LookupEnv("INSTANA_SERVICE_NAME")
+	os.Setenv("INSTANA_SERVICE_NAME", "Service Name")
+	defer func() {
+		if wasSet {
+			os.Setenv("INSTANA_SERVICE_NAME", envVarOriginalValue)
+		} else {
+			os.Unsetenv("INSTANA_SERVICE_NAME")
+		}
+	}()
+
+	recorder := instana.NewTestRecorder()
+	tracer := instana.NewTracerWithEverything(
+		&instana.Options{
+			AgentClient: alwaysReadyClient{},
+		},
+		recorder,
+	)
+	defer instana.ShutdownSensor()
+	sp := tracer.StartSpan("g.http")
+	sp.Finish()
+	spans := recorder.GetQueuedSpans()
+
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "Service Name", span.Data.(instana.HTTPSpanData).SpanData.Service)
+	assert.Contains(t, spanToJson(t, span), "\"service\":\"Service Name\"")
+}
+
+func spanToJson(t *testing.T, span instana.Span) string {
+	jsonBytes, err := span.MarshalJSON()
+	assert.NoError(t, err)
+	return string(jsonBytes[:])
 }
 
 func TestNewSDKSpanData(t *testing.T) {

--- a/tracer.go
+++ b/tracer.go
@@ -112,7 +112,7 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 	return &spanS{
 		context:     sc,
 		tracer:      r,
-		Service:     sensor.options.Service,
+		Service:     sensor.serviceName,
 		Operation:   operationName,
 		Start:       startTime,
 		Duration:    -1,


### PR DESCRIPTION
feat: improve robustness of custom service naming

Use `INSTANA_SERVICE_NAME` value for `span.data.service` annotation.

Previously, `span.data.service` has only been added when configured via in-code
configuration, but not when the environment variable `INSTANA_SERVICE_NAME` is
set. The Go tracer implicitly relied on the back end to link spans to
infrastructure entities and get the service name from there. Adding the
annotation to the span makes service name extraction more resilient, in
particular with respect to situations in which spans cannot be linked to
infrastructure.

The binary name is now kept as a separate attribute in the sensor struct. This
is to keep the pre-existing behavior to fall back to the binary's name when
sending the infrastructure snapshot `name` attribute and the `service`
attribute for events. However, we explicitly do not want to add the
binary's name as an annotation to all spans.

See also: 
* https://github.ibm.com/instana/technical-documentation/pull/290/files
* https://instana.slack.com/archives/GBS2G15GD/p1675160462737709