### PR TITLE
Removed instapgx from older build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,17 +110,17 @@ workflows:
       - build:
           name: "go1.16"
           image: "cimg/go:1.16"
-          exclude_dirs: "./internal/bin/sql ./example/gin ./example/sql-redis ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2"
+          exclude_dirs: "./internal/bin/sql ./example/gin ./example/sql-redis ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instapgx"
       - build:
           name: "go1.15"
           image: "cimg/go:1.15"
-          exclude_dirs: "./instrumentation/instaredigo ./internal/bin/sql ./example/gin ./example/sql-redis ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2"
+          exclude_dirs: "./instrumentation/instaredigo ./internal/bin/sql ./example/gin ./example/sql-redis ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instapgx"
       - build:
           name: "go1.14"
           image: "cimg/go:1.14"
-          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego"
+          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego ./instrumentation/instapgx"
       - build:
           name: "go1.13"
           image: "cimg/go:1.13"
-          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego"
+          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego ./instrumentation/instapgx"
 


### PR DESCRIPTION
This PR limits the CI/CD pipeline for instapgx to go runtimes 1.17 or newer.