### PR TITLE
ci: added a separate command to the Makefile for Couchbase integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,9 @@ endif
 INSTAPGX_EXCLUDED := $(findstring ./instrumentation/instapgx, $(EXCLUDE_DIRS))
 INSTAGOCB_EXCLUDED := $(findstring ./instrumentation/instagocb, $(EXCLUDE_DIRS))
 INSTACOSMOS_EXCLUDED := $(findstring ./instrumentation/instacosmos, $(EXCLUDE_DIRS))
-integration: $(INTEGRATION_TESTS)
+integration-common: $(INTEGRATION_TESTS)
 ifndef INSTAPGX_EXCLUDED
 	cd instrumentation/instapgx && go test -tags=integration
-endif
-ifndef INSTAGOCB_EXCLUDED
-	cd instrumentation/instagocb && go test -v -coverprofile cover.out -tags=integration ./...
 endif
 ifndef INSTACOSMOS_EXCLUDED
 	cd instrumentation/instacosmos && go test -v -coverprofile cover.out -tags=integration ./...
@@ -32,6 +29,11 @@ endif
 
 $(INTEGRATION_TESTS):
 	go test $(GOFLAGS) -tags "$@ integration" $(shell grep --exclude-dir=instagocb --exclude-dir=instapgx --exclude-dir=instacosmos  -lR '^// +build \($@,\)\?integration\(,$@\)\?' .)
+
+integration-couchbase:
+ifndef INSTAGOCB_EXCLUDED
+	cd instrumentation/instagocb && go test -v -coverprofile cover.out -tags=integration ./...
+endif
 
 $(LINTER):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/a2bc9b7a99e3280805309d71036e8c2106853250/install.sh \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,20 @@ endif
 INSTAPGX_EXCLUDED := $(findstring ./instrumentation/instapgx, $(EXCLUDE_DIRS))
 INSTAGOCB_EXCLUDED := $(findstring ./instrumentation/instagocb, $(EXCLUDE_DIRS))
 INSTACOSMOS_EXCLUDED := $(findstring ./instrumentation/instacosmos, $(EXCLUDE_DIRS))
+
+# Run all integration tests
+integration: $(INTEGRATION_TESTS)
+ifndef INSTAPGX_EXCLUDED
+	cd instrumentation/instapgx && go test -tags=integration
+endif
+ifndef INSTAGOCB_EXCLUDED
+	cd instrumentation/instagocb && go test -v -coverprofile cover.out -tags=integration ./...
+endif
+ifndef INSTACOSMOS_EXCLUDED
+	cd instrumentation/instacosmos && go test -v -coverprofile cover.out -tags=integration ./...
+endif
+
+# Run all integration tests excluding Couchbase
 integration-common: $(INTEGRATION_TESTS)
 ifndef INSTAPGX_EXCLUDED
 	cd instrumentation/instapgx && go test -tags=integration


### PR DESCRIPTION
This modification will divide the Makefile command for integration tests into two parts: one for Couchbase integration tests and the other for all other integration tests. This adjustment is intended for running Couchbase integration tests separately in Tekton.