### PR TITLE
chore: removed toolchain directive from go.mod file

### DIFF
--- a/instrumentation/instagrpc/go.mod
+++ b/instrumentation/instagrpc/go.mod
@@ -2,8 +2,6 @@ module github.com/instana/go-sensor/instrumentation/instagrpc
 
 go 1.22.7
 
-toolchain go1.23.2
-
 require (
 	github.com/instana/go-sensor v1.65.0
 	github.com/opentracing/opentracing-go v1.2.0


### PR DESCRIPTION
This PR removed the `toolchain` directive from the go.mod file as part of running of `go mod tidy` on the package.