### PR TITLE
Removing toolchain from go.mod file

### DIFF
--- a/instrumentation/instacosmos/go.mod
+++ b/instrumentation/instacosmos/go.mod
@@ -2,8 +2,6 @@ module github.com/instana/go-sensor/instrumentation/instacosmos
 
 go 1.22.0
 
-toolchain go1.22.2
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0


### PR DESCRIPTION
This PR removes the `toolchain` line from the go.mod file. This was updated by running `go mod tidy` command.