### PR TITLE
Removed header check for the agent host

### DIFF
--- a/agent_communicator.go
+++ b/agent_communicator.go
@@ -73,30 +73,31 @@ func (a *agentCommunicator) serverHeader() string {
 	return ""
 }
 
+// TODO: If the URL can be agentDataURL, there is already a pingAgent() API which can be made use of
 // checkForSuccessResponse checks for a success HEAD operation with the agent
 func (a *agentCommunicator) checkForSuccessResponse() bool {
 	url := a.buildURL("/")
-	req, err := http.NewRequest(http.MethodHead, url, nil)
 
+	req, err := http.NewRequest(http.MethodHead, url, nil)
 	if err != nil {
 		a.l.Debug("Error creating request while attempting to retrieve the 'Server' response: ", err.Error())
 		return false
 	}
 
 	resp, err := a.client.Do(req)
-
-	if resp == nil {
+	if err != nil || resp == nil {
 		a.l.Debug("No response from the agent while attempting to retrieve the 'Server' response: ", err.Error())
 		return false
 	}
 
-	if err == nil && (resp.StatusCode >= 200 && resp.StatusCode <= 299) {
-		return true
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		a.l.Debug("Unexpected response from the agent host server. Status code: ", resp.StatusCode)
+		return false
 	}
 
-	a.l.Debug("Error requesting header from the agent while attempting to retrieve the 'Server' response: ", err.Error())
+	a.l.Debug("Expected response from Agent! Status code: ", resp.StatusCode)
 
-	return false
+	return true
 }
 
 // agentResponse attempts to retrieve the agent response containing its configuration

--- a/agent_communicator.go
+++ b/agent_communicator.go
@@ -73,6 +73,32 @@ func (a *agentCommunicator) serverHeader() string {
 	return ""
 }
 
+// checkForSuccessResponse checks for a success HEAD operation with the agent
+func (a *agentCommunicator) checkForSuccessResponse() bool {
+	url := a.buildURL("/")
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+
+	if err != nil {
+		a.l.Debug("Error creating request while attempting to retrieve the 'Server' response: ", err.Error())
+		return false
+	}
+
+	resp, err := a.client.Do(req)
+
+	if resp == nil {
+		a.l.Debug("No response from the agent while attempting to retrieve the 'Server' response: ", err.Error())
+		return false
+	}
+
+	if err == nil && (resp.StatusCode >= 200 && resp.StatusCode <= 299) {
+		return true
+	}
+
+	a.l.Debug("Error requesting header from the agent while attempting to retrieve the 'Server' response: ", err.Error())
+
+	return false
+}
+
 // agentResponse attempts to retrieve the agent response containing its configuration
 func (a *agentCommunicator) agentResponse(d *discoveryS) *agentResponse {
 	jsonData, _ := json.Marshal(d)

--- a/fsm.go
+++ b/fsm.go
@@ -93,7 +93,7 @@ func (r *fsmS) lookupAgentHost(_ context.Context, e *f.Event) {
 	go r.checkHost(e)
 }
 
-// checkHost will try to verify whether agent host is found or not. The procedure for this is explained below,
+// checkHost verifies and set the agent host address
 func (r *fsmS) checkHost(e *f.Event) {
 
 	// Look for a successful ping from the configured host


### PR DESCRIPTION
This PR introduces the changes for removing the HTTP header check for identifying the agent host.