### PR TITLE
poc: refactoring sql instrumentation

### DIFF
--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -26,6 +26,7 @@ type sqlSpan interface {
 	start(ctx context.Context, sensor TracerLogger) (sp ot.Span, dbKey string)
 }
 
+// sqlSpanData implements sqlSpan
 type sqlSpanData struct {
 	m           *sync.Mutex
 	connDetails DbConnDetails
@@ -33,6 +34,7 @@ type sqlSpanData struct {
 	tags        ot.Tags
 }
 
+// getSQLSpanData returns instance of sqlSpanData while creating a connection to DB
 func getSQLSpanData(c DbConnDetails, q string) *sqlSpanData {
 	var m sync.Mutex
 	tags := make(ot.Tags)
@@ -48,6 +50,7 @@ func getSQLSpanData(c DbConnDetails, q string) *sqlSpanData {
 
 }
 
+// applyTags applies db tags in tags map
 func (c DbConnDetails) applyTags(tags ot.Tags) {
 	switch c.DatabaseName {
 	case "postgres":
@@ -77,6 +80,7 @@ func (s *sqlSpanData) addTag(key string, val string) {
 
 }
 
+// start a new sql span
 func (s *sqlSpanData) start(
 	ctx context.Context,
 	sensor TracerLogger) (sp ot.Span, dbKey string) {
@@ -92,6 +96,7 @@ func (s *sqlSpanData) start(
 
 	// *-------------------* //
 
+	// calling new postgresSpan method
 	case "postgres":
 		return s.postgresSpan(ctx, sensor), "pg"
 
@@ -111,6 +116,7 @@ func (s *sqlSpanData) start(
 
 }
 
+// postgresSpan creates a new postgres span
 func (s *sqlSpanData) postgresSpan(
 	ctx context.Context,
 	sensor TracerLogger) (sp ot.Span) {

--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -53,7 +53,7 @@ func getSQLSpanData(c DbConnDetails, opts ...sqlSpanOption) *sqlSpanData {
 		tf = withGenericSQLTags
 	}
 
-	tf(c).Apply(tags)
+	tf(&c).Apply(tags)
 
 	spanData := &sqlSpanData{
 		m:           &m,
@@ -307,7 +307,7 @@ func (s *sqlSpanData) updateSpanDataIfRedis() {
 		// as go sensor was not able to determine the database from connection details.
 		// Hence removing the existing tags and adding default redis connection tags.
 		s.tags = make(ot.Tags)
-		withRedisTags(s.connDetails).Apply(s.tags)
+		withRedisTags(&s.connDetails).Apply(s.tags)
 
 		s.updateDBNameInSpanData(Redis)
 	}

--- a/instrumentation_sql_stmt.go
+++ b/instrumentation_sql_stmt.go
@@ -12,15 +12,13 @@ import (
 type wStmt struct {
 	driver.Stmt
 
-	// connDetails DbConnDetails
-	// query       string
 	sqlSpan *sqlSpanData
 	sensor  TracerLogger
 }
 
 func (stmt *wStmt) Exec(args []driver.Value) (driver.Result, error) {
 	ctx := context.Background()
-	// sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+
 	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 
@@ -35,7 +33,7 @@ func (stmt *wStmt) Exec(args []driver.Value) (driver.Result, error) {
 
 func (stmt *wStmt) Query(args []driver.Value) (driver.Rows, error) {
 	ctx := context.Background()
-	// sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+
 	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 

--- a/instrumentation_sql_stmt.go
+++ b/instrumentation_sql_stmt.go
@@ -14,8 +14,8 @@ type wStmt struct {
 
 	// connDetails DbConnDetails
 	// query       string
-	sqlSpan
-	sensor TracerLogger
+	sqlSpan *sqlSpanData
+	sensor  TracerLogger
 }
 
 func (stmt *wStmt) Exec(args []driver.Value) (driver.Result, error) {

--- a/instrumentation_sql_stmt.go
+++ b/instrumentation_sql_stmt.go
@@ -12,14 +12,16 @@ import (
 type wStmt struct {
 	driver.Stmt
 
-	connDetails DbConnDetails
-	query       string
-	sensor      TracerLogger
+	// connDetails DbConnDetails
+	// query       string
+	sqlSpan
+	sensor TracerLogger
 }
 
 func (stmt *wStmt) Exec(args []driver.Value) (driver.Result, error) {
 	ctx := context.Background()
-	sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+	// sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 
 	res, err := stmt.Stmt.Exec(args) //nolint:staticcheck
@@ -33,7 +35,8 @@ func (stmt *wStmt) Exec(args []driver.Value) (driver.Result, error) {
 
 func (stmt *wStmt) Query(args []driver.Value) (driver.Rows, error) {
 	ctx := context.Background()
-	sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+	// sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 
 	res, err := stmt.Stmt.Query(args) //nolint:staticcheck

--- a/sql_data.go
+++ b/sql_data.go
@@ -2,6 +2,37 @@
 
 package instana
 
+type database int8
+
+const (
+	sql_generic database = iota
+	postgres
+	mysql
+	redis
+	couchbase
+	cosmos
+)
+
+// database names
+const (
+	Postgres  string = "postgres"
+	MySQL     string = "mysql"
+	Redis     string = "redis"
+	Couchbase string = "couchbase"
+	Cosmos    string = "cosmos"
+	DB2       string = "db2"
+)
+
+// db Keys
+const (
+	pg_db_key          string = "pg"
+	mysql_db_key       string = "mysql"
+	redis_db_key       string = "redis"
+	couchbase_db_key   string = "couchbase"
+	cosmos_db_key      string = "cosmos"
+	generic_sql_db_key string = "db"
+)
+
 var redisCommands = map[string]struct{}{
 	"SET":           {},
 	"GET":           {},
@@ -82,4 +113,23 @@ var redisCommands = map[string]struct{}{
 	"BGSAVE":        {},
 	"BGREWRITEAOF":  {},
 	"SHUTDOWN":      {},
+}
+
+var dbMap = map[string]database{
+	Postgres:  postgres,
+	MySQL:     mysql,
+	Redis:     redis,
+	Couchbase: couchbase,
+	Cosmos:    cosmos,
+	DB2:       sql_generic,
+}
+
+func db(dbName string) database {
+
+	db, ok := dbMap[dbName]
+	if !ok {
+		return sql_generic
+	}
+
+	return db
 }

--- a/sql_execer.go
+++ b/sql_execer.go
@@ -22,7 +22,8 @@ func (conn *wExecer) Exec(query string, args []driver.Value) (driver.Result, err
 
 	ctx := context.Background()
 
-	// updating db query in sqlSpanData instance
+	// Since the query is not a constant value like database connection details,
+	// it needs to be updated in the sqlSpanData instance with the current value.
 	conn.sqlSpan.updateDBQuery(query)
 
 	sp, dbKey := conn.sqlSpan.start(ctx, conn.sensor)

--- a/sql_execer_context.go
+++ b/sql_execer_context.go
@@ -12,12 +12,15 @@ import (
 type wExecerContext struct {
 	driver.ExecerContext
 
-	connDetails DbConnDetails
-	sensor      TracerLogger
+	// connDetails DbConnDetails
+	sqlSpan *sqlSpanData
+	sensor  TracerLogger
 }
 
 func (conn *wExecerContext) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	sp, dbKey := startSQLSpan(ctx, conn.connDetails, query, conn.sensor)
+	// sp, dbKey := startSQLSpan(ctx, conn.connDetails, query, conn.sensor)
+	conn.sqlSpan.updateDBQuery(query)
+	sp, dbKey := conn.sqlSpan.start(ctx, conn.sensor)
 	defer sp.Finish()
 
 	res, err := conn.ExecerContext.ExecContext(ctx, query, args)

--- a/sql_execer_context.go
+++ b/sql_execer_context.go
@@ -18,7 +18,8 @@ type wExecerContext struct {
 
 func (conn *wExecerContext) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 
-	// updating db query in sqlSpanData instance
+	// Since the query is not a constant value like database connection details,
+	// it needs to be updated in the sqlSpanData instance with the current value.
 	conn.sqlSpan.updateDBQuery(query)
 
 	sp, dbKey := conn.sqlSpan.start(ctx, conn.sensor)

--- a/sql_execer_context.go
+++ b/sql_execer_context.go
@@ -11,15 +11,16 @@ import (
 
 type wExecerContext struct {
 	driver.ExecerContext
+	sensor TracerLogger
 
-	// connDetails DbConnDetails
 	sqlSpan *sqlSpanData
-	sensor  TracerLogger
 }
 
 func (conn *wExecerContext) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	// sp, dbKey := startSQLSpan(ctx, conn.connDetails, query, conn.sensor)
+
+	// updating db query in sqlSpanData instance
 	conn.sqlSpan.updateDBQuery(query)
+
 	sp, dbKey := conn.sqlSpan.start(ctx, conn.sensor)
 	defer sp.Finish()
 

--- a/sql_queryer.go
+++ b/sql_queryer.go
@@ -21,7 +21,8 @@ type wQueryer struct {
 func (conn *wQueryer) Query(query string, args []driver.Value) (driver.Rows, error) {
 	ctx := context.Background()
 
-	// updating db query in sqlSpanData instance
+	// Since the query is not a constant value like database connection details,
+	// it needs to be updated in the sqlSpanData instance with the current value.
 	conn.sqlSpan.updateDBQuery(query)
 
 	sp, dbKey := conn.sqlSpan.start(ctx, conn.sensor)

--- a/sql_queryer_context.go
+++ b/sql_queryer_context.go
@@ -18,7 +18,8 @@ type wQueryerContext struct {
 
 func (conn *wQueryerContext) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 
-	// updating db query in sqlSpanData instance
+	// Since the query is not a constant value like database connection details,
+	// it needs to be updated in the sqlSpanData instance with the current value.
 	conn.sqlSpan.updateDBQuery(query)
 
 	sp, dbKey := conn.sqlSpan.start(ctx, conn.sensor)

--- a/sql_stmt_execer_context.go
+++ b/sql_stmt_execer_context.go
@@ -11,14 +11,13 @@ import (
 
 type wStmtExecContext struct {
 	driver.StmtExecContext
-	// connDetails DbConnDetails
 	sensor TracerLogger
-	// query       string
+
 	sqlSpan *sqlSpanData
 }
 
 func (stmt *wStmtExecContext) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	// sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+
 	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 

--- a/sql_stmt_execer_context.go
+++ b/sql_stmt_execer_context.go
@@ -14,7 +14,7 @@ type wStmtExecContext struct {
 	// connDetails DbConnDetails
 	sensor TracerLogger
 	// query       string
-	sqlSpan
+	sqlSpan *sqlSpanData
 }
 
 func (stmt *wStmtExecContext) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {

--- a/sql_stmt_execer_context.go
+++ b/sql_stmt_execer_context.go
@@ -11,13 +11,15 @@ import (
 
 type wStmtExecContext struct {
 	driver.StmtExecContext
-	connDetails DbConnDetails
-	sensor      TracerLogger
-	query       string
+	// connDetails DbConnDetails
+	sensor TracerLogger
+	// query       string
+	sqlSpan
 }
 
 func (stmt *wStmtExecContext) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+	// sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 
 	res, err := stmt.StmtExecContext.ExecContext(ctx, args)

--- a/sql_stmt_queryer_context.go
+++ b/sql_stmt_queryer_context.go
@@ -11,13 +11,14 @@ import (
 
 type wStmtQueryContext struct {
 	driver.StmtQueryContext
-	connDetails DbConnDetails
-	sensor      TracerLogger
-	query       string
+	sensor TracerLogger
+
+	sqlSpan *sqlSpanData
 }
 
 func (stmt *wStmtQueryContext) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	sp, dbKey := startSQLSpan(ctx, stmt.connDetails, stmt.query, stmt.sensor)
+
+	sp, dbKey := stmt.sqlSpan.start(ctx, stmt.sensor)
 	defer sp.Finish()
 
 	res, err := stmt.StmtQueryContext.QueryContext(ctx, args)

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,646 @@
+// // (c) Copyright IBM Corp. 2023
+
+package instana
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type returnNoRows struct{}
+
+type returnError struct{}
+
+type rowsAffected struct{}
+
+type rows struct {
+	columns []string
+}
+
+var errUnexpected = errors.New("unexpected error")
+
+var connDetails = DbConnDetails{
+	RawString:    "connection string",
+	Host:         "host",
+	Port:         "1234",
+	Schema:       "test-schema",
+	User:         "user1",
+	DatabaseName: "mysql",
+}
+
+func (r rows) Columns() []string {
+	return r.columns
+}
+
+func (r rows) Close() error {
+	return nil
+}
+
+func (r rows) Next(dest []driver.Value) error {
+	return nil
+}
+
+func (e returnNoRows) ExecContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue) (driver.Result, error) {
+	return driver.ResultNoRows, nil
+}
+
+func (e returnError) ExecContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue) (driver.Result, error) {
+	return driver.ResultNoRows, errUnexpected
+}
+
+func (e rowsAffected) ExecContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue) (driver.Result, error) {
+	return driver.RowsAffected(1), nil
+}
+
+func (e returnNoRows) QueryContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue) (driver.Rows, error) {
+	return rows{[]string{}}, nil
+}
+
+func (e returnError) QueryContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue) (driver.Rows, error) {
+	return rows{[]string{}}, errUnexpected
+}
+
+func (e rowsAffected) QueryContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue) (driver.Rows, error) {
+	return rows{[]string{"test"}}, nil
+}
+
+func (e returnNoRows) Query(
+	query string,
+	args []driver.Value) (driver.Rows, error) {
+	return rows{[]string{}}, nil
+}
+
+func (e returnError) Query(
+	query string,
+	args []driver.Value) (driver.Rows, error) {
+	return rows{[]string{}}, errUnexpected
+}
+
+func (e rowsAffected) Query(
+	query string,
+	args []driver.Value) (driver.Rows, error) {
+	return rows{[]string{"test"}}, nil
+}
+
+func (e returnNoRows) Exec(
+	query string,
+	args []driver.Value) (driver.Result, error) {
+	return driver.ResultNoRows, nil
+}
+
+func (e returnError) Exec(
+	query string,
+	args []driver.Value) (driver.Result, error) {
+	return driver.ResultNoRows, errUnexpected
+}
+
+func (e rowsAffected) Exec(
+	query string,
+	args []driver.Value) (driver.Result, error) {
+	return driver.RowsAffected(1), nil
+}
+
+func Test_wExecerContext_ExecContext(t *testing.T) {
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
+	}, recorder))
+	defer ShutdownSensor()
+
+	type fields struct {
+		ExecerContext driver.ExecerContext
+		sensor        TracerLogger
+		sqlSpan       *sqlSpanData
+	}
+	type args struct {
+		ctx   context.Context
+		query string
+		args  []driver.NamedValue
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    driver.Result
+		wantErr bool
+	}{
+		{
+			name: "ResultNoRows",
+			fields: fields{
+				ExecerContext: returnNoRows{},
+				sensor:        s,
+				sqlSpan:       getSQLSpanData(connDetails),
+			},
+			args: args{
+				ctx:   context.Background(),
+				query: "TEST QUERY",
+				args:  []driver.NamedValue{},
+			},
+			want:    driver.ResultNoRows,
+			wantErr: false,
+		},
+		{
+			name: "ReturnError",
+			fields: fields{
+				ExecerContext: returnError{},
+				sensor:        s,
+				sqlSpan:       getSQLSpanData(connDetails),
+			},
+			args: args{
+				ctx:   context.Background(),
+				query: "TEST QUERY",
+				args:  []driver.NamedValue{},
+			},
+			want:    driver.ResultNoRows,
+			wantErr: true,
+		},
+		{
+			name: "RowsAffected",
+			fields: fields{
+				ExecerContext: rowsAffected{},
+				sensor:        s,
+				sqlSpan:       getSQLSpanData(connDetails),
+			},
+			args: args{
+				ctx:   context.Background(),
+				query: "TEST QUERY",
+				args:  []driver.NamedValue{},
+			},
+			want:    driver.RowsAffected(1),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &wExecerContext{
+				ExecerContext: tt.fields.ExecerContext,
+				sensor:        tt.fields.sensor,
+				sqlSpan:       tt.fields.sqlSpan,
+			}
+			got, err := conn.ExecContext(tt.args.ctx, tt.args.query, tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wExecerContext.ExecContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wExecerContext.ExecContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_wExecer_Exec(t *testing.T) {
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
+	}, recorder))
+	defer ShutdownSensor()
+
+	type fields struct {
+		Execer  driver.Execer
+		sensor  TracerLogger
+		sqlSpan *sqlSpanData
+	}
+	type args struct {
+		query string
+		args  []driver.Value
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    driver.Result
+		wantErr bool
+	}{
+		{
+			name: "ResultNoRows",
+			fields: fields{
+				Execer:  returnNoRows{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				query: "TEST QUERY",
+				args:  []driver.Value{},
+			},
+			want:    driver.ResultNoRows,
+			wantErr: false,
+		},
+		{
+			name: "ReturnError",
+			fields: fields{
+				Execer:  returnError{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				query: "TEST QUERY",
+				args:  []driver.Value{},
+			},
+			want:    driver.ResultNoRows,
+			wantErr: true,
+		},
+		{
+			name: "RowsAffected",
+			fields: fields{
+				Execer:  rowsAffected{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				query: "TEST QUERY",
+				args:  []driver.Value{},
+			},
+			want:    driver.RowsAffected(1),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &wExecer{
+				Execer:  tt.fields.Execer,
+				sensor:  tt.fields.sensor,
+				sqlSpan: tt.fields.sqlSpan,
+			}
+			got, err := conn.Exec(tt.args.query, tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wExecer.Exec() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wExecer.Exec() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_wQueryerContext_QueryContext(t *testing.T) {
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
+	}, recorder))
+	defer ShutdownSensor()
+
+	type fields struct {
+		QueryerContext driver.QueryerContext
+		sensor         TracerLogger
+		sqlSpan        *sqlSpanData
+	}
+	type args struct {
+		ctx   context.Context
+		query string
+		args  []driver.NamedValue
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    driver.Rows
+		wantErr bool
+	}{
+		{
+			name: "ResultNoRows",
+			fields: fields{
+				QueryerContext: returnNoRows{},
+				sensor:         s,
+				sqlSpan:        getSQLSpanData(connDetails),
+			},
+			args: args{
+				ctx:   context.Background(),
+				query: "TEST QUERY",
+				args:  []driver.NamedValue{},
+			},
+			want:    rows{[]string{}},
+			wantErr: false,
+		},
+		{
+			name: "ReturnError",
+			fields: fields{
+				QueryerContext: returnError{},
+				sensor:         s,
+				sqlSpan:        getSQLSpanData(connDetails),
+			},
+			args: args{
+				ctx:   context.Background(),
+				query: "TEST QUERY",
+				args:  []driver.NamedValue{},
+			},
+			want:    rows{[]string{}},
+			wantErr: true,
+		},
+		{
+			name: "RowsAffected",
+			fields: fields{
+				QueryerContext: rowsAffected{},
+				sensor:         s,
+				sqlSpan:        getSQLSpanData(connDetails),
+			},
+			args: args{
+				ctx:   context.Background(),
+				query: "TEST QUERY",
+				args:  []driver.NamedValue{},
+			},
+			want:    rows{[]string{"test"}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &wQueryerContext{
+				QueryerContext: tt.fields.QueryerContext,
+				sensor:         tt.fields.sensor,
+				sqlSpan:        tt.fields.sqlSpan,
+			}
+			got, err := conn.QueryContext(tt.args.ctx, tt.args.query, tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wQueryerContext.QueryContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wQueryerContext.QueryContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_wQueryer_Query(t *testing.T) {
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
+	}, recorder))
+	defer ShutdownSensor()
+
+	type fields struct {
+		Queryer driver.Queryer
+		sensor  TracerLogger
+		sqlSpan *sqlSpanData
+	}
+	type args struct {
+		query string
+		args  []driver.Value
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    driver.Rows
+		wantErr bool
+	}{
+		{
+			name: "ResultNoRows",
+			fields: fields{
+				Queryer: returnNoRows{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				query: "TEST QUERY",
+				args:  []driver.Value{},
+			},
+			want:    rows{[]string{}},
+			wantErr: false,
+		},
+		{
+			name: "ReturnError",
+			fields: fields{
+				Queryer: returnError{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				query: "TEST QUERY",
+				args:  []driver.Value{},
+			},
+			want:    rows{[]string{}},
+			wantErr: true,
+		},
+		{
+			name: "RowsAffected",
+			fields: fields{
+				Queryer: rowsAffected{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				query: "TEST QUERY",
+				args:  []driver.Value{},
+			},
+			want:    rows{[]string{"test"}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &wQueryer{
+				Queryer: tt.fields.Queryer,
+				sensor:  tt.fields.sensor,
+				sqlSpan: tt.fields.sqlSpan,
+			}
+			got, err := conn.Query(tt.args.query, tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wQueryer.Query() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wQueryer.Query() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type stmt struct{}
+
+func (s stmt) Query(args []driver.Value) (driver.Rows, error) {
+	return rows{[]string{}}, nil
+}
+
+func (s stmt) Exec(args []driver.Value) (driver.Result, error) {
+	return driver.ResultNoRows, nil
+}
+
+func (s stmt) Close() error { return nil }
+
+func (s stmt) NumInput() int { return -1 }
+
+type stmtErr struct{}
+
+func (s stmtErr) Query(args []driver.Value) (driver.Rows, error) {
+	return rows{[]string{}}, errUnexpected
+}
+
+func (s stmtErr) Exec(args []driver.Value) (driver.Result, error) {
+	return driver.ResultNoRows, errUnexpected
+}
+
+func (s stmtErr) Close() error { return nil }
+
+func (s stmtErr) NumInput() int { return -1 }
+
+func Test_wStmt_Query(t *testing.T) {
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
+	}, recorder))
+	defer ShutdownSensor()
+
+	type fields struct {
+		Stmt    driver.Stmt
+		sqlSpan *sqlSpanData
+		sensor  TracerLogger
+	}
+	type args struct {
+		args []driver.Value
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    driver.Rows
+		wantErr bool
+	}{
+		{
+			name: "sql stmt Query",
+			fields: fields{
+				Stmt:    stmt{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				args: []driver.Value{},
+			},
+			want:    rows{[]string{}},
+			wantErr: false,
+		},
+		{
+			name: "sql stmt Query with error",
+			fields: fields{
+				Stmt:    stmtErr{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				args: []driver.Value{},
+			},
+			want:    rows{[]string{}},
+			wantErr: true,
+		},
+		{
+			name: "sql stmt Exec with error",
+			fields: fields{
+				Stmt:    stmtErr{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				args: []driver.Value{},
+			},
+			want:    rows{[]string{}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := &wStmt{
+				Stmt:    tt.fields.Stmt,
+				sqlSpan: tt.fields.sqlSpan,
+				sensor:  tt.fields.sensor,
+			}
+			got, err := stmt.Query(tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wStmt.Query() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wStmt.Query() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_wStmt_Exec(t *testing.T) {
+
+	recorder := NewTestRecorder()
+	s := NewSensorWithTracer(NewTracerWithEverything(&Options{
+		Service:     "go-sensor-test",
+		AgentClient: alwaysReadyClient{},
+	}, recorder))
+	defer ShutdownSensor()
+
+	type fields struct {
+		Stmt    driver.Stmt
+		sqlSpan *sqlSpanData
+		sensor  TracerLogger
+	}
+	type args struct {
+		args []driver.Value
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    driver.Result
+		wantErr bool
+	}{
+		{
+			name: "sql stmt Exec with error",
+			fields: fields{
+				Stmt:    stmtErr{},
+				sensor:  s,
+				sqlSpan: getSQLSpanData(connDetails),
+			},
+			args: args{
+				args: []driver.Value{},
+			},
+			want:    driver.ResultNoRows,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := &wStmt{
+				Stmt:    tt.fields.Stmt,
+				sqlSpan: tt.fields.sqlSpan,
+				sensor:  tt.fields.sensor,
+			}
+			got, err := stmt.Exec(tt.args.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wStmt.Query() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wStmt.Query() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sql_wrappers.go
+++ b/sql_wrappers.go
@@ -2059,14 +2059,12 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			connDetails:      connDetails,
@@ -2080,14 +2078,12 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker(stmt driver.Stm
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			connDetails:      connDetails,
@@ -2100,8 +2096,7 @@ func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stm
 	return &w_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
@@ -2116,14 +2111,12 @@ func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt
 	return &w_stmt_StmtExecContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2132,14 +2125,12 @@ func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt,
 	return &w_stmt_StmtExecContext_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			connDetails:      connDetails,
@@ -2153,8 +2144,7 @@ func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, c
 	return &w_stmt_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
@@ -2169,8 +2159,7 @@ func get_stmt_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string,
 	return &w_stmt_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
@@ -2184,14 +2173,12 @@ func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, co
 	return &w_stmt_StmtExecContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		},
 		cc: ColumnConverter}
 }
@@ -2200,14 +2187,12 @@ func get_stmt_StmtExecContext_NamedValueChecker(stmt driver.Stmt, query string, 
 	return &w_stmt_StmtExecContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -2215,8 +2200,7 @@ func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, 
 	return &w_stmt_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
@@ -2226,14 +2210,12 @@ func get_stmt_StmtExecContext_StmtQueryContext(stmt driver.Stmt, query string, c
 	return &w_stmt_StmtExecContext_StmtQueryContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			connDetails:      connDetails,
@@ -2246,8 +2228,7 @@ func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConn
 	return &w_stmt_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		},
 		cc: ColumnConverter}
@@ -2257,14 +2238,12 @@ func get_stmt_StmtExecContext(stmt driver.Stmt, query string, connDetails DbConn
 	return &w_stmt_StmtExecContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
-			connDetails:     connDetails,
 			sensor:          sensor,
-			query:           query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 		}}
 }
 
@@ -2272,8 +2251,7 @@ func get_stmt_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbCo
 	return &w_stmt_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -2282,8 +2260,7 @@ func get_stmt_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbCon
 	return &w_stmt_StmtQueryContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			connDetails: connDetails,
-			query:       query,
+			sqlSpan: getSQLSpanData(connDetails, query),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
@@ -2317,8 +2294,7 @@ func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor 
 
 	return &wStmt{
 		Stmt:        stmt,
-		connDetails: connDetails,
-		query:       query,
+		sqlSpan: getSQLSpanData(connDetails, query),
 		sensor:      sensor,
 	}
 }

--- a/sql_wrappers.go
+++ b/sql_wrappers.go
@@ -695,22 +695,22 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_Nam
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -729,22 +729,22 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(con
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -763,17 +763,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValue
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -792,17 +792,17 @@ func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -821,17 +821,17 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueC
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -850,17 +850,17 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -879,22 +879,22 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker(conn
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -908,17 +908,17 @@ func get_conn_Execer_Queryer_QueryerContext_NamedValueChecker(connDetails DbConn
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -932,17 +932,17 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConn
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -961,12 +961,12 @@ func get_conn_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDe
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -985,12 +985,12 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1009,12 +1009,12 @@ func get_conn_Execer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDet
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1033,12 +1033,12 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDet
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1057,12 +1057,12 @@ func get_conn_Execer_Queryer_ConnPrepareContext_NamedValueChecker(connDetails Db
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1081,22 +1081,22 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext(connDetails DbConnDeta
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1110,12 +1110,12 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker(connDeta
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1134,17 +1134,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1158,17 +1158,17 @@ func get_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker(connDetails 
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1182,17 +1182,17 @@ func get_conn_Execer_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnD
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1206,17 +1206,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetail
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1235,17 +1235,17 @@ func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext(connDetails DbCon
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1264,17 +1264,17 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext(connDetails
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1293,7 +1293,7 @@ func get_conn_Execer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDeta
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1312,17 +1312,17 @@ func get_conn_Execer_Queryer_QueryerContext(connDetails DbConnDetails, conn driv
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1336,12 +1336,12 @@ func get_conn_Execer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1360,12 +1360,12 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConn
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1384,12 +1384,12 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1408,12 +1408,12 @@ func get_conn_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetail
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1432,12 +1432,12 @@ func get_conn_Execer_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn 
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1456,17 +1456,17 @@ func get_conn_Execer_ExecerContext_QueryerContext(connDetails DbConnDetails, con
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1480,7 +1480,7 @@ func get_conn_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails Db
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1499,17 +1499,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, co
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1523,7 +1523,7 @@ func get_conn_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDet
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1542,7 +1542,7 @@ func get_conn_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbC
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1561,12 +1561,12 @@ func get_conn_Execer_ExecerContext_NamedValueChecker(connDetails DbConnDetails, 
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1580,17 +1580,17 @@ func get_conn_Execer_ExecerContext_Queryer(connDetails DbConnDetails, conn drive
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}}
 }
@@ -1604,12 +1604,12 @@ func get_conn_Execer_Queryer_NamedValueChecker(connDetails DbConnDetails, conn d
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1623,12 +1623,12 @@ func get_conn_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1642,12 +1642,12 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext(connDetails DbConnDetails,
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1666,12 +1666,12 @@ func get_conn_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1685,12 +1685,12 @@ func get_conn_Execer_QueryerContext_NamedValueChecker(connDetails DbConnDetails,
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1704,12 +1704,12 @@ func get_conn_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnD
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1723,7 +1723,7 @@ func get_conn_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1742,7 +1742,7 @@ func get_conn_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.C
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1756,12 +1756,12 @@ func get_conn_Execer_ExecerContext(connDetails DbConnDetails, conn driver.Conn, 
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}}
 }
@@ -1775,12 +1775,12 @@ func get_conn_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}}
 }
@@ -1794,7 +1794,7 @@ func get_conn_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn 
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1827,12 +1827,12 @@ func get_conn_Execer_QueryerContext(connDetails DbConnDetails, conn driver.Conn,
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1846,7 +1846,7 @@ func get_conn_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn dr
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1860,12 +1860,12 @@ func get_conn_ExecerContext_QueryerContext(connDetails DbConnDetails, conn drive
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1879,7 +1879,7 @@ func get_conn_Execer_NamedValueChecker(connDetails DbConnDetails, conn driver.Co
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1893,12 +1893,12 @@ func get_conn_Execer_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}}
 }
@@ -1912,7 +1912,7 @@ func get_conn_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn d
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1926,7 +1926,7 @@ func get_conn_Execer_ConnPrepareContext(connDetails DbConnDetails, conn driver.C
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1945,7 +1945,7 @@ func get_conn_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn d
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1964,12 +1964,12 @@ func get_conn_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1983,7 +1983,7 @@ func get_conn_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			connDetails:    connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1997,7 +1997,7 @@ func get_conn_Execer(connDetails DbConnDetails, conn driver.Conn, sensor TracerL
 		},
 		Execer: &wExecer{
 			Execer:      Execer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}}
 }
@@ -2025,7 +2025,7 @@ func get_conn_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor Tracer
 		},
 		Queryer: &wQueryer{
 			Queryer:     Queryer,
-			connDetails: connDetails,
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:      sensor,
 		}}
 }
@@ -2048,7 +2048,7 @@ func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor 
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails, ""),
+			sqlSpan: getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}}
 }
@@ -2059,17 +2059,16 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2078,17 +2077,16 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker(stmt driver.Stm
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -2096,13 +2094,12 @@ func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stm
 	return &w_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2111,12 +2108,12 @@ func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt
 	return &w_stmt_StmtExecContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2125,17 +2122,16 @@ func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt,
 	return &w_stmt_StmtExecContext_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		},
 		cc: ColumnConverter}
 }
@@ -2144,13 +2140,12 @@ func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, c
 	return &w_stmt_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		},
 		cc: ColumnConverter}
 }
@@ -2159,13 +2154,12 @@ func get_stmt_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string,
 	return &w_stmt_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -2173,12 +2167,12 @@ func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, co
 	return &w_stmt_StmtExecContext_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		},
 		cc: ColumnConverter}
 }
@@ -2187,12 +2181,12 @@ func get_stmt_StmtExecContext_NamedValueChecker(stmt driver.Stmt, query string, 
 	return &w_stmt_StmtExecContext_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -2200,7 +2194,7 @@ func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, 
 	return &w_stmt_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
@@ -2210,17 +2204,16 @@ func get_stmt_StmtExecContext_StmtQueryContext(stmt driver.Stmt, query string, c
 	return &w_stmt_StmtExecContext_StmtQueryContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}}
 }
 
@@ -2228,7 +2221,7 @@ func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConn
 	return &w_stmt_ColumnConverter{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		},
 		cc: ColumnConverter}
@@ -2238,12 +2231,12 @@ func get_stmt_StmtExecContext(stmt driver.Stmt, query string, connDetails DbConn
 	return &w_stmt_StmtExecContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}}
 }
 
@@ -2251,7 +2244,7 @@ func get_stmt_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbCo
 	return &w_stmt_NamedValueChecker{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -2260,13 +2253,12 @@ func get_stmt_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbCon
 	return &w_stmt_StmtQueryContext{
 		Stmt: &wStmt{
 			Stmt:        stmt,
-			sqlSpan: getSQLSpanData(connDetails, query),
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 			sensor:      sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
-			connDetails:      connDetails,
 			sensor:           sensor,
-			query:            query,
+			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		}}
 }
 
@@ -2294,7 +2286,7 @@ func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor 
 
 	return &wStmt{
 		Stmt:        stmt,
-		sqlSpan: getSQLSpanData(connDetails, query),
+		sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
 		sensor:      sensor,
 	}
 }

--- a/sql_wrappers.go
+++ b/sql_wrappers.go
@@ -700,7 +700,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_Nam
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -734,7 +734,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(con
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -763,7 +763,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValue
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -826,7 +826,7 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueC
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -855,7 +855,7 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -884,7 +884,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker(conn
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -937,7 +937,7 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConn
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -985,7 +985,7 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1033,7 +1033,7 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDet
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1086,7 +1086,7 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext(connDetails DbConnDeta
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1115,7 +1115,7 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker(connDeta
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1134,7 +1134,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1163,7 +1163,7 @@ func get_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker(connDetails 
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1187,7 +1187,7 @@ func get_conn_Execer_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnD
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1206,7 +1206,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetail
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1269,7 +1269,7 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext(connDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1360,7 +1360,7 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConn
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1384,7 +1384,7 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1461,7 +1461,7 @@ func get_conn_Execer_ExecerContext_QueryerContext(connDetails DbConnDetails, con
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1499,7 +1499,7 @@ func get_conn_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, co
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1542,7 +1542,7 @@ func get_conn_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbC
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1566,7 +1566,7 @@ func get_conn_Execer_ExecerContext_NamedValueChecker(connDetails DbConnDetails, 
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1585,7 +1585,7 @@ func get_conn_Execer_ExecerContext_Queryer(connDetails DbConnDetails, conn drive
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1623,7 +1623,7 @@ func get_conn_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1647,7 +1647,7 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext(connDetails DbConnDetails,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1704,7 +1704,7 @@ func get_conn_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnD
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1761,7 +1761,7 @@ func get_conn_Execer_ExecerContext(connDetails DbConnDetails, conn driver.Conn, 
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		}}
 }
@@ -1775,7 +1775,7 @@ func get_conn_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
@@ -1846,7 +1846,7 @@ func get_conn_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn dr
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1860,7 +1860,7 @@ func get_conn_ExecerContext_QueryerContext(connDetails DbConnDetails, conn drive
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
@@ -1945,7 +1945,7 @@ func get_conn_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn d
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -2048,7 +2048,7 @@ func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor 
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			connDetails:   connDetails,
+			sqlSpan: getSQLSpanData(connDetails, ""),
 			sensor:        sensor,
 		}}
 }

--- a/sql_wrappers.go
+++ b/sql_wrappers.go
@@ -694,23 +694,23 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_Nam
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -728,23 +728,23 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(con
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -763,17 +763,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext_NamedValue
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -791,18 +791,18 @@ func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -820,18 +820,18 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueC
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -849,19 +849,19 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -878,23 +878,23 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext_NamedValueChecker(conn
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -907,18 +907,18 @@ func get_conn_Execer_Queryer_QueryerContext_NamedValueChecker(connDetails DbConn
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -931,19 +931,19 @@ func get_conn_Execer_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConn
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -960,13 +960,13 @@ func get_conn_Queryer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDe
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -985,12 +985,12 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext_NamedValueChecker(
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1008,13 +1008,13 @@ func get_conn_Execer_QueryerContext_ConnPrepareContext_NamedValueChecker(connDet
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1033,13 +1033,13 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext_NamedValueChecker(connDet
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1056,14 +1056,14 @@ func get_conn_Execer_Queryer_ConnPrepareContext_NamedValueChecker(connDetails Db
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1080,23 +1080,23 @@ func get_conn_Execer_ExecerContext_Queryer_QueryerContext(connDetails DbConnDeta
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1109,13 +1109,13 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext_NamedValueChecker(connDeta
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1134,17 +1134,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext_NamedValueChecker(connDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1157,18 +1157,18 @@ func get_conn_Execer_ExecerContext_QueryerContext_NamedValueChecker(connDetails 
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1181,19 +1181,19 @@ func get_conn_Execer_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnD
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -1206,17 +1206,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext_ConnPrepareContext(connDetail
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1234,18 +1234,18 @@ func get_conn_Execer_Queryer_QueryerContext_ConnPrepareContext(connDetails DbCon
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1263,18 +1263,18 @@ func get_conn_Execer_ExecerContext_QueryerContext_ConnPrepareContext(connDetails
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1292,9 +1292,9 @@ func get_conn_Execer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDeta
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1311,18 +1311,18 @@ func get_conn_Execer_Queryer_QueryerContext(connDetails DbConnDetails, conn driv
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1335,13 +1335,13 @@ func get_conn_Execer_QueryerContext_ConnPrepareContext(connDetails DbConnDetails
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1360,12 +1360,12 @@ func get_conn_ExecerContext_QueryerContext_ConnPrepareContext(connDetails DbConn
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1384,13 +1384,13 @@ func get_conn_ExecerContext_Queryer_ConnPrepareContext(connDetails DbConnDetails
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1407,13 +1407,13 @@ func get_conn_Queryer_QueryerContext_ConnPrepareContext(connDetails DbConnDetail
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1431,14 +1431,14 @@ func get_conn_Execer_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn 
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1455,18 +1455,18 @@ func get_conn_Execer_ExecerContext_QueryerContext(connDetails DbConnDetails, con
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1480,7 +1480,7 @@ func get_conn_QueryerContext_ConnPrepareContext_NamedValueChecker(connDetails Db
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1499,17 +1499,17 @@ func get_conn_ExecerContext_Queryer_QueryerContext(connDetails DbConnDetails, co
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1522,9 +1522,9 @@ func get_conn_Queryer_ConnPrepareContext_NamedValueChecker(connDetails DbConnDet
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1542,7 +1542,7 @@ func get_conn_ExecerContext_ConnPrepareContext_NamedValueChecker(connDetails DbC
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1560,13 +1560,13 @@ func get_conn_Execer_ExecerContext_NamedValueChecker(connDetails DbConnDetails, 
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1579,19 +1579,19 @@ func get_conn_Execer_ExecerContext_Queryer(connDetails DbConnDetails, conn drive
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}}
 }
 
@@ -1603,14 +1603,14 @@ func get_conn_Execer_Queryer_NamedValueChecker(connDetails DbConnDetails, conn d
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -1623,13 +1623,13 @@ func get_conn_ExecerContext_Queryer_NamedValueChecker(connDetails DbConnDetails,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -1641,13 +1641,13 @@ func get_conn_Execer_ExecerContext_ConnPrepareContext(connDetails DbConnDetails,
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1665,13 +1665,13 @@ func get_conn_Queryer_QueryerContext_NamedValueChecker(connDetails DbConnDetails
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1684,13 +1684,13 @@ func get_conn_Execer_QueryerContext_NamedValueChecker(connDetails DbConnDetails,
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1704,12 +1704,12 @@ func get_conn_ExecerContext_QueryerContext_NamedValueChecker(connDetails DbConnD
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1722,9 +1722,9 @@ func get_conn_Queryer_ConnPrepareContext(connDetails DbConnDetails, conn driver.
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1741,9 +1741,9 @@ func get_conn_Queryer_NamedValueChecker(connDetails DbConnDetails, conn driver.C
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -1755,13 +1755,13 @@ func get_conn_Execer_ExecerContext(connDetails DbConnDetails, conn driver.Conn, 
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}}
 }
@@ -1775,13 +1775,13 @@ func get_conn_ExecerContext_Queryer(connDetails DbConnDetails, conn driver.Conn,
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}}
 }
 
@@ -1794,7 +1794,7 @@ func get_conn_QueryerContext_ConnPrepareContext(connDetails DbConnDetails, conn 
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1826,13 +1826,13 @@ func get_conn_Execer_QueryerContext(connDetails DbConnDetails, conn driver.Conn,
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1846,7 +1846,7 @@ func get_conn_ExecerContext_NamedValueChecker(connDetails DbConnDetails, conn dr
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1860,12 +1860,12 @@ func get_conn_ExecerContext_QueryerContext(connDetails DbConnDetails, conn drive
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1878,9 +1878,9 @@ func get_conn_Execer_NamedValueChecker(connDetails DbConnDetails, conn driver.Co
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
@@ -1892,14 +1892,14 @@ func get_conn_Execer_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}}
 }
 
@@ -1912,7 +1912,7 @@ func get_conn_QueryerContext_NamedValueChecker(connDetails DbConnDetails, conn d
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
@@ -1925,9 +1925,9 @@ func get_conn_Execer_ConnPrepareContext(connDetails DbConnDetails, conn driver.C
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
 			ConnPrepareContext: ConnPrepareContext,
@@ -1945,7 +1945,7 @@ func get_conn_ExecerContext_ConnPrepareContext(connDetails DbConnDetails, conn d
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		},
 		ConnPrepareContext: &wConnPrepareContext{
@@ -1963,13 +1963,13 @@ func get_conn_Queryer_QueryerContext(connDetails DbConnDetails, conn driver.Conn
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1983,7 +1983,7 @@ func get_conn_QueryerContext(connDetails DbConnDetails, conn driver.Conn, sensor
 		},
 		QueryerContext: &wQueryerContext{
 			QueryerContext: QueryerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:        getSQLSpanData(connDetails),
 			sensor:         sensor,
 		}}
 }
@@ -1996,9 +1996,9 @@ func get_conn_Execer(connDetails DbConnDetails, conn driver.Conn, sensor TracerL
 			sensor:      sensor,
 		},
 		Execer: &wExecer{
-			Execer:      Execer,
+			Execer:  Execer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}}
 }
 
@@ -2024,9 +2024,9 @@ func get_conn_Queryer(connDetails DbConnDetails, conn driver.Conn, sensor Tracer
 			sensor:      sensor,
 		},
 		Queryer: &wQueryer{
-			Queryer:     Queryer,
+			Queryer: Queryer,
 			sqlSpan: getSQLSpanData(connDetails),
-			sensor:      sensor,
+			sensor:  sensor,
 		}}
 }
 
@@ -2048,7 +2048,7 @@ func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor 
 		},
 		ExecerContext: &wExecerContext{
 			ExecerContext: ExecerContext,
-			sqlSpan: getSQLSpanData(connDetails),
+			sqlSpan:       getSQLSpanData(connDetails),
 			sensor:        sensor,
 		}}
 }
@@ -2058,17 +2058,17 @@ func get_conn_ExecerContext(connDetails DbConnDetails, conn driver.Conn, sensor 
 func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2076,30 +2076,30 @@ func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker_ColumnConverter
 func get_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
 func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2107,13 +2107,13 @@ func get_stmt_StmtQueryContext_NamedValueChecker_ColumnConverter(stmt driver.Stm
 func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2121,17 +2121,17 @@ func get_stmt_StmtExecContext_NamedValueChecker_ColumnConverter(stmt driver.Stmt
 func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		},
 		cc: ColumnConverter}
 }
@@ -2139,13 +2139,13 @@ func get_stmt_StmtExecContext_StmtQueryContext_ColumnConverter(stmt driver.Stmt,
 func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		},
 		cc: ColumnConverter}
 }
@@ -2153,26 +2153,26 @@ func get_stmt_StmtQueryContext_ColumnConverter(stmt driver.Stmt, query string, c
 func get_stmt_StmtQueryContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext_NamedValueChecker{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
 func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		},
 		cc: ColumnConverter}
 }
@@ -2180,22 +2180,22 @@ func get_stmt_StmtExecContext_ColumnConverter(stmt driver.Stmt, query string, co
 func get_stmt_StmtExecContext_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_NamedValueChecker{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}, NamedValueChecker: NamedValueChecker}
 }
 
 func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_NamedValueChecker_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker,
 		cc: ColumnConverter}
 }
@@ -2203,26 +2203,26 @@ func get_stmt_NamedValueChecker_ColumnConverter(stmt driver.Stmt, query string, 
 func get_stmt_StmtExecContext_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext_StmtQueryContext{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		}}
 }
 
 func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_ColumnConverter{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		},
 		cc: ColumnConverter}
 }
@@ -2230,35 +2230,35 @@ func get_stmt_ColumnConverter(stmt driver.Stmt, query string, connDetails DbConn
 func get_stmt_StmtExecContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtExecContext{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtExecContext: &wStmtExecContext{
 			StmtExecContext: StmtExecContext,
 			sensor:          sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:         getSQLSpanData(connDetails, withQuery(query)),
 		}}
 }
 
 func get_stmt_NamedValueChecker(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_NamedValueChecker{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, NamedValueChecker: NamedValueChecker}
 }
 
 func get_stmt_StmtQueryContext(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor TracerLogger, StmtExecContext driver.StmtExecContext, StmtQueryContext driver.StmtQueryContext, NamedValueChecker driver.NamedValueChecker, ColumnConverter driver.ColumnConverter) driver.Stmt {
 	return &w_stmt_StmtQueryContext{
 		Stmt: &wStmt{
-			Stmt:        stmt,
+			Stmt:    stmt,
 			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-			sensor:      sensor,
+			sensor:  sensor,
 		}, StmtQueryContext: &wStmtQueryContext{
 			StmtQueryContext: StmtQueryContext,
 			sensor:           sensor,
-			sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
+			sqlSpan:          getSQLSpanData(connDetails, withQuery(query)),
 		}}
 }
 
@@ -2285,9 +2285,9 @@ func wrapStmt(stmt driver.Stmt, query string, connDetails DbConnDetails, sensor 
 	}
 
 	return &wStmt{
-		Stmt:        stmt,
+		Stmt:    stmt,
 		sqlSpan: getSQLSpanData(connDetails, withQuery(query)),
-		sensor:      sensor,
+		sensor:  sensor,
 	}
 }
 

--- a/tags.go
+++ b/tags.go
@@ -34,6 +34,7 @@ var tagsFuncMap = map[database]DBTagsFunc{
 	mysql:       withMySQLTags,
 	redis:       withRedisTags,
 	couchbase:   withCouchbaseTags,
+	cosmos:      withCosmosTags,
 	sql_generic: withGenericSQLTags,
 }
 
@@ -98,6 +99,10 @@ var withCouchbaseTags DBTagsFunc = func(c DbConnDetails) Tags {
 	return TagsFunc(func(tags ot.Tags) {
 		tags["couchbase.hostname"] = c.RawString
 	})
+}
+
+var withCosmosTags DBTagsFunc = func(c DbConnDetails) Tags {
+	return TagsFunc(func(tags ot.Tags) {})
 }
 
 var withGenericSQLTags DBTagsFunc = func(c DbConnDetails) Tags {

--- a/tags.go
+++ b/tags.go
@@ -21,18 +21,18 @@ type Tags interface {
 	Apply(ot.Tags)
 }
 
-// TagsFunc implements Tags interface
-type TagsFunc func(ot.Tags)
+// tagsFunc implements Tags interface
+type tagsFunc func(ot.Tags)
 
-func (f TagsFunc) Apply(t ot.Tags) {
+func (f tagsFunc) Apply(t ot.Tags) {
 	f(t)
 }
 
-// DBTagsFunc is a function type that takes a DbConnDetails struct as input and returns Tags interface.
+// dbTagsFunc is a function type that takes a DbConnDetails struct as input and returns Tags interface.
 // It can be used to generate or retrieve a set of tags associated with a specific database connection.
-type DBTagsFunc func(c DbConnDetails) Tags
+type dbTagsFunc func(c *DbConnDetails) Tags
 
-var tagsFuncMap = map[database]DBTagsFunc{
+var tagsFuncMap = map[database]dbTagsFunc{
 	postgres:    withPostgresTags,
 	mysql:       withMySQLTags,
 	redis:       withRedisTags,
@@ -41,8 +41,8 @@ var tagsFuncMap = map[database]DBTagsFunc{
 	sql_generic: withGenericSQLTags,
 }
 
-var withPostgresTags DBTagsFunc = func(c DbConnDetails) Tags {
-	return TagsFunc(func(tags ot.Tags) {
+var withPostgresTags dbTagsFunc = func(c *DbConnDetails) Tags {
+	return tagsFunc(func(tags ot.Tags) {
 
 		tags["pg.user"] = c.User
 		tags["pg.host"] = c.Host
@@ -60,8 +60,8 @@ var withPostgresTags DBTagsFunc = func(c DbConnDetails) Tags {
 	})
 }
 
-var withMySQLTags DBTagsFunc = func(c DbConnDetails) Tags {
-	return TagsFunc(func(tags ot.Tags) {
+var withMySQLTags dbTagsFunc = func(c *DbConnDetails) Tags {
+	return tagsFunc(func(tags ot.Tags) {
 
 		tags["mysql.user"] = c.User
 		tags["mysql.host"] = c.Host
@@ -79,8 +79,8 @@ var withMySQLTags DBTagsFunc = func(c DbConnDetails) Tags {
 	})
 }
 
-var withRedisTags DBTagsFunc = func(c DbConnDetails) Tags {
-	return TagsFunc(func(tags ot.Tags) {
+var withRedisTags dbTagsFunc = func(c *DbConnDetails) Tags {
+	return tagsFunc(func(tags ot.Tags) {
 
 		if c.Error != nil {
 			tags["redis.error"] = c.Error.Error()
@@ -98,18 +98,18 @@ var withRedisTags DBTagsFunc = func(c DbConnDetails) Tags {
 	})
 }
 
-var withCouchbaseTags DBTagsFunc = func(c DbConnDetails) Tags {
-	return TagsFunc(func(tags ot.Tags) {
+var withCouchbaseTags dbTagsFunc = func(c *DbConnDetails) Tags {
+	return tagsFunc(func(tags ot.Tags) {
 		tags["couchbase.hostname"] = c.RawString
 	})
 }
 
-var withCosmosTags DBTagsFunc = func(c DbConnDetails) Tags {
-	return TagsFunc(func(tags ot.Tags) {})
+var withCosmosTags dbTagsFunc = func(c *DbConnDetails) Tags {
+	return tagsFunc(func(tags ot.Tags) {})
 }
 
-var withGenericSQLTags DBTagsFunc = func(c DbConnDetails) Tags {
-	return TagsFunc(func(tags ot.Tags) {
+var withGenericSQLTags dbTagsFunc = func(c *DbConnDetails) Tags {
+	return tagsFunc(func(tags ot.Tags) {
 
 		tags[string(ext.DBType)] = "sql"
 		tags[string(ext.PeerAddress)] = c.RawString

--- a/tags.go
+++ b/tags.go
@@ -27,7 +27,17 @@ func (f TagsFunc) Apply(t ot.Tags) {
 	f(t)
 }
 
-func WithPostgresTags(c *DbConnDetails) Tags {
+type DBTagsFunc func(c DbConnDetails) Tags
+
+var tagsFuncMap = map[database]DBTagsFunc{
+	postgres:    withPostgresTags,
+	mysql:       withMySQLTags,
+	redis:       withRedisTags,
+	couchbase:   withCouchbaseTags,
+	sql_generic: withGenericSQLTags,
+}
+
+var withPostgresTags DBTagsFunc = func(c DbConnDetails) Tags {
 	return TagsFunc(func(tags ot.Tags) {
 
 		tags["pg.user"] = c.User
@@ -46,7 +56,7 @@ func WithPostgresTags(c *DbConnDetails) Tags {
 	})
 }
 
-func WithMySQLTags(c *DbConnDetails) Tags {
+var withMySQLTags DBTagsFunc = func(c DbConnDetails) Tags {
 	return TagsFunc(func(tags ot.Tags) {
 
 		tags["mysql.user"] = c.User
@@ -65,7 +75,7 @@ func WithMySQLTags(c *DbConnDetails) Tags {
 	})
 }
 
-func WithRedisTags(c *DbConnDetails) Tags {
+var withRedisTags DBTagsFunc = func(c DbConnDetails) Tags {
 	return TagsFunc(func(tags ot.Tags) {
 
 		if c.Error != nil {
@@ -84,13 +94,13 @@ func WithRedisTags(c *DbConnDetails) Tags {
 	})
 }
 
-func WithCouchbaseTags(c *DbConnDetails) Tags {
+var withCouchbaseTags DBTagsFunc = func(c DbConnDetails) Tags {
 	return TagsFunc(func(tags ot.Tags) {
 		tags["couchbase.hostname"] = c.RawString
 	})
 }
 
-func WithGenericSQLTags(c *DbConnDetails) Tags {
+var withGenericSQLTags DBTagsFunc = func(c DbConnDetails) Tags {
 	return TagsFunc(func(tags ot.Tags) {
 
 		tags[string(ext.DBType)] = "sql"

--- a/tags.go
+++ b/tags.go
@@ -21,12 +21,15 @@ type Tags interface {
 	Apply(ot.Tags)
 }
 
+// TagsFunc implements Tags interface
 type TagsFunc func(ot.Tags)
 
 func (f TagsFunc) Apply(t ot.Tags) {
 	f(t)
 }
 
+// DBTagsFunc is a function type that takes a DbConnDetails struct as input and returns Tags interface.
+// It can be used to generate or retrieve a set of tags associated with a specific database connection.
 type DBTagsFunc func(c DbConnDetails) Tags
 
 var tagsFuncMap = map[database]DBTagsFunc{

--- a/tags.go
+++ b/tags.go
@@ -16,6 +16,7 @@ const (
 	syntheticCallTag   = "synthetic_call"
 )
 
+// Tags is the interface that applies new tags to ot.Tags map
 type Tags interface {
 	Apply(ot.Tags)
 }

--- a/tags.go
+++ b/tags.go
@@ -3,13 +3,113 @@
 
 package instana
 
-import ot "github.com/opentracing/opentracing-go"
+import (
+	"strings"
+
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
 
 const (
 	batchSizeTag       = "batch_size"
 	suppressTracingTag = "suppress_tracing"
 	syntheticCallTag   = "synthetic_call"
 )
+
+type Tags interface {
+	Apply(ot.Tags)
+}
+
+type TagsFunc func(ot.Tags)
+
+func (f TagsFunc) Apply(t ot.Tags) {
+	f(t)
+}
+
+func WithPostgresTags(c *DbConnDetails) Tags {
+	return TagsFunc(func(tags ot.Tags) {
+
+		tags["pg.user"] = c.User
+		tags["pg.host"] = c.Host
+
+		if c.Schema != "" {
+			tags["pg.db"] = c.Schema
+		} else {
+			tags["pg.db"] = c.RawString
+		}
+
+		if c.Port != "" {
+			tags["pg.port"] = c.Port
+		}
+
+	})
+}
+
+func WithMySQLTags(c *DbConnDetails) Tags {
+	return TagsFunc(func(tags ot.Tags) {
+
+		tags["mysql.user"] = c.User
+		tags["mysql.host"] = c.Host
+
+		if c.Schema != "" {
+			tags["mysql.db"] = c.Schema
+		} else {
+			tags["mysql.db"] = c.RawString
+		}
+
+		if c.Port != "" {
+			tags["mysql.port"] = c.Port
+		}
+
+	})
+}
+
+func WithRedisTags(c *DbConnDetails) Tags {
+	return TagsFunc(func(tags ot.Tags) {
+
+		if c.Error != nil {
+			tags["redis.error"] = c.Error.Error()
+		}
+
+		connection := c.Host + ":" + c.Port
+
+		if c.Host == "" || c.Port == "" {
+			i := strings.LastIndex(c.RawString, "@")
+			connection = c.RawString[i+1:]
+		}
+
+		tags["redis.connection"] = connection
+
+	})
+}
+
+func WithCouchbaseTags(c *DbConnDetails) Tags {
+	return TagsFunc(func(tags ot.Tags) {
+		tags["couchbase.hostname"] = c.RawString
+	})
+}
+
+func WithGenericSQLTags(c *DbConnDetails) Tags {
+	return TagsFunc(func(tags ot.Tags) {
+
+		tags[string(ext.DBType)] = "sql"
+		tags[string(ext.PeerAddress)] = c.RawString
+
+		if c.Schema != "" {
+			tags[string(ext.DBInstance)] = c.Schema
+		} else {
+			tags[string(ext.DBInstance)] = c.RawString
+		}
+
+		if c.Host != "" {
+			tags[string(ext.PeerHostname)] = c.Host
+		}
+
+		if c.Port != "" {
+			tags[string(ext.PeerPort)] = c.Port
+		}
+	})
+}
 
 // BatchSize returns an opentracing.Tag to mark the span as a batched span representing
 // similar span categories. An example of such span would be batch writes to a queue,


### PR DESCRIPTION
This PR optimizes the creation of SQL span tags by decoupling tag generation from query execution. Currently, all span tags—including connection details, which are constants—are generated during query execution. This change moves the creation of these constant tags to the connection setup phase, allowing them to be reused across multiple queries executed through the same connection instance.

Additionally, span creation is now handled by a single object, enabling easier extension and the incorporation of more data in the future. A `Tags` interface has been introduced to streamline the process of adding tags to spans, ensuring efficient tag management. This refactor also aims to improve code structure, enabling cleaner design and facilitating future expansion.

By leveraging a single object for span creation, rather than passing parameters and constructing tags for each query, the changes are expected to improve the overall performance of the application.