### PR TITLE
chore: fixed tekton cron job for deleting old pipelineruns

### DIFF
--- a/.tekton/cleanup-cron-job.yaml
+++ b/.tekton/cleanup-cron-job.yaml
@@ -51,5 +51,5 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                    TO_DELETE="$(kubectl get pipelinerun -o jsonpath='{range .items[?(@.status.completionTime)]}{.status.completionTime}{" "}{.metadata.name}{"\n"}{end}' | sort | head -n -${NUM_TO_KEEP} | awk '{ print $2}')"
-                    test -n "$TO_DELETE" && kubectl delete pipelinerun ${TO_DELETE} || true
+                    TO_DELETE="$(kubectl get pipelinerun -o jsonpath='{range .items[?(@.status.completionTime)]}{.status.completionTime}{" "}{.metadata.name}{"\n"}{end}' | sort | head -n -${NUM_TO_KEEP} | awk '{ print $2}' | tr '\n' ' ')"
+                    test -n "$TO_DELETE" && eval kubectl delete pipelinerun $TO_DELETE || true


### PR DESCRIPTION
The `$TO_DELETE` variable is being expanded by the shell and passed as a single argument to the `kubectl delete` command. As a result, `kubectl` tries to delete a resource using the entire string as its name.

To ensure that the `kubectl delete` command receives each `pipelinerun` name as a separate argument, I added `eval`. This allows the command to treat each `pipelinerun` name individually, rather than as a single resource.