### PR TITLE
Upgrading fsm package

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -76,7 +76,7 @@ func newFSM(ahd *agentCommunicator, logger LeveledLogger) *fsmS {
 	return ret
 }
 
-func (r *fsmS) scheduleRetry(e *f.Event, cb func(ctx context.Context, e *f.Event)) {
+func (r *fsmS) scheduleRetry(e *f.Event, cb func(_ context.Context, e *f.Event)) {
 	r.timer = time.NewTimer(r.lookupAgentHostRetryPeriod)
 	go func() {
 		<-r.timer.C
@@ -84,12 +84,12 @@ func (r *fsmS) scheduleRetry(e *f.Event, cb func(ctx context.Context, e *f.Event
 	}()
 }
 
-func (r *fsmS) scheduleRetryWithExponentialDelay(e *f.Event, cb func(ctx context.Context, e *f.Event), retryNumber int) {
+func (r *fsmS) scheduleRetryWithExponentialDelay(e *f.Event, cb func(_ context.Context, e *f.Event), retryNumber int) {
 	time.Sleep(r.expDelayFunc(retryNumber))
 	cb(context.Background(), e)
 }
 
-func (r *fsmS) lookupAgentHost(ctx context.Context, e *f.Event) {
+func (r *fsmS) lookupAgentHost(_ context.Context, e *f.Event) {
 	go r.checkHost(e, r.agentComm.host)
 }
 
@@ -150,7 +150,7 @@ func (r *fsmS) lookupSuccess(host string) {
 	r.fsm.Event(context.Background(), eLookup)
 }
 
-func (r *fsmS) handleRetries(e *f.Event, cb func(ctx context.Context, e *f.Event), retryFailMsg, retryMsg string) {
+func (r *fsmS) handleRetries(e *f.Event, cb func(_ context.Context, e *f.Event), retryFailMsg, retryMsg string) {
 	r.retriesLeft--
 	if r.retriesLeft == 0 {
 		r.logger.Error(retryFailMsg)
@@ -180,7 +180,7 @@ func (r *fsmS) applyHostAgentSettings(resp agentResponse) {
 	}
 }
 
-func (r *fsmS) announceSensor(ctx context.Context, e *f.Event) {
+func (r *fsmS) announceSensor(_ context.Context, e *f.Event) {
 	r.logger.Debug("announcing sensor to the agent")
 
 	go func() {
@@ -257,7 +257,7 @@ func (r *fsmS) getDiscoveryS() *discoveryS {
 	return d
 }
 
-func (r *fsmS) testAgent(ctx context.Context, e *f.Event) {
+func (r *fsmS) testAgent(_ context.Context, e *f.Event) {
 	r.logger.Debug("testing communication with the agent")
 	go func() {
 		if !r.agentComm.pingAgent() {
@@ -275,7 +275,7 @@ func (r *fsmS) reset() {
 	r.fsm.Event(context.Background(), eInit)
 }
 
-func (r *fsmS) ready(ctx context.Context, e *f.Event) {
+func (r *fsmS) ready(_ context.Context, e *f.Event) {
 	go delayed.flush()
 }
 

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -3,6 +3,7 @@
 package instana
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -51,7 +52,7 @@ func Test_fsmS_testAgent(t *testing.T) {
 			f.Events{
 				{Name: eTest, Src: []string{"announced"}, Dst: "ready"}},
 			f.Callbacks{
-				"ready": func(event *f.Event) {
+				"ready": func(ctx context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -62,7 +63,7 @@ func Test_fsmS_testAgent(t *testing.T) {
 		logger: defaultLogger,
 	}
 
-	r.testAgent(&f.Event{})
+	r.testAgent(context.Background(), &f.Event{})
 
 	assert.True(t, <-res)
 	// after a successful request, retriesLeft is reset to maximumRetries
@@ -91,7 +92,7 @@ func Test_fsmS_testAgent_Error(t *testing.T) {
 			f.Events{
 				{Name: eInit, Src: []string{"announced"}, Dst: "init"}},
 			f.Callbacks{
-				"init": func(event *f.Event) {
+				"init": func(ctx context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -102,7 +103,7 @@ func Test_fsmS_testAgent_Error(t *testing.T) {
 		logger: defaultLogger,
 	}
 
-	r.testAgent(&f.Event{})
+	r.testAgent(context.Background(), &f.Event{})
 
 	assert.True(t, <-res)
 	assert.Equal(t, 0, r.retriesLeft)
@@ -141,7 +142,7 @@ func Test_fsmS_announceSensor(t *testing.T) {
 			f.Events{
 				{Name: eAnnounce, Src: []string{"unannounced"}, Dst: "announced"}},
 			f.Callbacks{
-				"announced": func(event *f.Event) {
+				"announced": func(ctx context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -152,7 +153,7 @@ func Test_fsmS_announceSensor(t *testing.T) {
 		logger: defaultLogger,
 	}
 
-	r.announceSensor(&f.Event{})
+	r.announceSensor(context.Background(), &f.Event{})
 
 	assert.True(t, <-res)
 	assert.Equal(t, maximumRetries, r.retriesLeft)
@@ -178,7 +179,7 @@ func Test_fsmS_announceSensor_Error(t *testing.T) {
 			f.Events{
 				{Name: eInit, Src: []string{"unannounced"}, Dst: "init"}},
 			f.Callbacks{
-				"init": func(event *f.Event) {
+				"init": func(ctx context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -189,7 +190,7 @@ func Test_fsmS_announceSensor_Error(t *testing.T) {
 		logger: defaultLogger,
 	}
 
-	r.announceSensor(&f.Event{})
+	r.announceSensor(context.Background(), &f.Event{})
 
 	assert.True(t, <-res)
 	assert.Equal(t, 0, r.retriesLeft)
@@ -225,7 +226,7 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 			f.Events{
 				{Name: eLookup, Src: []string{"init"}, Dst: "unannounced"}},
 			f.Callbacks{
-				"enter_unannounced": func(event *f.Event) {
+				"enter_unannounced": func(ctx context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -236,7 +237,7 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 		logger: defaultLogger,
 	}
 
-	r.lookupAgentHost(&f.Event{})
+	r.lookupAgentHost(context.Background(), &f.Event{})
 
 	assert.True(t, <-res)
 	assert.Equal(t, maximumRetries, r.retriesLeft)

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -52,7 +52,7 @@ func Test_fsmS_testAgent(t *testing.T) {
 			f.Events{
 				{Name: eTest, Src: []string{"announced"}, Dst: "ready"}},
 			f.Callbacks{
-				"ready": func(ctx context.Context, event *f.Event) {
+				"ready": func(_ context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -92,7 +92,7 @@ func Test_fsmS_testAgent_Error(t *testing.T) {
 			f.Events{
 				{Name: eInit, Src: []string{"announced"}, Dst: "init"}},
 			f.Callbacks{
-				"init": func(ctx context.Context, event *f.Event) {
+				"init": func(_ context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -142,7 +142,7 @@ func Test_fsmS_announceSensor(t *testing.T) {
 			f.Events{
 				{Name: eAnnounce, Src: []string{"unannounced"}, Dst: "announced"}},
 			f.Callbacks{
-				"announced": func(ctx context.Context, event *f.Event) {
+				"announced": func(_ context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -179,7 +179,7 @@ func Test_fsmS_announceSensor_Error(t *testing.T) {
 			f.Events{
 				{Name: eInit, Src: []string{"unannounced"}, Dst: "init"}},
 			f.Callbacks{
-				"init": func(ctx context.Context, event *f.Event) {
+				"init": func(_ context.Context, event *f.Event) {
 					res <- true
 				},
 			}),
@@ -226,7 +226,7 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 			f.Events{
 				{Name: eLookup, Src: []string{"init"}, Dst: "unannounced"}},
 			f.Callbacks{
-				"enter_unannounced": func(ctx context.Context, event *f.Event) {
+				"enter_unannounced": func(_ context.Context, event *f.Event) {
 					res <- true
 				},
 			}),

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/instana/go-sensor
 go 1.13
 
 require (
-	github.com/looplab/fsm v0.1.0
+	github.com/looplab/fsm v1.0.1
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/looplab/fsm v0.1.0 h1:Qte7Zdn/5hBNbXzP7yxVU4OIFHWXBovyTT2LaBTyC20=
-github.com/looplab/fsm v0.1.0/go.mod h1:m2VaOfDHxqXBBMgc26m6yUOwkFn8H2AlJDE+jd/uafI=
+github.com/looplab/fsm v1.0.1 h1:OEW0ORrIx095N/6lgoGkFkotqH6s7vaFPsgjLAaF5QU=
+github.com/looplab/fsm v1.0.1/go.mod h1:PmD3fFvQEIsjMEfvZdrCDZ6y8VwKTwWNjlpEr6IKPO4=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This PR upgrades the dependent `fsm` package to the latest major version and removes the module path conflict issue if the our clients want to use the latest `fsm` package in their implementation of their module.