### PR TITLE
Modification was made to the Tekton pipeline to exclude tests related to Instacosmos from Go 1.21

### DIFF
--- a/.tekton/ci-build/github-eventlistener.yaml
+++ b/.tekton/ci-build/github-eventlistener.yaml
@@ -60,7 +60,7 @@ spec:
         - name: go-version
           value: "1.21"
         - name: excludeDirs
-          value: ""
+          value: "./instrumentation/instacosmos"
         pipelineRef:
           name: go-tracer-ci-pipeline
         workspaces:

--- a/.tekton/ci-build/pipeline.yaml
+++ b/.tekton/ci-build/pipeline.yaml
@@ -44,7 +44,8 @@ spec:
       workspaces:
         - name: task-pvc
           workspace: go-tracer-ci-pipeline-pvc
-
+    # TODO : Revisit cache implementation. Disabling cache for now, as it causes memory issues.
+    
     # - name: cache-restore
     #   params:
     #   - name: imageTag

--- a/.tekton/ci-build/pipeline.yaml
+++ b/.tekton/ci-build/pipeline.yaml
@@ -45,17 +45,17 @@ spec:
         - name: task-pvc
           workspace: go-tracer-ci-pipeline-pvc
 
-    - name: cache-restore
-      params:
-      - name: imageTag
-        value: $(params.go-version)
-      taskRef:
-        name: go-tracer-cache-restore-task
-      workspaces:
-        - name: task-pvc
-          workspace: go-tracer-ci-pipeline-pvc
-        - name: cache-pvc
-          workspace: cache-pvc
+    # - name: cache-restore
+    #   params:
+    #   - name: imageTag
+    #     value: $(params.go-version)
+    #   taskRef:
+    #     name: go-tracer-cache-restore-task
+    #   workspaces:
+    #     - name: task-pvc
+    #       workspace: go-tracer-ci-pipeline-pvc
+    #     - name: cache-pvc
+    #       workspace: cache-pvc
 
     - name: go-fmt
       runAfter:
@@ -88,7 +88,7 @@ spec:
     - name: unit-test
       runAfter:
         - go-imports
-        - cache-restore
+        # - cache-restore
       params:
       - name: imageTag
         value: $(params.go-version)
@@ -138,19 +138,19 @@ spec:
         - name: cache-pvc
           workspace: cache-pvc
 
-    - name: cache-update
-      runAfter:
-        - integration-test-couchbase
-      params:
-      - name: imageTag
-        value: $(params.go-version)
-      taskRef:
-        name: go-tracer-cache-update-task
-      workspaces:
-        - name: task-pvc
-          workspace: go-tracer-ci-pipeline-pvc
-        - name: cache-pvc
-          workspace: cache-pvc
+    # - name: cache-update
+    #   runAfter:
+    #     - integration-test-couchbase
+    #   params:
+    #   - name: imageTag
+    #     value: $(params.go-version)
+    #   taskRef:
+    #     name: go-tracer-cache-update-task
+    #   workspaces:
+    #     - name: task-pvc
+    #       workspace: go-tracer-ci-pipeline-pvc
+    #     - name: cache-pvc
+    #       workspace: cache-pvc
 
   finally:
     - name: github-set-check-status-to-success-or-failure


### PR DESCRIPTION
This PR aims to modify the Tekton pipeline to exclude tests related to` Instacosmos` from Go version 1.21. This is because `azcosmos` has restricted the minimum Go version to 1.22 in their new update.

The [pipeline run succeeded](http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/#/namespaces/default/pipelineruns/update-instrumentations-instacos-go21-88484fc) in Go 1.21 after implementing this change.