### PR TITLE
Removed deprecated instaamqp instrumentation from CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,25 +102,25 @@ workflows:
       - build:
           name: "go1.18"
           image: "cimg/go:1.18"
-          exclude_dirs: "./example/grpc-client-server ./instrumentation/cloud.google.com/go ./instrumentation/instaawsv2"
+          exclude_dirs: "./example/grpc-client-server ./instrumentation/cloud.google.com/go ./instrumentation/instaawsv2 ./instrumentation/instaamqp"
       - build:
           name: "go1.17"
           image: "cimg/go:1.17"
-          exclude_dirs: "./internal/bin/sql ./example/gin ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./example/grpc-client-server ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instaecho ./instrumentation/instagorm"
+          exclude_dirs: "./internal/bin/sql ./example/gin ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./example/grpc-client-server ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instaecho ./instrumentation/instagorm ./instrumentation/instaamqp"
       - build:
           name: "go1.16"
           image: "cimg/go:1.16"
-          exclude_dirs: "./internal/bin/sql ./example/gin ./example/sql-redis ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instapgx ./instrumentation/instaecho ./instrumentation/instagorm"
+          exclude_dirs: "./internal/bin/sql ./example/gin ./example/sql-redis ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instapgx ./instrumentation/instaecho ./instrumentation/instagorm ./instrumentation/instaamqp"
       - build:
           name: "go1.15"
           image: "cimg/go:1.15"
-          exclude_dirs: "./instrumentation/instaredigo ./internal/bin/sql ./example/gin ./example/sql-redis ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instapgx ./instrumentation/instaecho"
+          exclude_dirs: "./instrumentation/instaredigo ./internal/bin/sql ./example/gin ./example/sql-redis ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/cloud.google.com/go ./instrumentation/instabeego ./example/beego ./instrumentation/instaawsv2 ./instrumentation/instapgx ./instrumentation/instaecho ./instrumentation/instaamqp"
       - build:
           name: "go1.14"
           image: "cimg/go:1.14"
-          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego ./instrumentation/instapgx"
+          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego ./instrumentation/instapgx ./instrumentation/instaamqp"
       - build:
           name: "go1.13"
           image: "cimg/go:1.13"
-          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego ./instrumentation/instapgx"
+          exclude_dirs: "./instrumentation/instaecho ./instrumentation/instaredigo ./internal/bin/sql ./instrumentation/cloud.google.com/go ./example/gin ./instrumentation/instagorm ./example/grpc-client-server ./instrumentation/instafiber ./instrumentation/instaawsv2 ./example/sql-redis ./example/gorm-postgres ./example/gorm-sqlite ./instrumentation/instasarama ./instrumentation/instasarama/example ./example/kafka-producer-consumer ./instrumentation/instabeego ./example/beego ./instrumentation/instapgx ./instrumentation/instaamqp"
 

--- a/.github/workflows/coverage_run_and_upload.yml
+++ b/.github/workflows/coverage_run_and_upload.yml
@@ -31,7 +31,9 @@ jobs:
 
             go test -v -coverpkg=./... -cover -covermode atomic -coverprofile $TRACER_PATH/coverage/coverage.out ./... -json > $TRACER_PATH/coverage/coverage.json
 
-            LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \;)
+            DEPRECATED_PKGS=".*instaamqp$"
+  
+            LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$DEPRECATED_PKGS")
 
             for lib in $LIB_LIST
               do echo "Generating test coverage for $lib" && cd "$lib" && go mod tidy && go test -v -coverpkg=./... -cover -covermode atomic -coverprofile $TRACER_PATH/coverage/coverage_$(date +%s%N)_$RANDOM.out ./... -json > $TRACER_PATH/coverage/coverage_$(date +%s%N)_$RANDOM.json && cd -;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,10 @@ jobs:
         #!/bin/bash
 
         EXCLUDED_DIRS="\/.*\/example"
+        DEPRECATED_PKGS=".*instaamqp$"
 
         # List of instrumentation folders
-        LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$EXCLUDED_DIRS")
+        LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$DEPRECATED_PKGS")
 
         git config user.name "IBM/Instana/Team Go"
         git config user.email "github-actions@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
 
         #!/bin/bash
 
-        EXCLUDED_DIRS="\/.*\/example"
         DEPRECATED_PKGS=".*instaamqp$"
 
         # List of instrumentation folders

--- a/.github/workflows/update-instrumentations-release.yml
+++ b/.github/workflows/update-instrumentations-release.yml
@@ -30,8 +30,9 @@ jobs:
         git config user.email "github-actions@github.com"
 
         EXCLUDED_DIRS="\/.*\/example"
+        DEPRECATED_PKGS=".*instaamqp$"
 
-        LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$EXCLUDED_DIRS")
+        LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$EXCLUDED_DIRS" | grep -E -v "$DEPRECATED_PKGS")
 
         TAGS=""
         for lib in $LIB_LIST

--- a/supported_versions.md
+++ b/supported_versions.md
@@ -15,7 +15,6 @@
 | 13 | Databases | [gorm](https://pkg.go.dev/gorm.io/gorm) | [instagorm](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/instagorm) | v1.25.0 | v1.25.5 |
 | 14 | Messaging | [pubsub](https://pkg.go.dev/cloud.google.com/go/pubsub) | [instapubsub](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/cloud.google.com/go/pubsub) | v1.3.1 | v1.33.0 |
 | 15 | Messaging | [sarama](https://pkg.go.dev/github.com/IBM/sarama) | [instasarama](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/instasarama) | v1.19.0 | v1.41.3 |
-| 16 | Messaging | [amqp](https://pkg.go.dev/github.com/streadway/amqp) | [instaamqp](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/instaamqp) | v1.0.0 | v1.1.0 |
 | 17 | Messaging | [amqp091-go](https://pkg.go.dev/github.com/rabbitmq/amqp091-go) | [instaamqp091](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/instaamqp091) | v1.5.0 | v1.9.0 |
 | 18 | GraphQL | [graphql](https://pkg.go.dev/github.com/graphql-go/graphql) | [instagraphql](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/instagraphql) | v0.8.0 | v0.8.1 |
 | 19 | Other | [storage](https://pkg.go.dev/cloud.google.com/go/storage) | [storage](https://pkg.go.dev/github.com/instana/go-sensor/instrumentation/cloud.google.com/go/storage) | v1.7.0 | v1.36.0 |


### PR DESCRIPTION
This PR prevents futures releases of instaamqp when we run the CI pipeline based releases.