### PR TITLE
chore: updated golang version policy in tekton tasks

### DIFF
--- a/.tekton/ci-build/task.yaml
+++ b/.tekton/ci-build/task.yaml
@@ -102,6 +102,7 @@ spec:
   steps:
     - name: unit-test
       image: golang:$(params.imageTag)
+      imagePullPolicy: Always
       env:
         - name: GO_VERSION
           value: $(params.imageTag)
@@ -143,6 +144,7 @@ spec:
   steps:
     - name: go-fmt
       image: golang:$(params.imageTag)
+      imagePullPolicy: Always
       env:
         - name: EXCLUDE_DIRS
           value: $(params.excludeDirs)
@@ -169,6 +171,7 @@ spec:
   steps:
     - name: go-imports
       image: golang:$(params.imageTag)
+      imagePullPolicy: Always
       env:
         - name: EXCLUDE_DIRS
           value: $(params.excludeDirs)
@@ -210,6 +213,7 @@ spec:
   steps:
     - name: integration-test-common
       image: golang:$(params.imageTag)
+      imagePullPolicy: Always
       env:
         - name: GO_VERSION
           value: $(params.imageTag)
@@ -277,6 +281,7 @@ spec:
   steps:
     - name: integration-test-couchbase
       image: golang:$(params.imageTag)
+      imagePullPolicy: Always
       env:
         - name: GO_VERSION
           value: $(params.imageTag)

--- a/.tekton/tracer-reports/task.yaml
+++ b/.tekton/tracer-reports/task.yaml
@@ -47,7 +47,7 @@ spec:
       mountPath: /workspace
   steps:
     - name: run-tracer-reports-script
-      image: golang:1.22.0
+      image: golang:1.23.0
       workingDir: /workspace/
       script: |
         cd /workspace/go-sensor

--- a/.tekton/tracer-reports/task.yaml
+++ b/.tekton/tracer-reports/task.yaml
@@ -47,7 +47,8 @@ spec:
       mountPath: /workspace
   steps:
     - name: run-tracer-reports-script
-      image: golang:1.23.0
+      image: golang:1.22
+      imagePullPolicy: Always
       workingDir: /workspace/
       script: |
         cd /workspace/go-sensor


### PR DESCRIPTION
The gRPC package has been updated to Go version 1.22.7, and subsequently, the instagrpc package has also been updated to 1.22.7. Since our current currency script is running on Go version 1.22, it fails to execute with the instagrpc package, resulting in the following error:

> 2024-11-11T16:00:53.532616286Z go: go.mod requires go >= 1.22.7 (running go 1.22.0; GOTOOLCHAIN=local)

This PR updates the `imagePullPolicy` of the Go image to `always`. This change will ensure that the script consistently runs on the latest patch version of each Go release, which will always be at least the minimum version required for each package.
