### PR TITLE
Introducing the instana.Collector

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -14,6 +14,14 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
+var _ TracerLogger = (*Sensor)(nil)
+
+type SensorLogger interface {
+	Tracer() ot.Tracer
+	Logger() LeveledLogger
+	SetLogger(l LeveledLogger)
+}
+
 // SpanSensitiveFunc is a function executed within a span context
 //
 // Deprecated: use instana.ContextWithSpan() and instana.SpanFromContext() to inject and retrieve spans

--- a/agent_communicator.go
+++ b/agent_communicator.go
@@ -199,7 +199,7 @@ func (a *agentCommunicator) sendDataToAgent(suffix string, data interface{}) err
 	if resp != nil {
 		respCode := resp.StatusCode
 		if respCode < 200 || respCode >= 300 {
-			a.l.Debug("Sending data to agent: response code: ", resp.StatusCode, "-", resp.Status)
+			a.l.Debug("Sending data to agent: response code: ", resp.StatusCode, "-", resp.Status, "; ", url)
 		}
 
 		io.CopyN(ioutil.Discard, resp.Body, 256<<10)

--- a/azure_agent_test.go
+++ b/azure_agent_test.go
@@ -106,7 +106,7 @@ func TestAzureAgent_SpanDetails(t *testing.T) {
           "functionname": "testfunction",
           "triggername": "HTTP",
           "runtime": "custom"
-        } }`, string(spans[0]["data"]))
+        }, "service": "instana.test"}`, string(spans[0]["data"]))
 }
 
 func setupAzureFunctionEnv() func() {

--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,142 @@
+// (c) Copyright IBM Corp. 2023
+
+package instana
+
+import (
+	"context"
+
+	ot "github.com/opentracing/opentracing-go"
+)
+
+// TracerLogger represents the Instana Go collector and is composed by a tracer, a logger and a reference to the legacy sensor.
+type TracerLogger interface {
+	Tracer
+	LeveledLogger
+	LegacySensor() *Sensor
+	Tracer() ot.Tracer
+	Logger() LeveledLogger
+}
+
+// Collector is used to inject tracing information into requests
+type Collector struct {
+	t Tracer
+	LeveledLogger
+	*Sensor
+}
+
+var _ TracerLogger = (*Collector)(nil)
+
+// InitCollector creates a new [Collector]
+func InitCollector(opts *Options) TracerLogger {
+
+	// if instana.C is already an instance of Collector, we just return
+	if _, ok := C.(*Collector); ok {
+		C.Warn("InitCollector was previously called. instana.C is reused")
+		return C
+	}
+
+	if opts == nil {
+		opts = &Options{
+			Recorder: NewRecorder(),
+		}
+	}
+
+	if opts.Recorder == nil {
+		opts.Recorder = NewRecorder()
+	}
+
+	StartMetrics(opts)
+
+	tracer := &tracerS{
+		recorder: opts.Recorder,
+	}
+
+	C = &Collector{
+		t:             tracer,
+		LeveledLogger: defaultLogger,
+		Sensor:        NewSensorWithTracer(tracer),
+	}
+
+	return C
+}
+
+// Extract() returns a SpanContext instance given `format` and `carrier`. It matches [opentracing.Tracer.Extract].
+func (c *Collector) Extract(format interface{}, carrier interface{}) (ot.SpanContext, error) {
+	return c.t.Extract(format, carrier)
+}
+
+// Inject() takes the `sm` SpanContext instance and injects it for
+// propagation within `carrier`. The actual type of `carrier` depends on
+// the value of `format`. It matches [opentracing.Tracer.Inject]
+func (c *Collector) Inject(sm ot.SpanContext, format interface{}, carrier interface{}) error {
+	return c.t.Inject(sm, format, carrier)
+}
+
+// Create, start, and return a new Span with the given `operationName` and
+// incorporate the given StartSpanOption `opts`. (Note that `opts` borrows
+// from the "functional options" pattern, per
+// http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)
+//
+// It matches [opentracing.Tracer.StartSpan].
+func (c *Collector) StartSpan(operationName string, opts ...ot.StartSpanOption) ot.Span {
+	return c.t.StartSpan(operationName, opts...)
+}
+
+// StartSpanWithOptions creates and starts a span by setting Instana relevant data within the span.
+// It matches [instana.Tracer.StartSpanWithOptions].
+func (c *Collector) StartSpanWithOptions(operationName string, opts ot.StartSpanOptions) ot.Span {
+	return c.t.StartSpanWithOptions(operationName, opts)
+}
+
+// Options gets the current tracer options
+// It matches [instana.Tracer.Options].
+func (c *Collector) Options() TracerOptions {
+	return c.t.Options()
+}
+
+// Flush sends all finished spans to the agent
+// It matches [instana.Tracer.Flush].
+func (c *Collector) Flush(ctx context.Context) error {
+	return c.t.Flush(ctx)
+}
+
+// Debug logs a debug message by calling [LeveledLogger] underneath
+func (c *Collector) Debug(v ...interface{}) {
+	c.LeveledLogger.Debug(v...)
+}
+
+// Info logs an info message by calling [LeveledLogger] underneath
+func (c *Collector) Info(v ...interface{}) {
+	c.LeveledLogger.Info(v...)
+}
+
+// Warn logs a warning message by calling [LeveledLogger] underneath
+func (c *Collector) Warn(v ...interface{}) {
+	c.LeveledLogger.Warn(v...)
+}
+
+// Error logs a error message by calling [LeveledLogger] underneath
+func (c *Collector) Error(v ...interface{}) {
+	c.LeveledLogger.Error(v...)
+}
+
+// LegacySensor returns a reference to [Sensor] that can be used for old instrumentations that still require it.
+//
+// Example:
+//
+//	// Instrumenting HTTP incoming calls
+//	c := instana.InitCollector("my-service")
+//	http.HandleFunc("/", instana.TracingNamedHandlerFunc(c.LegacySensor(), "", "/{name}", handle))
+func (c *Collector) LegacySensor() *Sensor {
+	return c.Sensor
+}
+
+// Tracer returns an implementation of [opentracing.Tracer]
+func (c *Collector) Tracer() ot.Tracer {
+	return c.t
+}
+
+// Logger returns an implementation of [LeveledLogger]
+func (c *Collector) Logger() LeveledLogger {
+	return c.LeveledLogger
+}

--- a/collector.go
+++ b/collector.go
@@ -13,8 +13,7 @@ type TracerLogger interface {
 	Tracer
 	LeveledLogger
 	LegacySensor() *Sensor
-	Tracer() ot.Tracer
-	Logger() LeveledLogger
+	SensorLogger
 }
 
 // Collector is used to inject tracing information into requests
@@ -129,14 +128,4 @@ func (c *Collector) Error(v ...interface{}) {
 //	http.HandleFunc("/", instana.TracingNamedHandlerFunc(c.LegacySensor(), "", "/{name}", handle))
 func (c *Collector) LegacySensor() *Sensor {
 	return c.Sensor
-}
-
-// Tracer returns an implementation of [opentracing.Tracer]
-func (c *Collector) Tracer() ot.Tracer {
-	return c.t
-}
-
-// Logger returns an implementation of [LeveledLogger]
-func (c *Collector) Logger() LeveledLogger {
-	return c.LeveledLogger
 }

--- a/collector_noop.go
+++ b/collector_noop.go
@@ -1,0 +1,86 @@
+// (c) Copyright IBM Corp. 2023
+
+package instana
+
+import (
+	"context"
+	"errors"
+
+	ot "github.com/opentracing/opentracing-go"
+)
+
+var (
+	_                   TracerLogger = (*noopCollector)(nil)
+	noopCollectorErrMsg string       = "collector not initialized. make sure to initialize the Collector. eg: instana.InitCollector"
+	noopCollectorErr    error        = errors.New(noopCollectorErrMsg)
+)
+
+type noopCollector struct {
+	l LeveledLogger
+}
+
+func newNoopCollector() TracerLogger {
+	c := &noopCollector{
+		l: defaultLogger,
+	}
+	return c
+}
+
+func (c *noopCollector) Extract(format interface{}, carrier interface{}) (ot.SpanContext, error) {
+	c.l.Error(noopCollectorErrMsg)
+	return nil, noopCollectorErr
+}
+
+func (c *noopCollector) Inject(sm ot.SpanContext, format interface{}, carrier interface{}) error {
+	c.l.Error(noopCollectorErrMsg)
+	return noopCollectorErr
+}
+
+func (c *noopCollector) StartSpan(operationName string, opts ...ot.StartSpanOption) ot.Span {
+	c.l.Error(noopCollectorErrMsg)
+	return nil
+}
+
+func (c *noopCollector) StartSpanWithOptions(operationName string, opts ot.StartSpanOptions) ot.Span {
+	c.l.Error(noopCollectorErrMsg)
+	return nil
+}
+
+func (c *noopCollector) Options() TracerOptions {
+	return TracerOptions{}
+}
+
+func (c *noopCollector) Flush(ctx context.Context) error {
+	return noopCollectorErr
+}
+
+func (c *noopCollector) Debug(v ...interface{}) {
+	c.l.Error(noopCollectorErrMsg)
+}
+
+func (c *noopCollector) Info(v ...interface{}) {
+	c.l.Error(noopCollectorErrMsg)
+}
+
+func (c *noopCollector) Warn(v ...interface{}) {
+	c.l.Error(noopCollectorErrMsg)
+}
+
+func (c *noopCollector) Error(v ...interface{}) {
+	c.l.Error(noopCollectorErrMsg)
+}
+
+func (c *noopCollector) LegacySensor() *Sensor {
+	c.l.Error(noopCollectorErrMsg)
+	return nil
+}
+
+func (c *noopCollector) Tracer() ot.Tracer {
+	c.l.Error(noopCollectorErrMsg)
+	return nil
+}
+
+func (c *noopCollector) Logger() LeveledLogger {
+	c.l.Error(noopCollectorErrMsg)
+	return nil
+}

--- a/collector_noop.go
+++ b/collector_noop.go
@@ -84,3 +84,6 @@ func (c *noopCollector) Logger() LeveledLogger {
 	c.l.Error(noopCollectorErrMsg)
 	return nil
 }
+
+// SetLogger sets the logger
+func (c *noopCollector) SetLogger(l LeveledLogger) {}

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,0 +1,61 @@
+// (c) Copyright IBM Corp. 2023
+
+package instana_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	instana "github.com/instana/go-sensor"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Collector_Noop(t *testing.T) {
+	assert.NotNil(t, instana.C, "instana.C should never be nil and be initialized as noop")
+
+	sc, err := instana.C.Extract(nil, nil)
+	assert.Nil(t, sc)
+	assert.Error(t, err)
+	assert.Nil(t, instana.C.StartSpan(""))
+	assert.Nil(t, instana.C.LegacySensor())
+}
+
+func Test_Collector_LegacySensor(t *testing.T) {
+	recorder := instana.NewTestRecorder()
+	c := instana.InitCollector(&instana.Options{AgentClient: alwaysReadyClient{}, Recorder: recorder})
+	s := c.LegacySensor()
+	defer instana.ShutdownSensor()
+
+	assert.NotNil(t, instana.C.LegacySensor())
+
+	h := instana.TracingHandlerFunc(s, "/{action}", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintln(w, "Ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Len(t, recorder.GetQueuedSpans(), 1, "Instrumentations should still work fine with instana.C.LegacySensor()")
+}
+
+func Test_Collector_Singleton(t *testing.T) {
+	instana.C = nil
+	var ok bool
+	var instance instana.TracerLogger
+
+	_, ok = instana.C.(*instana.Collector)
+	assert.False(t, ok, "instana.C is noop before InitCollector is called")
+
+	instana.InitCollector(instana.DefaultOptions())
+
+	instance, ok = instana.C.(*instana.Collector)
+	assert.True(t, ok, "instana.C is of type instana.Collector after InitCollector is called")
+
+	instana.InitCollector(instana.DefaultOptions())
+
+	assert.Equal(t, instana.C, instance, "instana.C is singleton and should not be reassigned if InitCollector is called again")
+}

--- a/example_collector_test.go
+++ b/example_collector_test.go
@@ -1,0 +1,39 @@
+// (c) Copyright IBM Corp. 2023
+
+package instana_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	instana "github.com/instana/go-sensor"
+)
+
+func Example_collectorBasicUsage() {
+	// Initialize the collector
+	c := instana.InitCollector(&instana.Options{
+		// If Service is not provided, the executable filename will be used instead.
+		// We recommend that Service be set.
+		Service: "my-go-app",
+	})
+
+	// Instrument something
+	sp := c.StartSpan("my_span")
+
+	time.Sleep(time.Second * 3)
+
+	sp.Finish()
+}
+
+func Example_collectorWithHTTPServer() {
+	c := instana.InitCollector(&instana.Options{
+		Service: "my-go-app",
+	})
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Ok")
+	}
+
+	http.HandleFunc("/foo", instana.TracingHandlerFunc(c.LegacySensor(), "/foo", handler))
+}

--- a/options.go
+++ b/options.go
@@ -45,6 +45,9 @@ type Options struct {
 	// If it is nil the default implementation will be used.
 	AgentClient AgentClient
 
+	// Recorder records and manages spans. When this option is not set, instana.NewRecorder() will be used.
+	Recorder SpanRecorder
+
 	disableW3CTraceCorrelation bool
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -15,7 +15,6 @@ const (
 	MaxLogsPerSpan = 2
 )
 
-var _ ot.Tracer = (*tracerS)(nil)
 var _ Tracer = (*tracerS)(nil)
 
 type tracerS struct {


### PR DESCRIPTION
This PR introduces `Collector`, a type that is composed by the same methods of Sensor, ot.Tracer and LeveledLogger, plus a few convenient methods. Collector is an implementation of the newly introduced `TracerLogger` interface.
It also deprecates `InitSensor` in favor of `StartMetrics`.

### Why
The name "sensor" is misleading. What our tracer provides is a tracer **collector**.
Our tracer communicates to the Go Sensor, which is a plugin of the Instana Agent.

As we cannot delete public APIs, we then deprecate Sensor in favor of using the collector. This will happen in future PRs.

> The sensor instance is still accessible via Collector.LegacySensor() and can be used for instrumentations. Exemple:

```go
c := instana.InitCollector(&instana.Options{
	Service: "my-go-app",
})

handler := func(w http.ResponseWriter, r *http.Request) {
	fmt.Fprint(w, "Ok")
}

http.HandleFunc("/foo", instana.TracingHandlerFunc(c.LegacySensor(), "/foo", handler))
```
### Features

 * The Collector is a concrete implementation of a new interface `TracerLogger`.
 * `SensorLogger` is a small interface representing all non-deprecated methods from `Sensor`
 * The `TracerLogger` interface embeds `Tracer` and `LeveledLogger` and the newly introduced `SensorLogger`.
 * It works as both Tracer and Logger, so their usage is less verbose:
    * Before: sensor.Tracer().StartSpan(...)
    * After: c.StartSpan...()
    * Before: s.Logger().Error()
    * After: c.Error()
 * Usage is simpler. There is no need to provide a tracer and then provide the options. The function InitCollector expects the options as an argument
 * A new `Recorder` option is available. It's usually used for testing, so customers shouldn't worry about setting it.
 * A new method `instana.StartMetrics` should be used in favor of `instana.InitSensor` for better naming.




