### PR TITLE
Collector: SetLogger properly updates embedded LeveledLogger

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -119,6 +119,12 @@ func (c *Collector) Error(v ...interface{}) {
 	c.LeveledLogger.Error(v...)
 }
 
+// SetLogger changes the [Sensor] logger and [LeveledLogger] both to satisfy [TracerLogger]
+func (c *Collector) SetLogger(l LeveledLogger) {
+	c.Sensor.SetLogger(l)
+	c.LeveledLogger = l
+}
+
 // LegacySensor returns a reference to [Sensor] that can be used for old instrumentations that still require it.
 //
 // Example:


### PR DESCRIPTION
This PR ensures that the instance of Collector receives a proper logger when SetLogger is invoked.
Previously, only the logger inside of the Sensor was being updated.
Additionally, we increase test coverage for the Collector by testing `StartSpan`, `Inject` and `Extract` methods.