### PR TITLE
Removed automatic service name set when env var is not provided

### DIFF
--- a/azure_agent_test.go
+++ b/azure_agent_test.go
@@ -106,7 +106,7 @@ func TestAzureAgent_SpanDetails(t *testing.T) {
           "functionname": "testfunction",
           "triggername": "HTTP",
           "runtime": "custom"
-        }`, string(spans[0]["data"]))
+        }}`, string(spans[0]["data"]))
 }
 
 func setupAzureFunctionEnv() func() {

--- a/azure_agent_test.go
+++ b/azure_agent_test.go
@@ -106,7 +106,7 @@ func TestAzureAgent_SpanDetails(t *testing.T) {
           "functionname": "testfunction",
           "triggername": "HTTP",
           "runtime": "custom"
-        }, "service": "instana.test"}`, string(spans[0]["data"]))
+        }`, string(spans[0]["data"]))
 }
 
 func setupAzureFunctionEnv() func() {

--- a/sensor.go
+++ b/sensor.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -83,15 +82,8 @@ func newSensor(options *Options) *sensorS {
 	s.setLogger(defaultLogger)
 
 	// override service name with an env value if set
-	if name, ok := os.LookupEnv("INSTANA_SERVICE_NAME"); ok {
+	if name, ok := os.LookupEnv("INSTANA_SERVICE_NAME"); ok && strings.TrimSpace(name) != "" {
 		s.serviceName = name
-	}
-
-	// if no service name is provided, we use the executable name
-	if "" == strings.TrimSpace(s.serviceName) {
-		sn := path.Base(os.Args[0])
-		s.logger.Debug("Using args[0] as service name: ", sn)
-		s.serviceName = sn
 	}
 
 	// handle the legacy (instana.Options).LogLevel value if we use logger.Logger to log


### PR DESCRIPTION
This PR removes a recently implemented feature that automatically set the service name based on the executable file when the environment variable INSTANA_SERVICE_NAME was not provided.
According to our specification, the service name should not be set automatically, but explicitly set by the user:

```
Tracers CAN set span.data.service to override the default service name extraction rules and set the service name extracted from that span explicitly.
This SHOULD only be done when explicitly configured or triggered by the customer.
```