### PR TITLE
Added runtime-generated db name for pgx integration tests

### DIFF
--- a/instrumentation/instapgx/go.mod
+++ b/instrumentation/instapgx/go.mod
@@ -3,6 +3,7 @@ module github.com/instana/go-sensor/instrumentation/instapgx
 go 1.17
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/instana/go-sensor v1.60.0
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v4 v4.18.3

--- a/instrumentation/instapgx/go.sum
+++ b/instrumentation/instapgx/go.sum
@@ -15,6 +15,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/instana/go-sensor v1.60.0 h1:lsAiwmK5AtNQ9gLHPLvZt0aLddZxM4R0oakkO7rXO2U=
 github.com/instana/go-sensor v1.60.0/go.mod h1:Ks06EG9Da5O3hbdJiHIePG/vNmToovkaJjMlUBd70Yc=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=

--- a/instrumentation/instapgx/main_test.go
+++ b/instrumentation/instapgx/main_test.go
@@ -10,24 +10,68 @@ import (
 	"database/sql"
 	"log"
 	"math/rand"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	instana "github.com/instana/go-sensor"
 	"github.com/instana/go-sensor/instrumentation/instapgx"
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
 )
 
-var databaseUrl = "postgres://postgres:mysecretpassword@localhost/postgres"
+var databaseUrl = "postgres://postgres:mysecretpassword@localhost/"
+
+var dbNamePrefix = "db_"
 
 func TestMain(m *testing.M) {
-	db, err := sql.Open("postgres", databaseUrl)
+
+	// Create test db
+	databaseUrlOrg := databaseUrl
+	db, err := sql.Open("postgres", databaseUrl+"?sslmode=disable")
+
 	if err != nil {
 		log.Fatalln("Can not connect to the database:", err.Error())
 	}
+
+	dbName := dbNamePrefix + strings.Replace(uuid.New().String(), "-", "", -1)
+	_, err = db.Exec("CREATE DATABASE " + dbName)
+
+	if err != nil {
+		log.Fatalln("Can not create database: ", err.Error())
+	}
+
+	db.Close()
+
+	// Connect to test db
+	databaseUrl = databaseUrl + dbName
+	db, err = sql.Open("postgres", databaseUrl+"?sslmode=disable")
+
+	if err != nil {
+		log.Fatalln("Can not connect to the database:", err.Error())
+	}
+
+	// Running tests
+	code := m.Run()
+	db.Close()
+
+	// Clean test db
+	db, err = sql.Open("postgres", databaseUrlOrg+"?sslmode=disable")
+
+	if err != nil {
+		log.Fatalln("Can not connect to the database:", err.Error())
+	}
+
 	defer db.Close()
 
-	m.Run()
+	_, err = db.Exec("DROP DATABASE " + dbName + " WITH (FORCE)")
+
+	if err != nil {
+		log.Fatalln("Can not drop database: "+dbName, err.Error())
+	}
+
+	os.Exit(code)
 }
 
 func prepare(t *testing.T) (*instana.Recorder, context.Context, *instapgx.Conn) {


### PR DESCRIPTION
 Added runtime-generated database name for pgx integration tests. This feature would enable multiple pgx tests to run in parallel.