### PR TITLE
Marshal map issue

### DIFF
--- a/example/http-database-greeter/go.mod
+++ b/example/http-database-greeter/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/lib/pq v1.8.0
 	github.com/opentracing/opentracing-go v1.2.0
 )
+
+replace github.com/instana/go-sensor => ../../

--- a/json_span.go
+++ b/json_span.go
@@ -282,11 +282,11 @@ func newSDKSpanTags(span *spanS, spanType string) SDKSpanTags {
 	}
 
 	if len(span.Tags) != 0 {
-		tags.Custom["tags"] = span.Tags
+		tags.Custom["tags"] = cloneTags(span.Tags)
 	}
 
 	if len(span.context.Baggage) != 0 {
-		tags.Custom["baggage"] = span.context.Baggage
+		tags.Custom["baggage"] = cloneMapStringString(span.context.Baggage)
 	}
 
 	return tags

--- a/tracer.go
+++ b/tracer.go
@@ -116,7 +116,7 @@ func (r *tracerS) StartSpanWithOptions(operationName string, opts ot.StartSpanOp
 		Start:       startTime,
 		Duration:    -1,
 		Correlation: corrData,
-		Tags:        opts.Tags,
+		Tags:        cloneTags(opts.Tags),
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	ot "github.com/opentracing/opentracing-go"
 )
 
 var (
@@ -202,4 +204,24 @@ func hexGatewayToAddr(gateway []rune) (string, error) {
 	}
 
 	return fmt.Sprintf("%v.%v.%v.%v", octets[0], octets[1], octets[2], octets[3]), nil
+}
+
+func cloneTags(t ot.Tags) ot.Tags {
+	clone := ot.Tags{}
+
+	for k, v := range t {
+		clone[k] = v
+	}
+
+	return clone
+}
+
+func cloneMapStringString(t map[string]string) map[string]string {
+	clone := map[string]string{}
+
+	for k, v := range t {
+		clone[k] = v
+	}
+
+	return clone
 }


### PR DESCRIPTION
This PR makes sure that maps received from public methods are properly copied internally to prevent modifications that may interfere with marshalling.

Maps are implicitly pointers so the best approach is to create a new map, iterate over the original one and feed the new one.
In the vast majority of cases, this should not be a problem, but it could be an issue in some cases, for instance:

1. If a map is passed ahead but the original one changes in a go routine. 
1. If a variable is of type `interface{}` and it ends up being a map, it becomes really hard to track it, unless we use the reflect package

In our case, `ot.Tags` is a type on top of `map[string]interface{}` so you can have maps as items of `ot.Tags`. We should keep this scenario also in mind for similar issues in the future.
