### PR TITLE
test: added checks to debug the unit test failures in delayed spans

### DIFF
--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -54,10 +54,8 @@ func TestPartiallyFlushDelayedSpans(t *testing.T) {
 	// serverless agent should not be present for this test to pass.
 	// following check is added for debugging random failures in the unit tests of delayed spans
 	// TODO: remove it once the issue is resolved.
-	_, isURLPresent := os.LookupEnv("INSTANA_ENDPOINT_URL")
-	_, isKeyPresent := os.LookupEnv("INSTANA_AGENT_KEY")
-	assert.Equal(t, false, isURLPresent)
-	assert.Equal(t, false, isKeyPresent)
+	url, _ := os.LookupEnv("INSTANA_ENDPOINT_URL")
+	assert.Equal(t, "", url)
 
 	assert.Len(t, delayed.spans, maxDelayedSpans)
 
@@ -89,9 +87,7 @@ func TestFlushDelayedSpans(t *testing.T) {
 	// following check is added for debugging random failures in the unit tests of delayed spans
 	// TODO: remove it once the issue is resolved.
 	_, isURLPresent := os.LookupEnv("INSTANA_ENDPOINT_URL")
-	_, isKeyPresent := os.LookupEnv("INSTANA_AGENT_KEY")
 	assert.Equal(t, false, isURLPresent)
-	assert.Equal(t, false, isKeyPresent)
 
 	assert.Len(t, delayed.spans, maxDelayedSpans)
 
@@ -122,9 +118,7 @@ func TestParallelFlushDelayedSpans(t *testing.T) {
 	// following check is added for debugging random failures in the unit tests of delayed spans
 	// TODO: remove it once the issue is resolved.
 	_, isURLPresent := os.LookupEnv("INSTANA_ENDPOINT_URL")
-	_, isKeyPresent := os.LookupEnv("INSTANA_AGENT_KEY")
 	assert.Equal(t, false, isURLPresent)
-	assert.Equal(t, false, isKeyPresent)
 
 	assert.Len(t, delayed.spans, maxDelayedSpans)
 

--- a/delayed_spans_test.go
+++ b/delayed_spans_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -50,6 +51,14 @@ func TestPartiallyFlushDelayedSpans(t *testing.T) {
 
 	generateSomeTraffic(s, maxDelayedSpans)
 
+	// serverless agent should not be present for this test to pass.
+	// following check is added for debugging random failures in the unit tests of delayed spans
+	// TODO: remove it once the issue is resolved.
+	_, isURLPresent := os.LookupEnv("INSTANA_ENDPOINT_URL")
+	_, isKeyPresent := os.LookupEnv("INSTANA_AGENT_KEY")
+	assert.Equal(t, false, isURLPresent)
+	assert.Equal(t, false, isKeyPresent)
+
 	assert.Len(t, delayed.spans, maxDelayedSpans)
 
 	notReadyAfter := maxDelayedSpans / 10
@@ -76,6 +85,14 @@ func TestFlushDelayedSpans(t *testing.T) {
 
 	generateSomeTraffic(s, maxDelayedSpans)
 
+	// serverless agent should not be present for this test to pass.
+	// following check is added for debugging random failures in the unit tests of delayed spans
+	// TODO: remove it once the issue is resolved.
+	_, isURLPresent := os.LookupEnv("INSTANA_ENDPOINT_URL")
+	_, isKeyPresent := os.LookupEnv("INSTANA_AGENT_KEY")
+	assert.Equal(t, false, isURLPresent)
+	assert.Equal(t, false, isKeyPresent)
+
 	assert.Len(t, delayed.spans, maxDelayedSpans)
 
 	sensor.agent = alwaysReadyClient{}
@@ -100,6 +117,14 @@ func TestParallelFlushDelayedSpans(t *testing.T) {
 	defer ShutdownSensor()
 
 	generateSomeTraffic(s, maxDelayedSpans*2)
+
+	// serverless agent should not be present for this test to pass.
+	// following check is added for debugging random failures in the unit tests of delayed spans
+	// TODO: remove it once the issue is resolved.
+	_, isURLPresent := os.LookupEnv("INSTANA_ENDPOINT_URL")
+	_, isKeyPresent := os.LookupEnv("INSTANA_AGENT_KEY")
+	assert.Equal(t, false, isURLPresent)
+	assert.Equal(t, false, isKeyPresent)
 
 	assert.Len(t, delayed.spans, maxDelayedSpans)
 


### PR DESCRIPTION
The suspicion is that the unit tests might have failed due to the following environment variables.

- INSTANA_ENDPOINT_URL
- INSTANA_AGENT_KEY

The serverless agent should not be present for this test to pass. So these checks are added in the unit test to debug the failures in delayed spans.