### PR TITLE
Updated instagin to cover Gin v1.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,19 +83,16 @@ workflows:
       - build:
           name: "go1.20"
           image: "cimg/go:1.20"
-          exclude_dirs: "./example/gin"
       - build:
           name: "go1.19"
           image: "cimg/go:1.19"
-          exclude_dirs: "./example/gin"
       - build:
           name: "go1.18"
           image: "cimg/go:1.18"
-          exclude_dirs: "./example/gin"
       - build:
           name: "go1.17"
           image: "circleci/golang:1.17"
-          exclude_dirs: "./internal/bin/sql ./example/gin"
+          exclude_dirs: "./internal/bin/sql"
       - build:
           name: "go1.16"
           image: "circleci/golang:1.16"

--- a/example/gin/go.mod
+++ b/example/gin/go.mod
@@ -8,4 +8,3 @@ require (
 	github.com/instana/go-sensor/instrumentation/instagin v1.5.0
 )
 
-require github.com/looplab/fsm v1.0.1 // indirect

--- a/example/gin/go.mod
+++ b/example/gin/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/gin-gonic/gin v1.9.0
-	github.com/instana/go-sensor v1.49.0
+	github.com/instana/go-sensor v1.53.0
 	github.com/instana/go-sensor/instrumentation/instagin v1.5.0
 )
 

--- a/instrumentation/instagin/README.md
+++ b/instrumentation/instagin/README.md
@@ -5,6 +5,11 @@ This module contains middleware to instrument HTTP services written with [github
 
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)][godoc]
 
+Compatibility
+-------------
+
+ * Starting at version 1.6.0 of instagin, gin v1.9.0 is used, which requires Go v1.18 or higher
+
 
 Installation
 ------------

--- a/instrumentation/instagin/README.md
+++ b/instrumentation/instagin/README.md
@@ -8,7 +8,7 @@ This module contains middleware to instrument HTTP services written with [github
 Compatibility
 -------------
 
- * Starting at version 1.6.0 of instagin, gin v1.9.0 is used, which requires Go v1.18 or higher
+ * Starting at version 1.6.0 of instagin, [gin v1.9.0](https://github.com/gin-gonic/gin/releases/tag/v1.9.0) is used, which requires Go v1.18 or higher
 
 
 Installation


### PR DESCRIPTION
This PR updates the version of Gin to v1.9.0 as a vulnerability compliance suggested by [dependabot](https://github.com/instana/go-sensor/pull/418).
Important: this PR pushes the instrumentation to use Go v1.18, as this version is required by Gin v1.9.0