### PR TITLE
Fixing coverage for instapgx

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -26,6 +26,11 @@ jobs:
 
             LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \;)
 
+            for lib in $LIB_LIST
+              do echo "Generating test coverage for $lib" && cd "$lib" && go mod tidy && go test -v -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && cd -;
+            done
+
+            echo "Generating test coverage for ./instrumentation/instapgx"
             cd ./instrumentation/instapgx
             go mod tidy
             go test -v -tags=integration -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json
@@ -33,10 +38,6 @@ jobs:
             cat coverage.out || echo "error reading instapgx coverage.out"
             cat coverage.json || echo "error reading instapgx coverage.json"
             cd -
-
-            for lib in $LIB_LIST
-              do echo "Generting test coverage for $lib" && cd "$lib" && go mod tidy && go test -v -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && cd -;
-            done
 
       - name: Sonarqube Scan
         uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -33,11 +33,7 @@ jobs:
             echo "Generating test coverage for ./instrumentation/instapgx"
             cd ./instrumentation/instapgx
             go mod tidy
-            go test -v -tags=integration -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json
-            echo "Listing contents of pgx coverage files..."
-            cat coverage.out || echo "error reading instapgx coverage.out"
-            cat coverage.json || echo "error reading instapgx coverage.json"
-            cd -
+            go test -v -tags=integration -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && cd -
 
       - name: Sonarqube Scan
         uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -17,21 +17,25 @@ jobs:
         run: |
             #!/bin/bash
 
-            echo "starting postgres"
+            echo "Starting Postgres"
             sudo systemctl start postgresql.service
             sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'mysecretpassword'"
-            echo "after starting postgres"
+            echo "After starting Postgres"
 
-            go test -v -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && ls cover*
+            go test -v -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json
 
             LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \;)
 
             cd ./instrumentation/instapgx
             go mod tidy
-            go test -v -tags=integration -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && cd -
+            go test -v -tags=integration -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json
+            echo "Listing contents of pgx coverage files..."
+            cat coverage.out || echo "error reading instapgx coverage.out"
+            cat coverage.json || echo "error reading instapgx coverage.json"
+            cd -
 
             for lib in $LIB_LIST
-              do cd "$lib" && go mod tidy && go test -v -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && cd -;
+              do echo "Generting test coverage for $lib" && cd "$lib" && go mod tidy && go test -v -coverpkg=./... -cover -covermode atomic -coverprofile coverage.out ./... -json > coverage.json && cd -;
             done
 
       - name: Sonarqube Scan


### PR DESCRIPTION
This PR moves the test coverage generation of instapgx after the loop over all other instrumentations.
The reason for that is that the loop also attempts to generate the coverage for instapgx again, and since nothing is tested, the file was being overwritten by the empty one.