### PR TITLE
Using TracerLogger instead of *Sensor in the core module

### DIFF
--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -148,7 +148,7 @@ func (*eventuallyNotReadyClient) SendSpans(spans []Span) error                  
 func (*eventuallyNotReadyClient) SendProfiles(profiles []autoprofile.Profile) error { return nil }
 func (*eventuallyNotReadyClient) Flush(context.Context) error                       { return nil }
 
-func generateSomeTraffic(s *Sensor, amount int) {
+func generateSomeTraffic(s TracerLogger, amount int) {
 	h := TracingNamedHandlerFunc(s, "action", "/{action}", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "Ok")
 	})

--- a/example/http-database-greeter/main.go
+++ b/example/http-database-greeter/main.go
@@ -28,6 +28,12 @@ var (
 	}
 )
 
+// How to run the test:
+// 1. Make sure the agent is running, so you can see traces in the dashboard
+// 2. Start Postgres from the root folder running docker-compose up postgres
+// 3. Run the app with go run . -l 0.0.0.0:9090 -db="postgres://postgres:mysecretpassword@localhost:5432/postgres?sslmode=disable"
+// 4. Test the app by calling http://localhost:9090/John
+
 func main() {
 	flag.StringVar(&args.DBConnStr, "db", os.Getenv("POSTGRES"), "PostgreSQL connection string")
 	flag.StringVar(&args.ListenAddr, "l", os.Getenv("LISTEN_ADDR"), "Server listen address")

--- a/instrumentation_http.go
+++ b/instrumentation_http.go
@@ -24,13 +24,13 @@ import (
 //
 // The wrapped handler will also propagate the W3C trace context (https://www.w3.org/TR/trace-context/)
 // if found in request.
-func TracingHandlerFunc(sensor *Sensor, pathTemplate string, handler http.HandlerFunc) http.HandlerFunc {
+func TracingHandlerFunc(sensor TracerLogger, pathTemplate string, handler http.HandlerFunc) http.HandlerFunc {
 	return TracingNamedHandlerFunc(sensor, "", pathTemplate, handler)
 }
 
 // TracingNamedHandlerFunc is an HTTP middleware that similarly to instana.TracingHandlerFunc() captures the tracing data,
 // while allowing to provide a unique route indetifier to be associated with each request.
-func TracingNamedHandlerFunc(sensor *Sensor, routeID, pathTemplate string, handler http.HandlerFunc) http.HandlerFunc {
+func TracingNamedHandlerFunc(sensor TracerLogger, routeID, pathTemplate string, handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
@@ -158,7 +158,7 @@ func collectRequestHeaders(req *http.Request, collectableHTTPHeaders []string, c
 	}
 }
 
-func extractStartSpanOptionsFromHeaders(tracer ot.Tracer, req *http.Request, sensor *Sensor) []ot.StartSpanOption {
+func extractStartSpanOptionsFromHeaders(tracer ot.Tracer, req *http.Request, sensor TracerLogger) []ot.StartSpanOption {
 	var opts []ot.StartSpanOption
 	wireContext, err := tracer.Extract(ot.HTTPHeaders, ot.HTTPHeadersCarrier(req.Header))
 	switch err {
@@ -176,7 +176,7 @@ func extractStartSpanOptionsFromHeaders(tracer ot.Tracer, req *http.Request, sen
 
 // RoundTripper wraps an existing http.RoundTripper and injects the tracing headers into the outgoing request.
 // If the original RoundTripper is nil, the http.DefaultTransport will be used.
-func RoundTripper(sensor *Sensor, original http.RoundTripper) http.RoundTripper {
+func RoundTripper(sensor TracerLogger, original http.RoundTripper) http.RoundTripper {
 	return tracingRoundTripper(func(req *http.Request) (*http.Response, error) {
 		if original == nil {
 			original = http.DefaultTransport

--- a/instrumentation_sql_conn.go
+++ b/instrumentation_sql_conn.go
@@ -10,7 +10,7 @@ type wConn struct {
 	driver.Conn
 
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (conn *wConn) Prepare(query string) (driver.Stmt, error) {

--- a/instrumentation_sql_go1.10.go
+++ b/instrumentation_sql_go1.10.go
@@ -12,11 +12,11 @@ type wrappedSQLConnector struct {
 	driver.Connector
 
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 // WrapSQLConnector wraps an existing sql.Connector and instruments the DB calls made using it
-func WrapSQLConnector(sensor *Sensor, name string, connector driver.Connector) *wrappedSQLConnector {
+func WrapSQLConnector(sensor TracerLogger, name string, connector driver.Connector) *wrappedSQLConnector {
 	if c, ok := connector.(*wrappedSQLConnector); ok {
 		return c
 	}

--- a/instrumentation_sql_stmt.go
+++ b/instrumentation_sql_stmt.go
@@ -14,7 +14,7 @@ type wStmt struct {
 
 	connDetails DbConnDetails
 	query       string
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (stmt *wStmt) Exec(args []driver.Value) (driver.Result, error) {

--- a/internal/bin/sql/sql_wrappers.tpl
+++ b/internal/bin/sql/sql_wrappers.tpl
@@ -35,7 +35,7 @@ func connAlreadyWrapped(conn driver.Conn) bool {
 }
 
 // wrapConn wraps the matching type around the driver.Conn based on which interfaces the driver implements
-func wrapConn(connDetails dbConnDetails, conn driver.Conn, sensor *Sensor) driver.Conn {
+func wrapConn(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger) driver.Conn {
 	{{range connInterfaces -}}
 	{{replace . "driver." ""}}, is{{replace . "driver." ""}} := conn.({{.}})
 	{{end -}}
@@ -57,7 +57,7 @@ func wrapConn(connDetails dbConnDetails, conn driver.Conn, sensor *Sensor) drive
 // driver.Conn Constructors
 {{range .Drivers}}
 {{if .IsConn}}
-func get_{{.TypeName}}(connDetails dbConnDetails, conn driver.Conn, sensor *Sensor{{range connInterfaces}}, {{replace . "driver." ""}} {{.}}{{end}}) driver.Conn {
+func get_{{.TypeName}}(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger{{range connInterfaces}}, {{replace . "driver." ""}} {{.}}{{end}}) driver.Conn {
 	return &w_{{.TypeName}} {
 		Conn: &wConn{
 			Conn:	conn,
@@ -84,7 +84,7 @@ func get_{{.TypeName}}(connDetails dbConnDetails, conn driver.Conn, sensor *Sens
 // driver.Stmt Constructors
 {{range .Drivers}}
 {{if eq .IsConn false}}
-func get_{{.TypeName}}(stmt driver.Stmt, query string, connDetails dbConnDetails, sensor *Sensor{{range stmtInterfaces}}, {{replace . "driver." ""}} {{.}}{{end}}) driver.Stmt {
+func get_{{.TypeName}}(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger{{range stmtInterfaces}}, {{replace . "driver." ""}} {{.}}{{end}}) driver.Stmt {
 	return &w_{{.TypeName}} {
 		Stmt: &wStmt{
 			Stmt:	stmt,
@@ -123,7 +123,7 @@ func stmtAlreadyWrapped(stmt driver.Stmt) bool {
 }
 
 // wrapStmt wraps the matching type around the driver.Stmt based on which interfaces the driver implements
-func wrapStmt(stmt driver.Stmt, query string, connDetails dbConnDetails, sensor *Sensor) driver.Stmt {
+func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger) driver.Stmt {
 	{{range stmtInterfaces -}}
 	{{replace . "driver." ""}}, is{{replace . "driver." ""}} := stmt.({{.}})
 	{{end -}}
@@ -148,7 +148,7 @@ func wrapStmt(stmt driver.Stmt, query string, connDetails dbConnDetails, sensor 
 // In the example above, the following constructor is returned: get_conn_Queryer_NamedValueChecker
 //
 // Each bit sequentially represents the interfaces: Execer, ExecerContext, Queryer, QueryerContext, ConnPrepareContext, NamedValueChecker
-var _conn_n = map[int]func(dbConnDetails, driver.Conn, *Sensor, {{join connInterfaces ", "}}) driver.Conn {
+var _conn_n = map[int]func(DbConnDetails, driver.Conn, TracerLogger, {{join connInterfaces ", "}}) driver.Conn {
 	{{range $k, $v := connMap -}}
 	{{$k}}: {{$v}},
 	{{end}}
@@ -159,7 +159,7 @@ var _conn_n = map[int]func(dbConnDetails, driver.Conn, *Sensor, {{join connInter
 // In the example above, the following constructor is returned: get_stmt_StmtExecContext_ColumnConverter
 //
 // Each bit sequentially represents the interfaces: StmtExecContext, StmtQueryContext, NamedValueChecker, ColumnConverter
-var _stmt_n = map[int]func(driver.Stmt, string, dbConnDetails, *Sensor, {{join stmtInterfaces ", "}}) driver.Stmt {
+var _stmt_n = map[int]func(driver.Stmt, string, DbConnDetails, TracerLogger, {{join stmtInterfaces ", "}}) driver.Stmt {
 	{{range $k, $v := stmtMap -}}
 	{{$k}}: {{$v}},
 	{{end}}

--- a/sql_conn_prepare_context.go
+++ b/sql_conn_prepare_context.go
@@ -10,7 +10,7 @@ import (
 type wConnPrepareContext struct {
 	driver.ConnPrepareContext
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (conn *wConnPrepareContext) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {

--- a/sql_execer.go
+++ b/sql_execer.go
@@ -12,7 +12,7 @@ import (
 type wExecer struct {
 	driver.Execer
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (conn *wExecer) Exec(query string, args []driver.Value) (driver.Result, error) {

--- a/sql_execer_context.go
+++ b/sql_execer_context.go
@@ -13,7 +13,7 @@ type wExecerContext struct {
 	driver.ExecerContext
 
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (conn *wExecerContext) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {

--- a/sql_queryer.go
+++ b/sql_queryer.go
@@ -12,7 +12,7 @@ import (
 type wQueryer struct {
 	driver.Queryer
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (conn *wQueryer) Query(query string, args []driver.Value) (driver.Rows, error) {

--- a/sql_queryer_context.go
+++ b/sql_queryer_context.go
@@ -12,7 +12,7 @@ import (
 type wQueryerContext struct {
 	driver.QueryerContext
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 }
 
 func (conn *wQueryerContext) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {

--- a/sql_stmt_execer_context.go
+++ b/sql_stmt_execer_context.go
@@ -11,7 +11,7 @@ import (
 type wStmtExecContext struct {
 	driver.StmtExecContext
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 	query       string
 }
 

--- a/sql_stmt_queryer_context.go
+++ b/sql_stmt_queryer_context.go
@@ -11,7 +11,7 @@ import (
 type wStmtQueryContext struct {
 	driver.StmtQueryContext
 	connDetails DbConnDetails
-	sensor      *Sensor
+	sensor      TracerLogger
 	query       string
 }
 

--- a/sql_wrappers.go
+++ b/sql_wrappers.go
@@ -665,7 +665,7 @@ func connAlreadyWrapped(conn driver.Conn) bool {
 }
 
 // wrapConn wraps the matching type around the driver.Conn based on which interfaces the driver implements
-func wrapConn(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor) driver.Conn {
+func wrapConn(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger) driver.Conn {
 	Execer, isExecer := conn.(driver.Execer)
 	ExecerContext, isExecerContext := conn.(driver.ExecerContext)
 	Queryer, isQueryer := conn.(driver.Queryer)
@@ -686,7 +686,7 @@ func wrapConn(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor) drive
 
 // driver.Conn Constructors
 
-func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -720,7 +720,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_Nam
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -754,7 +754,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(con
 		}}
 }
 
-func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -783,7 +783,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValue
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -812,7 +812,7 @@ func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -841,7 +841,7 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueC
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -870,7 +870,7 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -899,7 +899,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker(conn
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -923,7 +923,7 @@ func get_conn_Execer_Queryer_QueryerContext_NamedValueChecker(connDetails DbConn
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -952,7 +952,7 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConn
 		}}
 }
 
-func get_conn_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -976,7 +976,7 @@ func get_conn_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDe
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1000,7 +1000,7 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1024,7 +1024,7 @@ func get_conn_Execer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDet
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1048,7 +1048,7 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDet
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1072,7 +1072,7 @@ func get_conn_Execer_Queryer_ConnPrepareContext_NamedValueChecker(connDetails Db
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1101,7 +1101,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext(connDetails DbConnDeta
 		}}
 }
 
-func get_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1125,7 +1125,7 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker(connDeta
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1149,7 +1149,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1173,7 +1173,7 @@ func get_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker(connDetails 
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1197,7 +1197,7 @@ func get_conn_Execer_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnD
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1226,7 +1226,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetail
 		}}
 }
 
-func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1255,7 +1255,7 @@ func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext(connDetails DbCon
 		}}
 }
 
-func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1284,7 +1284,7 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext(connDetails
 		}}
 }
 
-func get_conn_Execer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1303,7 +1303,7 @@ func get_conn_Execer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDeta
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1327,7 +1327,7 @@ func get_conn_Execer_Queryer_QueryerContext(connDetails DbConnDetails, conn driv
 		}}
 }
 
-func get_conn_Execer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1351,7 +1351,7 @@ func get_conn_Execer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails
 		}}
 }
 
-func get_conn_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1375,7 +1375,7 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConn
 		}}
 }
 
-func get_conn_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1399,7 +1399,7 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails
 		}}
 }
 
-func get_conn_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1423,7 +1423,7 @@ func get_conn_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetail
 		}}
 }
 
-func get_conn_Execer_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1447,7 +1447,7 @@ func get_conn_Execer_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn 
 		}}
 }
 
-func get_conn_Execer_ExecerContext_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1471,7 +1471,7 @@ func get_conn_Execer_ExecerContext_QueryerContext(connDetails DbConnDetails, con
 		}}
 }
 
-func get_conn_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_QueryerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1490,7 +1490,7 @@ func get_conn_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails Db
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1514,7 +1514,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, co
 		}}
 }
 
-func get_conn_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1533,7 +1533,7 @@ func get_conn_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDet
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1552,7 +1552,7 @@ func get_conn_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbC
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1571,7 +1571,7 @@ func get_conn_Execer_ExecerContext_NamedValueChecker(connDetails DbConnDetails, 
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_Queryer{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1595,7 +1595,7 @@ func get_conn_Execer_ExecerContext_Queryer(connDetails DbConnDetails, conn drive
 		}}
 }
 
-func get_conn_Execer_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1614,7 +1614,7 @@ func get_conn_Execer_Queryer_NamedValueChecker(connDetails DbConnDetails, conn d
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1633,7 +1633,7 @@ func get_conn_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1657,7 +1657,7 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext(connDetails DbConnDetails,
 		}}
 }
 
-func get_conn_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1676,7 +1676,7 @@ func get_conn_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1695,7 +1695,7 @@ func get_conn_Execer_QueryerContext_NamedValueChecker(connDetails DbConnDetails,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1714,7 +1714,7 @@ func get_conn_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnD
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1733,7 +1733,7 @@ func get_conn_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.
 		}}
 }
 
-func get_conn_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1747,7 +1747,7 @@ func get_conn_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.C
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ExecerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1766,7 +1766,7 @@ func get_conn_Execer_ExecerContext(connDetails DbConnDetails, conn driver.Conn, 
 		}}
 }
 
-func get_conn_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_Queryer{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1785,7 +1785,7 @@ func get_conn_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn,
 		}}
 }
 
-func get_conn_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_QueryerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1804,7 +1804,7 @@ func get_conn_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn 
 		}}
 }
 
-func get_conn_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ConnPrepareContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1818,7 +1818,7 @@ func get_conn_ConnPrepareContext_NamedValueChecker(connDetails DbConnDetails, co
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1837,7 +1837,7 @@ func get_conn_Execer_QueryerContext(connDetails DbConnDetails, conn driver.Conn,
 		}}
 }
 
-func get_conn_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1851,7 +1851,7 @@ func get_conn_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn dr
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1870,7 +1870,7 @@ func get_conn_ExecerContext_QueryerContext(connDetails DbConnDetails, conn drive
 		}}
 }
 
-func get_conn_Execer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1884,7 +1884,7 @@ func get_conn_Execer_NamedValueChecker(connDetails DbConnDetails, conn driver.Co
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_Queryer{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1903,7 +1903,7 @@ func get_conn_Execer_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor
 		}}
 }
 
-func get_conn_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_QueryerContext_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1917,7 +1917,7 @@ func get_conn_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn d
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_Execer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1936,7 +1936,7 @@ func get_conn_Execer_ConnPrepareContext(connDetails DbConnDetails, conn driver.C
 		}}
 }
 
-func get_conn_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1955,7 +1955,7 @@ func get_conn_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn d
 		}}
 }
 
-func get_conn_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1974,7 +1974,7 @@ func get_conn_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn
 		}}
 }
 
-func get_conn_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_QueryerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -1988,7 +1988,7 @@ func get_conn_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor
 		}}
 }
 
-func get_conn_Execer(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Execer(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Execer{
 		Conn: &wConn{
 			Conn:        conn,
@@ -2002,7 +2002,7 @@ func get_conn_Execer(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor
 		}}
 }
 
-func get_conn_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ConnPrepareContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -2016,7 +2016,7 @@ func get_conn_ConnPrepareContext(connDetails DbConnDetails, conn driver.Conn, se
 		}}
 }
 
-func get_conn_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_Queryer{
 		Conn: &wConn{
 			Conn:        conn,
@@ -2030,7 +2030,7 @@ func get_conn_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor *Senso
 		}}
 }
 
-func get_conn_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_NamedValueChecker{
 		Conn: &wConn{
 			Conn:        conn,
@@ -2039,7 +2039,7 @@ func get_conn_NamedValueChecker(connDetails DbConnDetails, conn driver.Conn, sen
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor *Sensor, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
+func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor TracerLogger, Execer driver.Execer, ExecerContext driver.ExecerContext, Queryer driver.Queryer, QueryerContext driver.QueryerContext, ConnPrepareContext driver.ConnPrepareContext, NamedValueChecker driver.NamedValueChecker) driver.Conn {
 	return &w_conn_ExecerContext{
 		Conn: &wConn{
 			Conn:        conn,
@@ -2055,7 +2055,7 @@ func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor 
 
 // driver.Stmt Constructors
 
-func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2076,7 +2076,7 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2096,7 +2096,7 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker(stmt driver.Stm
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2112,7 +2112,7 @@ func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stm
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2128,7 +2128,7 @@ func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2149,7 +2149,7 @@ func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt,
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2165,7 +2165,7 @@ func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, c
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2180,7 +2180,7 @@ func get_stmt_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2196,7 +2196,7 @@ func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, co
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtExecContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2211,7 +2211,7 @@ func get_stmt_StmtExecContext_NamedValueChecker(stmt driver.Stmt, query string, 
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2222,7 +2222,7 @@ func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, 
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtExecContext_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2242,7 +2242,7 @@ func get_stmt_StmtExecContext_StmtQueryContext(stmt driver.Stmt, query string, c
 		}}
 }
 
-func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2253,7 +2253,7 @@ func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConn
 		cc: ColumnConverter}
 }
 
-func get_stmt_StmtExecContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtExecContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2268,7 +2268,7 @@ func get_stmt_StmtExecContext(stmt driver.Stmt, query string, connDetails DbConn
 		}}
 }
 
-func get_stmt_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2278,7 +2278,7 @@ func get_stmt_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbCo
 		}, NamedValueChecker: NamedValueChecker}
 }
 
-func get_stmt_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
+func get_stmt_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
@@ -2305,7 +2305,7 @@ func stmtAlreadyWrapped(stmt driver.Stmt) bool {
 }
 
 // wrapStmt wraps the matching type around the driver.Stmt based on which interfaces the driver implements
-func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor *Sensor) driver.Stmt {
+func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger) driver.Stmt {
 	StmtExecContext, isStmtExecContext := stmt.(driver.StmtExecContext)
 	StmtQueryContext, isStmtQueryContext := stmt.(driver.StmtQueryContext)
 	NamedValueChecker, isNamedValueChecker := stmt.(driver.NamedValueChecker)
@@ -2328,7 +2328,7 @@ func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor 
 // In the example above, the following constructor is returned: get_conn_Queryer_NamedValueChecker
 //
 // Each bit sequentially represents the interfaces: Execer, ExecerContext, Queryer, QueryerContext, ConnPrepareContext, NamedValueChecker
-var _conn_n = map[int]func(DbConnDetails, driver.Conn, *Sensor, driver.Execer, driver.ExecerContext, driver.Queryer, driver.QueryerContext, driver.ConnPrepareContext, driver.NamedValueChecker) driver.Conn{
+var _conn_n = map[int]func(DbConnDetails, driver.Conn, TracerLogger, driver.Execer, driver.ExecerContext, driver.Queryer, driver.QueryerContext, driver.ConnPrepareContext, driver.NamedValueChecker) driver.Conn{
 	0b1:      get_conn_NamedValueChecker,
 	0b10:     get_conn_ConnPrepareContext,
 	0b100:    get_conn_QueryerContext,
@@ -2399,7 +2399,7 @@ var _conn_n = map[int]func(DbConnDetails, driver.Conn, *Sensor, driver.Execer, d
 // In the example above, the following constructor is returned: get_stmt_StmtExecContext_ColumnConverter
 //
 // Each bit sequentially represents the interfaces: StmtExecContext, StmtQueryContext, NamedValueChecker, ColumnConverter
-var _stmt_n = map[int]func(driver.Stmt, string, DbConnDetails, *Sensor, driver.StmtExecContext, driver.StmtQueryContext, driver.NamedValueChecker, driver.ColumnConverter) driver.Stmt{
+var _stmt_n = map[int]func(driver.Stmt, string, DbConnDetails, TracerLogger, driver.StmtExecContext, driver.StmtQueryContext, driver.NamedValueChecker, driver.ColumnConverter) driver.Stmt{
 	0b1:    get_stmt_ColumnConverter,
 	0b10:   get_stmt_NamedValueChecker,
 	0b100:  get_stmt_StmtQueryContext,


### PR DESCRIPTION
This PR updates the core module to replace references to instana.Sensor by the instana.TracerLogger interface.
The following code was affected:

* For HTTP instrumentation
* For SQL instrumentation
* SQL generator template updated