### PR TITLE
Increasing waiting time in GraphQL unit tests

### DIFF
--- a/instrumentation/instagraphql/instagraphql_test.go
+++ b/instrumentation/instagraphql/instagraphql_test.go
@@ -437,7 +437,7 @@ func TestGraphQLWithSubscription(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return recorder.QueuedSpansCount() == 2
-	}, time.Second*2, time.Millisecond*50)
+	}, time.Second*4, time.Millisecond*50)
 
 	spans = recorder.GetQueuedSpans()
 	assert.Len(t, spans, 2)


### PR DESCRIPTION
**Changes**
- Increasing waiting time in the GraphQL unit test.

**Why ?**
- We've observed intermittent failures in the GraphQL unit test with the error message "Condition never satisfied!" Without identifying any apparent issues in the code, we are adjusting the waiting time to see if this error persists. If the issue persists, further investigation will be required.


![image](https://github.com/instana/go-sensor/assets/25578971/70fd6c9c-9a4d-47e2-bb17-a3efa08a3827)


