### PR TITLE
fix: addressed an issue where connection strings for databases such as PostgreSQL were wrongly identified as Redis connections

### DIFF
--- a/instrumentation_sql.go
+++ b/instrumentation_sql.go
@@ -430,8 +430,7 @@ func parseDBConnDetailsURI(connStr string) (DbConnDetails, bool) {
 	//
 	// From the official postgresql doc - https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 	//
-	// "The URI scheme designator can be either postgresql:// or postgres://."
-	// "Each of the remaining URI parts is optional. The following examples illustrate valid URI syntax:"
+	// "The URI scheme designator can be either postgresql:// or postgres://"
 	//
 	if u.Scheme == "postgres" || u.Scheme == "postgresql" {
 		details.DatabaseName = "postgres"

--- a/instrumentation_sql_test.go
+++ b/instrumentation_sql_test.go
@@ -613,6 +613,28 @@ func TestDSNParing(t *testing.T) {
 				DatabaseName: "postgres",
 			},
 		},
+		"Postgres - URI - with password": {
+			DSN: "postgresql://postgres:mysecretpassword@localhost:5432/postgres?sslmode=disable",
+			ExpectedConfig: instana.DbConnDetails{
+				Schema:       "postgres",
+				RawString:    "postgresql://postgres@localhost:5432/postgres?sslmode=disable",
+				Host:         "localhost",
+				Port:         "5432",
+				User:         "postgres",
+				DatabaseName: "postgres",
+			},
+		},
+		"Postgres - URI - without password": {
+			DSN: "postgresql://postgres@localhost:5432/postgres?sslmode=disable",
+			ExpectedConfig: instana.DbConnDetails{
+				Schema:       "postgres",
+				RawString:    "postgresql://postgres@localhost:5432/postgres?sslmode=disable",
+				Host:         "localhost",
+				Port:         "5432",
+				User:         "postgres",
+				DatabaseName: "postgres",
+			},
+		},
 		"MySQL": {
 			DSN: "Server=db-host1, db-host2;Database=test-schema;Port=1234;Uid=user1;Pwd=p@55w0rd;",
 			ExpectedConfig: instana.DbConnDetails{


### PR DESCRIPTION
This PR addresses two issues related to the auto-detection of database names from connection strings:

**1. Incorrect Identification of PostgreSQL Connections as Redis Connections** (#997)

The issue arose because the regex used for detecting Redis connections was too generic and did not handle all edge cases. Specifically, it failed when the password was optional in certain connection strings. The regex has been updated to be more specific, with added handling for these edge cases. The new regex now correctly handles the following components of a URI:

- The URI scheme (optional)
- The username (optional)
- The optional password (if present, separated by a colon)
- The hostname
- The port number

With this modification, Redis connections are now correctly identified, and PostgreSQL URIs are no longer incorrectly flagged. Additionally, new unit tests have been added to cover these changes.

**2. Incorrect Database Name Identification for PostgreSQL URIs**

The logic previously only recognized the URI scheme `postgres` for PostgreSQL, which caused issues when the postgresql scheme was used. According to the official [PostgreSQL doc](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), both `postgres` and` postgresql` are valid URI schemes. The logic has been updated to correctly handle both schemes and identify the database name accurately in all cases.