### PR TITLE
chore: minor modification to the currency script to correctly update the 'Note' column when all versions are up-to-date

### DIFF
--- a/currency_report.sh
+++ b/currency_report.sh
@@ -210,6 +210,7 @@ while IFS= read -r line; do
     else
         changed_line=$(echo "$changed_line" | awk -v new_val=" 0 day/s " 'BEGIN{OFS=FS="|"} {$8=new_val} 1')
         changed_line=$(echo "$changed_line" | awk -v new_val=" Yes " 'BEGIN{OFS=FS="|"} {$9=new_val} 1')
+        changed_line=$(echo "$changed_line" | awk -v new_val=" " 'BEGIN{OFS=FS="|"} {$13=new_val} 1')
     fi
 
     # Update the markdown report file


### PR DESCRIPTION
This PR aims to fix the currency script so that the 'Note' column is correctly updated when all versions are up-to-date. 

Currently, if there is a scenario where some version is not up-to-date, the 'Note' column is filled with that information. However, even after correcting the versions, the 'Note' column does not update, resulting in outdated information being displayed. 

An example is provided below. 

<img width="467" alt="image" src="https://github.com/user-attachments/assets/61ac1129-d55f-4c8e-9113-b48fdfe8c745">

With this modification, the 'Note' column will be updated correctly in all scenarios.

