### PR TITLE
chore: fixed some minor issues in the currency automation scripts

### DIFF
--- a/.tekton/tracer-reports/task.yaml
+++ b/.tekton/tracer-reports/task.yaml
@@ -79,11 +79,7 @@ spec:
         git config user.email "$GITHUB_ENTERPRISE_USER_EMAIL"
         git add automated/currency/go/report.md || true
         git commit -m "Updated tracer reports for Team Go : $(date +'%d-%b-%Y %H:%M:%S')" || true
-        if [ -s output.txt ]; then
-          echo "Some error occurred!"
-        else
-          git push origin @ || true
-        fi
+        git push origin @ || true
 
 
 ---

--- a/currency_report.sh
+++ b/currency_report.sh
@@ -192,7 +192,7 @@ while IFS= read -r line; do
         debug_log "Immediate next version:" "$IMMEDIATE_NEXT_VERSION"
         debug_log "Immediate next version date:" "$IMMEDIATE_NEXT_VERSION_DATE"
 
-        debug_log "$TARGET_PACKAGE_NAME - $CURRENT_VERSION - $LATEST_VERSION - $IMMEDIATE_NEXT_VERSION" >> $OUTPUT_TO_SLACK
+        echo "$TARGET_PACKAGE_NAME - $CURRENT_VERSION - $LATEST_VERSION - $IMMEDIATE_NEXT_VERSION" >> $OUTPUT_TO_SLACK
 
         find_days_behind_last_support "$IMMEDIATE_NEXT_VERSION_DATE"
 

--- a/version_updater.sh
+++ b/version_updater.sh
@@ -165,7 +165,7 @@ COMMIT_MSG="feat(currency): updated go.mod, go.sum files, README.md for $INSTRUM
   git checkout -b "update-instrumentations-$INSTRUMENTATION-id-$CURRENT_TIME_UNIX"
 
   git add go.mod go.sum $LIBRARY_INFO_MD_PATH
-  git commit -m "$PR_TITLE"
+  git commit -m "$COMMIT_MSG"
   git push origin @
 
   # Create a PR request for the changes

--- a/version_updater.sh
+++ b/version_updater.sh
@@ -129,6 +129,7 @@ while IFS= read -r line; do
   fi
 
   PR_TITLE="feat(currency): updated instrumentation of $INSTRUMENTATION for new version $LATEST_VERSION"
+COMMIT_MSG="feat(currency): updated go.mod, go.sum files, README.md for $INSTRUMENTATION"
 
   if gh pr list | grep -q "$PR_TITLE"; then
     echo "PR for $INSTRUMENTATION newer version:$LATEST_VERSION already exists. Skipping to next iteration"

--- a/version_updater.sh
+++ b/version_updater.sh
@@ -128,7 +128,9 @@ while IFS= read -r line; do
     continue
   fi
 
-  if gh pr list | grep -q "feat(currency): updated instrumentation of $INSTRUMENTATION for new version $LATEST_VERSION"; then
+  PR_TITLE="feat(currency): updated instrumentation of $INSTRUMENTATION for new version $LATEST_VERSION"
+
+  if gh pr list | grep -q "$PR_TITLE"; then
     echo "PR for $INSTRUMENTATION newer version:$LATEST_VERSION already exists. Skipping to next iteration"
     continue
   fi
@@ -162,13 +164,13 @@ while IFS= read -r line; do
   git checkout -b "update-instrumentations-$INSTRUMENTATION-id-$CURRENT_TIME_UNIX"
 
   git add go.mod go.sum $LIBRARY_INFO_MD_PATH
-  git commit -m "feat(currency): updated go.mod, go.sum files, README.md for $INSTRUMENTATION"
+  git commit -m "$PR_TITLE"
   git push origin @
 
   # Create a PR request for the changes
   # shellcheck disable=SC2046
-  gh pr create --title "feat(currency): updated instrumentation of $INSTRUMENTATION for new version $LATEST_VERSION. Id: $CURRENT_TIME_UNIX" \
-    --body "This PR adds changes for the newer version $LATEST_VERSION for the instrumented package" --head $(git branch --show-current)
+  gh pr create --title "$PR_TITLE. Id: $CURRENT_TIME_UNIX" \
+    --body "This PR adds changes for the newer version $LATEST_VERSION for the instrumented package" --head $(git branch --show-current) --label "tekton_ci"
 
   # Back to working directry
   cd $TRACER_PATH


### PR DESCRIPTION
This PR aims to address the following minor issues in the currency scripts:

- Changes in the currency markdown file will now be pushed to upstream even if `output.txt` contains data. There are cases where scripts may fail for some libraries but succeed for others, and in such situations, the markdown file still needs to be pushed.
- PR title string has been moved to a variable for better clarity.
- In case of a version mismatch in any package, the details must be recorded in `output.txt`. The` debug_log` has been replaced with an `echo` command to ensure this information is always captured.
- add ci pipeline for currency PRs (Re-introducing #834)