### PR TITLE
Added agent successful reconnection test case

### DIFF
--- a/agent_communicator.go
+++ b/agent_communicator.go
@@ -42,37 +42,6 @@ func (a *agentCommunicator) buildURL(sufix string) string {
 	return url
 }
 
-// serverHeader attempts to retrieve the "Server" header key from the Agent
-func (a *agentCommunicator) serverHeader() string {
-	url := a.buildURL("/")
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-
-	if err != nil {
-		a.l.Debug("Error creating request while attempting to retrieve the 'Server' header: ", err.Error())
-		return ""
-	}
-
-	resp, err := a.client.Do(req)
-
-	if resp == nil {
-		a.l.Debug("No response from the agent while attempting to retrieve the 'Server' header: ", err.Error())
-		return ""
-	}
-
-	defer func() {
-		io.CopyN(ioutil.Discard, resp.Body, 256<<10)
-		resp.Body.Close()
-	}()
-
-	if err == nil {
-		return resp.Header.Get("Server")
-	}
-
-	a.l.Debug("Error requesting header from the agent while attempting to retrieve the 'Server' header: ", err.Error())
-
-	return ""
-}
-
 // checkForSuccessResponse checks for a successful GET operation with the agent host
 func (a *agentCommunicator) checkForSuccessResponse() bool {
 	url := a.buildURL("/")
@@ -178,7 +147,7 @@ func (a *agentCommunicator) pingAgent() bool {
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		a.l.Debug("Agent ping failed, response: ", resp.StatusCode, " with message ", resp.Status)
+		a.l.Debug("Agent ping failed, response: ", resp.StatusCode, " with message ", resp.Status, "; URL: ", u)
 		return false
 	}
 

--- a/fsm.go
+++ b/fsm.go
@@ -305,6 +305,7 @@ func (r *fsmS) testAgent(_ context.Context, e *f.Event) {
 }
 
 func (r *fsmS) reset() {
+	r.logger.Debug("State machine reset. Will restart agent connection cycle from the 'init' state")
 	r.retriesLeft = maximumRetries
 	r.fsm.Event(context.Background(), eInit)
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -252,8 +252,6 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 // 4. A valid Agent hostname is available in the INSTANA_AGENT_HOST env var.
 // 5. A connection with the Agent is reestablished via env var.
 func Test_fsmS_agentConnectionReestablished(t *testing.T) {
-	shouldPing := true
-
 	agentResponseJSON := `{
 		"pid": 37808,
 		"agentUuid": "88:66:5a:ff:fe:05:a5:f0",
@@ -280,11 +278,7 @@ func Test_fsmS_agentConnectionReestablished(t *testing.T) {
 			return
 		}
 
-		if shouldPing {
-			w.WriteHeader(http.StatusOK)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
-		}
+		w.WriteHeader(http.StatusOK)
 	})
 	defer server.Close()
 
@@ -343,14 +337,6 @@ func Test_fsmS_agentConnectionReestablished(t *testing.T) {
 	r.fsm.Event(context.Background(), eInit)
 
 	assert.True(t, <-res)
-
-	// make agent server unresponsive for 500 ms to force triggering retries
-	shouldPing = false
-	go func() {
-		time.AfterFunc(time.Millisecond*500, func() {
-			shouldPing = true
-		})
-	}()
 
 	// Simulate Agent connection lost
 	r.agentComm.host = "invalid_host"

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -23,6 +23,7 @@ func getTestServer(fn func(w http.ResponseWriter, r *http.Request)) *httptest.Se
 	return httptest.NewServer(handler)
 }
 
+// Case: Current state is ANNOUNCED, trying to be READY
 func Test_fsmS_testAgent(t *testing.T) {
 	// Forces the mocked agent to fail with HTTP 400 in the first call to lead fsm to retry once
 	var serverGaveErrorOnFirstCall bool
@@ -46,11 +47,12 @@ func Test_fsmS_testAgent(t *testing.T) {
 	res := make(chan bool, 1)
 
 	r := &fsmS{
-		agentComm: newAgentCommunicator(u.Hostname(), u.Port(), &fromS{}, defaultLogger),
+		agentComm: newAgentCommunicator(u.Hostname(), u.Port(), &fromS{EntityID: "12345"}, defaultLogger),
 		fsm: f.NewFSM(
 			"announced",
 			f.Events{
-				{Name: eTest, Src: []string{"announced"}, Dst: "ready"}},
+				{Name: eTest, Src: []string{"announced"}, Dst: "ready"},
+			},
 			f.Callbacks{
 				"ready": func(_ context.Context, event *f.Event) {
 					res <- true
@@ -241,4 +243,112 @@ func Test_fsmS_lookupAgentHost(t *testing.T) {
 
 	assert.True(t, <-res)
 	assert.Equal(t, maximumRetries, r.retriesLeft)
+}
+
+// Case:
+// 1. Connection between the application and the agent is established.
+// 2. Connection with Agent is lost.
+// 3. Former Agent host is no longer available.
+// 4. A valid Agent hostname is available in the INSTANA_AGENT_HOST env var.
+// 5. A connection with the Agent is reestablished via env var.
+func Test_fsmS_agentConnectionReestablished(t *testing.T) {
+	agentResponseJSON := `{
+		"pid": 37808,
+		"agentUuid": "88:66:5a:ff:fe:05:a5:f0",
+		"extraHeaders": ["expected-value"],
+		"secrets": {
+			"matcher": "contains-ignore-case",
+			"list": ["key","pass","secret"]
+		}
+	}`
+
+	sensor = &sensorS{
+		options: DefaultOptions(),
+	}
+	defer func() {
+		sensor = nil
+	}()
+
+	var shouldPingBack bool = true
+
+	server := getTestServer(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		// /com.instana.plugin.golang.37808: enter_announced
+		// fmt.Println("agent server received request url: ", p)
+
+		// announce phase (enter_unannounced)
+		if p == "/com.instana.plugin.golang.discovery" {
+			io.WriteString(w, agentResponseJSON)
+			return
+		}
+
+		if shouldPingBack {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+	defer server.Close()
+
+	surl := server.URL
+	u, err := url.Parse(surl)
+
+	os.Setenv("INSTANA_AGENT_HOST", u.Hostname())
+	defer func() {
+		os.Unsetenv("INSTANA_AGENT_HOST")
+	}()
+
+	assert.NoError(t, err)
+
+	res := make(chan bool)
+
+	go func() {
+		time.AfterFunc(time.Second*5, func() {
+			// fmt.Println("TIMEOUT")
+			res <- false
+		})
+	}()
+
+	r := &fsmS{
+		agentComm:                  newAgentCommunicator(u.Hostname(), u.Port(), &fromS{EntityID: "12345"}, defaultLogger),
+		lookupAgentHostRetryPeriod: 0,
+		retriesLeft:                maximumRetries,
+		expDelayFunc: func(retryNumber int) time.Duration {
+			return 0
+		},
+		logger: defaultLogger,
+	}
+
+	r.fsm = f.NewFSM(
+		"none",
+		f.Events{
+			{Name: eInit, Src: []string{"none", "unannounced", "announced", "ready"}, Dst: "init"},
+			{Name: eLookup, Src: []string{"init"}, Dst: "unannounced"},
+			{Name: eAnnounce, Src: []string{"unannounced"}, Dst: "announced"},
+			{Name: eTest, Src: []string{"announced"}, Dst: "ready"}},
+		f.Callbacks{
+			"init": func(ctx context.Context, e *f.Event) {
+				r.lookupAgentHost(ctx, e)
+			},
+			"enter_unannounced": func(ctx context.Context, e *f.Event) {
+				r.announceSensor(ctx, e)
+			},
+			"enter_announced": func(ctx context.Context, e *f.Event) {
+				r.testAgent(ctx, e)
+			},
+			"ready": func(ctx context.Context, e *f.Event) {
+				r.ready(ctx, e)
+				res <- true
+			},
+		})
+
+	r.fsm.Event(context.Background(), eInit)
+
+	assert.True(t, <-res)
+
+	// Simulate Agent connection lost
+	r.agentComm.host = "invalid_host"
+	r.reset()
+
+	assert.True(t, <-res)
 }


### PR DESCRIPTION
This PR adds a missing test to make sure that the fix provided at https://github.com/instana/go-sensor/pull/413 works as intended.

The following case is tested:
  1. Connection between the application and the agent is established.
  1. Connection with Agent is lost.
  1. Former Agent host is no longer available.
  1. A valid Agent hostname is available in the INSTANA_AGENT_HOST env var.
  1. A connection with the Agent is reestablished via env var.