### PR TITLE
chore: fixed issue with running integration tests in the core package for SonarCloud check

### DIFF
--- a/.github/workflows/coverage_run_and_upload_sonarcloud.yml
+++ b/.github/workflows/coverage_run_and_upload_sonarcloud.yml
@@ -32,18 +32,26 @@ jobs:
             sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'mysecretpassword'"
             echo "After starting Postgres"
 
+            echo "unit tests - core package"
             go test -v -coverpkg=./... -cover -covermode atomic -coverprofile $TRACER_PATH/coverage/coverage.out ./... -json > $TRACER_PATH/coverage/coverage.json
+
+            echo "integration tests - core package"
+            INTEGRATION_TESTS_TAGS=("fargate" "gcr" "lambda" "azure" "generic_serverless" "azureContainerApps")
+            for str in ${INTEGRATION_TESTS_TAGS[@]}; do
+              go test -v -coverpkg=./... -cover -covermode atomic -coverprofile $TRACER_PATH/coverage/coverage_$(date +%s%N)_$RANDOM.out -tags="$str integration" ./... -run TestIntegration -json > $TRACER_PATH/coverage/coverage_$(date +%s%N)_$RANDOM.json
+            done
 
             DEPRECATED_PKGS=".*instaamqp$"
   
             LIB_LIST=$(find ./instrumentation -name go.mod -exec dirname {} \; | grep -E -v "$DEPRECATED_PKGS")
 
+            echo "unit tests - instrumentation packages"
             for lib in $LIB_LIST
               do echo "Generating test coverage for $lib" && cd "$lib" && go mod tidy && go test -v -coverpkg=./... -cover -covermode atomic -coverprofile $TRACER_PATH/coverage/coverage_$(date +%s%N)_$RANDOM.out ./... -json > $TRACER_PATH/coverage/coverage_$(date +%s%N)_$RANDOM.json && cd -;
             done
 
+            echo "integration tests - instrumentation packages"
             INTEGRATIONS_TESTS=("instagocb" "instapgx" "instacosmos" "instapgx/v2")
-
             for str in ${INTEGRATIONS_TESTS[@]}; do
               dir=./instrumentation/$str
               echo "Generating test coverage for $dir"

--- a/azure_agent_test.go
+++ b/azure_agent_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestAzureAgent_SendSpans(t *testing.T) {
+func TestIntegration_AzureAgent_SendSpans(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()
@@ -66,7 +66,7 @@ func TestAzureAgent_SendSpans(t *testing.T) {
 	assert.JSONEq(t, `{"hl": true, "cp": "azure", "e": "/subscriptions/testgh05-3f0d-4bf9-8f53-209408003632/resourceGroups/test-resourcegroup/providers/Microsoft.Web/sites/test-funcname"}`, string(spans[0]["f"]))
 }
 
-func TestAzureAgent_SpanDetails(t *testing.T) {
+func TestIntegration_AzureAgent_SpanDetails(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()
@@ -109,7 +109,7 @@ func TestAzureAgent_SpanDetails(t *testing.T) {
         }}`, string(spans[0]["data"]))
 }
 
-func TestAzureAgent_SendSpans_Error(t *testing.T) {
+func TestIntegration_AzureAgent_SendSpans_Error(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()

--- a/azure_container_apps_test.go
+++ b/azure_container_apps_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestAzureContainerApps_SendSpans(t *testing.T) {
+func TestIntegration_AzureContainerApps_SendSpans(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()
@@ -66,7 +66,7 @@ func TestAzureContainerApps_SendSpans(t *testing.T) {
 	assert.JSONEq(t, `{"hl": true, "cp": "azure", "e": "/subscriptions/testgh05-3f0d-4bf9-8f53-209408003632/resourceGroups/testresourcegroup/providers/Microsoft.App/containerapps/azureapp"}`, string(spans[0]["f"]))
 }
 
-func TestAzureAgent_SendSpans_Error(t *testing.T) {
+func TestIntegration_AzureAgent_SendSpans_Error(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()

--- a/fargate_agent_test.go
+++ b/fargate_agent_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestFargateAgent_SendMetrics(t *testing.T) {
+func TestIntegration_FargateAgent_SendMetrics(t *testing.T) {
 	defer agent.Reset()
 
 	require.Eventually(t, func() bool { return len(agent.Bundles) > 0 }, 2*time.Second, 500*time.Millisecond)
@@ -204,7 +204,7 @@ func TestFargateAgent_SendMetrics(t *testing.T) {
 	})
 }
 
-func TestFargateAgent_SendSpans(t *testing.T) {
+func TestIntegration_FargateAgent_SendSpans(t *testing.T) {
 	defer agent.Reset()
 
 	sensor := instana.NewSensor("testing")
@@ -246,7 +246,7 @@ func TestFargateAgent_SendSpans(t *testing.T) {
 	assert.JSONEq(t, `{"hl": true, "cp": "aws", "e": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3::nginx-curl"}`, string(spans[0]["f"]))
 }
 
-func TestFargateAgent_FlushSpans(t *testing.T) {
+func TestIntegration_FargateAgent_FlushSpans(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()

--- a/gcr_agent_test.go
+++ b/gcr_agent_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestGCRAgent_SendMetrics(t *testing.T) {
+func TestIntegration_GCRAgent_SendMetrics(t *testing.T) {
 	defer agent.Reset()
 
 	require.Eventually(t, func() bool { return len(agent.Bundles) > 0 }, 2*time.Second, 500*time.Millisecond)
@@ -135,7 +135,7 @@ func TestGCRAgent_SendMetrics(t *testing.T) {
 	})
 }
 
-func TestGCRAgent_SendSpans(t *testing.T) {
+func TestIntegration_GCRAgent_SendSpans(t *testing.T) {
 	defer agent.Reset()
 
 	sensor := instana.NewSensor("testing")
@@ -177,7 +177,7 @@ func TestGCRAgent_SendSpans(t *testing.T) {
 	assert.JSONEq(t, `{"hl": true, "cp": "gcp", "e": "id1"}`, string(spans[0]["f"]))
 }
 
-func TestGCRAgent_FlushSpans(t *testing.T) {
+func TestIntegration_GCRAgent_FlushSpans(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()

--- a/generic_serverless_agent_test.go
+++ b/generic_serverless_agent_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestLocalServerlessAgent_SendSpans(t *testing.T) {
+func TestIntegration_LocalServerlessAgent_SendSpans(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()
@@ -61,7 +61,7 @@ func TestLocalServerlessAgent_SendSpans(t *testing.T) {
 	require.Len(t, spans, 1)
 }
 
-func TestLocalServerlessAgent_SendSpans_Error(t *testing.T) {
+func TestIntegration_LocalServerlessAgent_SendSpans_Error(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()

--- a/lambda_agent_test.go
+++ b/lambda_agent_test.go
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestLambdaAgent_SendSpans(t *testing.T) {
+func TestIntegration_LambdaAgent_SendSpans(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()
@@ -85,7 +85,7 @@ func TestLambdaAgent_SendSpans(t *testing.T) {
 	assert.JSONEq(t, `{"hl": true, "cp": "aws", "e": "aws::test-lambda::$LATEST"}`, string(spans[0]["f"]))
 }
 
-func TestLambdaAgent_SendSpans_Error(t *testing.T) {
+func TestIntegration_LambdaAgent_SendSpans_Error(t *testing.T) {
 	defer agent.Reset()
 
 	tracer := instana.NewTracer()


### PR DESCRIPTION
Added a prefix to integration tests, enabling them to be executed independently using the -run flag with coverage.