### PR TITLE
fix: fixed tracer config precedence to the correct order

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -121,6 +121,7 @@ func Test_agentApplyHostSettings(t *testing.T) {
 			host: "",
 			from: &fromS{},
 		},
+		logger: defaultLogger,
 	}
 
 	response := agentResponse{

--- a/fsm.go
+++ b/fsm.go
@@ -200,7 +200,10 @@ func (r *fsmS) handleRetries(e *f.Event, cb func(_ context.Context, e *f.Event),
 func (r *fsmS) applyHostAgentSettings(resp agentResponse) {
 	r.agentComm.from = newHostAgentFromS(int(resp.Pid), resp.HostID)
 
-	if resp.Secrets.Matcher != "" {
+	r.logger.Debug("agentOverrideSecrets flag value:", sensor.options.Tracer.agentOverrideSecrets)
+	r.logger.Debug("agent response received for secret config:", resp.Secrets.Matcher, resp.Secrets.List)
+
+	if isSecretsOverrideEnabled(sensor.options.Tracer) && isAgentSecretConfigValid(&resp) {
 		m, err := NamedMatcher(resp.Secrets.Matcher, resp.Secrets.List)
 		if err != nil {
 			r.logger.Warn("failed to apply secrets matcher configuration: ", err)
@@ -209,9 +212,13 @@ func (r *fsmS) applyHostAgentSettings(resp agentResponse) {
 		}
 	}
 
+	r.logger.Debug("secret Matcher used: ", sensor.options.Tracer.Secrets)
+
 	if len(sensor.options.Tracer.CollectableHTTPHeaders) == 0 {
 		sensor.options.Tracer.CollectableHTTPHeaders = resp.getExtraHTTPHeaders()
 	}
+
+	r.logger.Debug("CollectableHTTPHeaders used: ", sensor.options.Tracer.CollectableHTTPHeaders)
 }
 
 func (r *fsmS) announceSensor(_ context.Context, e *f.Event) {
@@ -327,4 +334,12 @@ func (r *fsmS) cpuSetFileContent(pid int) string {
 
 func expDelay(retryNumber int) time.Duration {
 	return time.Duration(math.Pow(2, float64(retryNumber-1))) * exponentialRetryPeriodBase
+}
+
+func isSecretsOverrideEnabled(opts TracerOptions) bool {
+	return opts.agentOverrideSecrets
+}
+
+func isAgentSecretConfigValid(resp *agentResponse) bool {
+	return resp.Secrets.Matcher != "" && len(resp.Secrets.List) != 0
 }

--- a/fsm.go
+++ b/fsm.go
@@ -204,14 +204,14 @@ func (r *fsmS) checkAndApplyHostAgentMatcher(resp agentResponse) error {
 	}
 
 	if !isAgentSecretConfigValid(&resp) {
+
 		return fmt.Errorf("invalid host agent secret matcher config: secrets-matcher: %s secrets-list: %s",
 			resp.Secrets.Matcher, resp.Secrets.List)
 	}
 
 	m, err := NamedMatcher(resp.Secrets.Matcher, resp.Secrets.List)
 	if err != nil {
-		err = fmt.Errorf("failed to apply secrets matcher configuration: ")
-		return err
+		return fmt.Errorf("failed to apply secrets matcher configuration: %s", err)
 	}
 
 	sensor.options.Tracer.Secrets = m

--- a/fsm.go
+++ b/fsm.go
@@ -204,7 +204,6 @@ func (r *fsmS) checkAndApplyHostAgentSecrets(resp agentResponse) error {
 	}
 
 	if !isAgentSecretConfigValid(&resp) {
-
 		return fmt.Errorf("invalid host agent secret matcher config: secrets-matcher: %s secrets-list: %s",
 			resp.Secrets.Matcher, resp.Secrets.List)
 	}

--- a/fsm.go
+++ b/fsm.go
@@ -197,7 +197,7 @@ func (r *fsmS) handleRetries(e *f.Event, cb func(_ context.Context, e *f.Event),
 	r.scheduleRetryWithExponentialDelay(e, cb, retryNumber)
 }
 
-func (r *fsmS) checkAndApplyHostAgentMatcher(resp agentResponse) error {
+func (r *fsmS) checkAndApplyHostAgentSecrets(resp agentResponse) error {
 	if !isTracerDefaultSecretsSet(sensor.options.Tracer) {
 		r.logger.Info("identified custom defined secrets matcher. Ignoring host agent default secrets configuration.")
 		return nil
@@ -222,7 +222,7 @@ func (r *fsmS) checkAndApplyHostAgentMatcher(resp agentResponse) error {
 func (r *fsmS) applyHostAgentSettings(resp agentResponse) {
 	r.agentComm.from = newHostAgentFromS(int(resp.Pid), resp.HostID)
 
-	if err := r.checkAndApplyHostAgentMatcher(resp); err != nil {
+	if err := r.checkAndApplyHostAgentSecrets(resp); err != nil {
 		r.logger.Error(err.Error())
 	}
 	r.logger.Debug("secret Matcher used: ", sensor.options.Tracer.Secrets)

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -350,7 +350,7 @@ func Test_fsmS_agentConnectionReestablished(t *testing.T) {
 func Test_fsmS_applyHostAgentSettings_agent_override(t *testing.T) {
 
 	opts := DefaultOptions()
-	opts.Tracer.agentOverrideSecrets = true
+	opts.Tracer.tracerDefaultSecrets = true
 	opts.Tracer.Secrets = secrets.NewContainsMatcher("test")
 
 	sensor = &sensorS{
@@ -395,7 +395,7 @@ func Test_fsmS_applyHostAgentSettings_agent_override(t *testing.T) {
 func Test_fsmS_applyHostAgentSettings_agent_NotOverride(t *testing.T) {
 
 	opts := DefaultOptions()
-	opts.Tracer.agentOverrideSecrets = false
+	opts.Tracer.tracerDefaultSecrets = false
 	opts.Tracer.Secrets = secrets.NewContainsMatcher("test")
 	opts.Tracer.CollectableHTTPHeaders = []string{"testHeader"}
 

--- a/options.go
+++ b/options.go
@@ -100,7 +100,7 @@ func (opts *Options) setDefaults() {
 	if secretsMatcher == nil {
 		// If secretMatcher is nil, it means no in-code secret matcher has been configured,
 		// and the INSTANA_SECRETS environment variable also doesn't have a valid matcher.
-		// So, we will set a default secret matcher here and mark overrideAgent as true,
+		// So, we will set a default secret matcher here and mark tracerDefaultSecrets as true,
 		// so that it can be overridden later if a matcher is received from the agent.
 		secretsMatcher = DefaultSecretsMatcher()
 		opts.Tracer.tracerDefaultSecrets = true

--- a/options.go
+++ b/options.go
@@ -54,7 +54,7 @@ type Options struct {
 // DefaultOptions returns the default set of options to configure Instana sensor.
 // The service name is set to the name of current executable, the MaxBufferedSpans
 // and ForceTransmissionStartingAt are set to instana.DefaultMaxBufferedSpans and
-// instana.DefaultForceSpanSendAt correspondigly. The AgentHost and AgentPort are
+// instana.DefaultForceSpanSendAt correspondingly. The AgentHost and AgentPort are
 // taken from the env INSTANA_AGENT_HOST and INSTANA_AGENT_PORT if set, and default
 // to localhost and 42699 otherwise.
 func DefaultOptions() *Options {
@@ -98,7 +98,12 @@ func (opts *Options) setDefaults() {
 	}
 
 	if secretsMatcher == nil {
+		// If secretMatcher is nil, it means no in-code secret matcher has been configured,
+		// and the INSTANA_SECRETS environment variable also doesn't have a valid matcher.
+		// So, we will set a default secret matcher here and mark overrideAgent as true,
+		// so that it can be overridden later if a matcher is received from the agent.
 		secretsMatcher = DefaultSecretsMatcher()
+		opts.Tracer.agentOverrideSecrets = true
 	}
 
 	opts.Tracer.Secrets = secretsMatcher

--- a/options.go
+++ b/options.go
@@ -103,7 +103,7 @@ func (opts *Options) setDefaults() {
 		// So, we will set a default secret matcher here and mark overrideAgent as true,
 		// so that it can be overridden later if a matcher is received from the agent.
 		secretsMatcher = DefaultSecretsMatcher()
-		opts.Tracer.agentOverrideSecrets = true
+		opts.Tracer.tracerDefaultSecrets = true
 	}
 
 	opts.Tracer.Secrets = secretsMatcher

--- a/options_test.go
+++ b/options_test.go
@@ -1,21 +1,125 @@
 // (c) Copyright IBM Corp. 2021
 // (c) Copyright Instana Inc. 2020
 
-package instana_test
+package instana
 
 import (
+	"os"
 	"testing"
 
-	instana "github.com/instana/go-sensor"
 	"github.com/stretchr/testify/assert"
 )
 
+type testMatcher struct{}
+
+func (t testMatcher) Match(s string) bool {
+	if s == "testing_matcher" {
+		return true
+	}
+	return false
+}
+
 func TestDefaultOptions(t *testing.T) {
-	assert.Equal(t, &instana.Options{
+	assert.Equal(t, &Options{
 		AgentHost:                   "localhost",
 		AgentPort:                   42699,
-		MaxBufferedSpans:            instana.DefaultMaxBufferedSpans,
-		ForceTransmissionStartingAt: instana.DefaultForceSpanSendAt,
-		Tracer:                      instana.DefaultTracerOptions(),
-	}, instana.DefaultOptions())
+		MaxBufferedSpans:            DefaultMaxBufferedSpans,
+		ForceTransmissionStartingAt: DefaultForceSpanSendAt,
+		Tracer:                      DefaultTracerOptions(),
+	}, DefaultOptions())
+}
+
+func TestTracerOptionsPrecedence_InCodeConfigPresent(t *testing.T) {
+	secretsRestore := restoreEnvVarFunc("INSTANA_SECRETS")
+	headerRestore := restoreEnvVarFunc("INSTANA_EXTRA_HTTP_HEADERS")
+
+	os.Unsetenv("INSTANA_SECRETS")
+	os.Unsetenv("INSTANA_EXTRA_HTTP_HEADERS")
+
+	defer secretsRestore()
+	defer headerRestore()
+
+	testOpts := &Options{
+		AgentHost:                   "localhost",
+		AgentPort:                   42699,
+		MaxBufferedSpans:            DefaultMaxBufferedSpans,
+		ForceTransmissionStartingAt: DefaultForceSpanSendAt,
+		Tracer: TracerOptions{
+			Secrets:                testMatcher{},
+			CollectableHTTPHeaders: []string{"test", "test1"},
+		},
+	}
+
+	testOpts.setDefaults()
+
+	assert.Equal(t, true, testOpts.Tracer.Secrets.Match("testing_matcher"))
+	assert.Equal(t, false, testOpts.Tracer.Secrets.Match("foo"))
+	assert.Equal(t, false, testOpts.Tracer.agentOverrideSecrets)
+
+	assert.Equal(t, []string{"test", "test1"}, testOpts.Tracer.CollectableHTTPHeaders)
+
+}
+
+func TestTracerOptionsPrecedence_InCodeConfigAbsent(t *testing.T) {
+	secretsRestore := restoreEnvVarFunc("INSTANA_SECRETS")
+	headerRestore := restoreEnvVarFunc("INSTANA_EXTRA_HTTP_HEADERS")
+
+	os.Setenv("INSTANA_SECRETS", "contains-ignore-case:key,password1,secret1")
+	os.Setenv("INSTANA_EXTRA_HTTP_HEADERS", "abc;def")
+
+	defer secretsRestore()
+	defer headerRestore()
+
+	testOpts := &Options{
+		AgentHost:                   "localhost",
+		AgentPort:                   42699,
+		MaxBufferedSpans:            DefaultMaxBufferedSpans,
+		ForceTransmissionStartingAt: DefaultForceSpanSendAt,
+		Tracer:                      TracerOptions{},
+	}
+
+	testOpts.setDefaults()
+
+	assert.Equal(t, false, testOpts.Tracer.Secrets.Match("testing_matcher"))
+	assert.Equal(t, true, testOpts.Tracer.Secrets.Match("secret1"))
+	assert.Equal(t, false, testOpts.Tracer.agentOverrideSecrets)
+
+	assert.Equal(t, []string{"abc", "def"}, testOpts.Tracer.CollectableHTTPHeaders)
+
+}
+
+func TestTracerOptionsPrecedence_InCodeConfigAndEnvAbsent(t *testing.T) {
+	secretsRestore := restoreEnvVarFunc("INSTANA_SECRETS")
+	headerRestore := restoreEnvVarFunc("INSTANA_EXTRA_HTTP_HEADERS")
+
+	os.Unsetenv("INSTANA_SECRETS")
+	os.Unsetenv("INSTANA_EXTRA_HTTP_HEADERS")
+
+	defer secretsRestore()
+	defer headerRestore()
+
+	testOpts := &Options{
+		AgentHost:                   "localhost",
+		AgentPort:                   42699,
+		MaxBufferedSpans:            DefaultMaxBufferedSpans,
+		ForceTransmissionStartingAt: DefaultForceSpanSendAt,
+		Tracer:                      TracerOptions{},
+	}
+
+	testOpts.setDefaults()
+
+	assert.Equal(t, false, testOpts.Tracer.Secrets.Match("testing_matcher"))
+	assert.Equal(t, true, testOpts.Tracer.Secrets.Match("secret"))
+	assert.Equal(t, true, testOpts.Tracer.agentOverrideSecrets)
+
+	assert.Equal(t, 0, len(testOpts.Tracer.CollectableHTTPHeaders))
+
+}
+
+func restoreEnvVarFunc(key string) func() {
+	if oldValue, ok := os.LookupEnv(key); ok {
+		return func() { os.Setenv(key, oldValue) }
+	}
+
+	return func() { os.Unsetenv(key) }
 }

--- a/options_test.go
+++ b/options_test.go
@@ -54,7 +54,7 @@ func TestTracerOptionsPrecedence_InCodeConfigPresent(t *testing.T) {
 
 	assert.Equal(t, true, testOpts.Tracer.Secrets.Match("testing_matcher"))
 	assert.Equal(t, false, testOpts.Tracer.Secrets.Match("foo"))
-	assert.Equal(t, false, testOpts.Tracer.agentOverrideSecrets)
+	assert.Equal(t, false, testOpts.Tracer.tracerDefaultSecrets)
 
 	assert.Equal(t, []string{"test", "test1"}, testOpts.Tracer.CollectableHTTPHeaders)
 
@@ -82,7 +82,7 @@ func TestTracerOptionsPrecedence_InCodeConfigAbsent(t *testing.T) {
 
 	assert.Equal(t, false, testOpts.Tracer.Secrets.Match("testing_matcher"))
 	assert.Equal(t, true, testOpts.Tracer.Secrets.Match("secret1"))
-	assert.Equal(t, false, testOpts.Tracer.agentOverrideSecrets)
+	assert.Equal(t, false, testOpts.Tracer.tracerDefaultSecrets)
 
 	assert.Equal(t, []string{"abc", "def"}, testOpts.Tracer.CollectableHTTPHeaders)
 
@@ -110,7 +110,7 @@ func TestTracerOptionsPrecedence_InCodeConfigAndEnvAbsent(t *testing.T) {
 
 	assert.Equal(t, false, testOpts.Tracer.Secrets.Match("testing_matcher"))
 	assert.Equal(t, true, testOpts.Tracer.Secrets.Match("secret"))
-	assert.Equal(t, true, testOpts.Tracer.agentOverrideSecrets)
+	assert.Equal(t, true, testOpts.Tracer.tracerDefaultSecrets)
 
 	assert.Equal(t, 0, len(testOpts.Tracer.CollectableHTTPHeaders))
 

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -22,13 +22,13 @@ type TracerOptions struct {
 	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#capture-custom-http-headers for details
 	CollectableHTTPHeaders []string
 
-	// agentOverrideSecrets flag is used to override the secret matcher configuration received from the agent.
+	// tracerDefaultSecrets flag is used to override the secret matcher configuration received from the agent.
 	// This flag will be set during the init collector process, and the following logic will apply:
 	//
 	// - If the INSTANA_SECRETS environment variable is set, it will be given the highest priority.
 	// - If not, the "Secrets" configured within the code will be preferred.
 	// - If neither of the above is available, the configuration received from the agent will be used.
-	agentOverrideSecrets bool
+	tracerDefaultSecrets bool
 }
 
 // DefaultTracerOptions returns the default set of options to configure a tracer

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -22,12 +22,17 @@ type TracerOptions struct {
 	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#capture-custom-http-headers for details
 	CollectableHTTPHeaders []string
 
-	// tracerDefaultSecrets flag is used to override the secret matcher configuration received from the agent.
-	// This flag will be set during the init collector process, and the following logic will apply:
+	// tracerDefaultSecrets flag is used to identify whether tracerOptions.Secrets
+	// contains the default secret matcher configured by the Instana SDK.
+	//
+	// This flag will be set during the collector initialization process, and the following logic will be followed:
 	//
 	// - If the INSTANA_SECRETS environment variable is set, it will be given the highest priority.
 	// - If not, the "Secrets" configured within the code will be preferred.
-	// - If neither of the above is available, the configuration received from the agent will be used.
+	// - If neither of the above is available, a default configuration will be applied to the Secrets,
+	//   and this flag will be set to true.
+	//
+	// Later, this flag will also be used to override the secret matcher configuration received from the agent during the handshake.
 	tracerDefaultSecrets bool
 }
 

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -21,6 +21,14 @@ type TracerOptions struct {
 	//
 	// See https://www.instana.com/docs/setup_and_manage/host_agent/configuration/#capture-custom-http-headers for details
 	CollectableHTTPHeaders []string
+
+	// agentOverrideSecrets flag is used to override the secret matcher configuration received from the agent.
+	// This flag will be set during the init collector process, and the following logic will apply:
+	//
+	// - If the INSTANA_SECRETS environment variable is set, it will be given the highest priority.
+	// - If not, the "Secrets" configured within the code will be preferred.
+	// - If neither of the above is available, the configuration received from the agent will be used.
+	agentOverrideSecrets bool
 }
 
 // DefaultTracerOptions returns the default set of options to configure a tracer


### PR DESCRIPTION
Environment variables will have the highest priority. If they are not set, the values configured in the code will be used. If those are also not present, the configuration received from the agent will be applied. And if none of these are available, default values will be used.