### PR TITLE
refactored Go Tracer for Go version 1.23

### DIFF
--- a/.tekton/ci-build/github-eventlistener.yaml
+++ b/.tekton/ci-build/github-eventlistener.yaml
@@ -21,6 +21,36 @@ spec:
         # After variable resolution, this has to be maximum 63 character long,
         # lower case, RFC 1123 subdomain name. The regex used for validation is
         # '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+        name: $(tt.params.git-branch-normalized)-go23-$(tt.params.git-commit-short-sha)
+      spec:
+        params:
+        - name: revision
+          value: $(tt.params.git-branch)
+        - name: git-commit-sha
+          value: $(tt.params.git-commit-sha)
+        - name: go-version
+          value: "1.23"
+        - name: excludeDirs
+          value: ""
+        pipelineRef:
+          name: go-tracer-ci-pipeline
+        workspaces:
+        - name: go-tracer-ci-pipeline-pvc
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+        - name: cache-pvc
+          persistentVolumeClaim:
+            claimName: cache-pvc
+
+
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
         name: $(tt.params.git-branch-normalized)-go22-$(tt.params.git-commit-short-sha)
       spec:
         params:
@@ -31,7 +61,7 @@ spec:
         - name: go-version
           value: "1.22"
         - name: excludeDirs
-          value: ""
+          value: "./instrumentation/instacosmos"
         pipelineRef:
           name: go-tracer-ci-pipeline
         workspaces:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 test: $(MODULES) legal
 
 $(MODULES):
-	cd $@ && go get -d -t ./... && go test $(GOFLAGS) ./...
+	cd $@ && go get -t ./... && go test $(GOFLAGS) ./...
 ifeq ($(RUN_LINTER),yes)
 	cd $@ && $(LINTER) run
 endif
@@ -66,7 +66,8 @@ install:
 
 # Make sure there is a copyright at the first line of each .go file
 legal:
-	awk 'FNR==1 { if (tolower($$0) !~ "^//.+copyright") { print FILENAME" does not contain copyright header"; rc=1 } }; END { exit rc }' $$(find . -name '*.go' -type f | grep -v "/vendor/")
+	@printf "Verifying that Go files include copyright headers\n"
+	@awk 'FNR==1 { if (tolower($$0) !~ "^//.+copyright") { print FILENAME" does not contain copyright header"; rc=1 } }; END { print "Done!"; exit rc }' $$(find . -name '*.go' -type f | grep -v "/vendor/")
 
 instrumentation/% :
 	mkdir -p $@


### PR DESCRIPTION
- Remove warnings in the build pipeline.
- Test go-sensor SDK against Go 1.23