### PR TITLE
Updated the Slack notification action

### DIFF
--- a/.github/workflows/slack_notification.yml
+++ b/.github/workflows/slack_notification.yml
@@ -11,36 +11,27 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Check instrumentation type
-        id: check
-        run: |
-          echo "result=$(echo ${{ github.event.release.name }} | grep -c 'instrumentation/')" >> $GITHUB_OUTPUT
-          echo "notes=$(echo ${{ github.event.release.body }} | grep -c '--auto-generated--')" >> $GITHUB_OUTPUT
-
       - name: Send success message to slack release channel
-        if: "${{ success() && env.DRY_RUN != 'true' && steps.check.outputs.result != '1' && steps.check.outputs.notes != '1' }}"
+        if: "${{ success() && env.DRY_RUN != 'true' }}"
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
           payload: |
             {
-              "text": ":mega: *Go Tracer team* : Version ${{ env.RELEASE_VERSION }} of go-sensor :package: has been released.",
+              "text": ":mega: *Go Tracer team* : Go package ${{ github.event.release.name }} has been released",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":mega: *Go Tracer team* : Version ${{ env.RELEASE_VERSION }} of go-sensor :package: has been released."
+                    "text": ":mega: *Go Tracer team* : Go package <${{ github.event.release.html_url }}|${{ github.event.release.name }}> has been released. :tada:"
                   }
-                },
-                {
-                  "type": "divider"
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*URL:* <${{ github.event.release.html_url }}|${{ github.event.release.html_url }}>"
+                    "text": "Release link: <${{ github.event.release.html_url }}|${{ github.event.release.html_url }}>"
                   }
                 }
               ]


### PR DESCRIPTION
This PR simplifies the slack notification action. Redundant checks for specific release types have been removed since it is taken care in the new build workflow scripts.