### PR TITLE
fix: updated the default secret matcher to use 'pass' instead of 'password' to align with the tracer specification and other services

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -67,8 +67,8 @@ func NamedMatcher(name string, list []string) (Matcher, error) {
 }
 
 // DefaultSecretsMatcher returns the default secrets matcher, that matches strings containing
-// "key", "password" and "secret" ignoring the case
+// "key", "pass" and "secret" ignoring the case
 func DefaultSecretsMatcher() Matcher {
-	m, _ := NamedMatcher(ContainsIgnoreCaseMatcher, []string{"key", "password", "secret"})
+	m, _ := NamedMatcher(ContainsIgnoreCaseMatcher, []string{"key", "pass", "secret"})
 	return m
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -106,6 +106,14 @@ func TestDefaultSecretsMatcher(t *testing.T) {
 	assert.False(t, m.Match("pas123s"))
 	assert.False(t, m.Match("sec123ret"))
 
+	// Test to ensure previous default matchers still work
+	//
+	// These test cases are added to confirm compatibility
+	// with the change where the default matcher now uses "pass" instead of "password"
+	//
+	// This change is non-breaking for existing users who are already using 'password'
+	// in their code, since the default secret matcher uses a 'contains-ignore-case' rule.
+	// So, any string that matches 'password' will still get matched by 'pass'.
 	assert.True(t, m.Match("password"))
 	assert.True(t, m.Match("PASSWORD"))
 	assert.True(t, m.Match("123password123"))

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -76,7 +76,7 @@ func TestNamedMatcher_Unsupported(t *testing.T) {
 func TestDefaultSecretsMatcher(t *testing.T) {
 	m := instana.DefaultSecretsMatcher()
 
-	// test default matcher - match
+	// Test default matcher - match
 	assert.True(t, m.Match("key"))
 	assert.True(t, m.Match("pass"))
 	assert.True(t, m.Match("secret"))
@@ -97,7 +97,7 @@ func TestDefaultSecretsMatcher(t *testing.T) {
 	assert.True(t, m.Match("123pass123"))
 	assert.True(t, m.Match("123secret123"))
 
-	// test default matcher - no match
+	// Test default matcher - no match
 	assert.False(t, m.Match("ke"))
 	assert.False(t, m.Match("pas"))
 	assert.False(t, m.Match("secre"))
@@ -105,5 +105,11 @@ func TestDefaultSecretsMatcher(t *testing.T) {
 	assert.False(t, m.Match("ke123y"))
 	assert.False(t, m.Match("pas123s"))
 	assert.False(t, m.Match("sec123ret"))
+
+	assert.True(t, m.Match("password"))
+	assert.True(t, m.Match("PASSWORD"))
+	assert.True(t, m.Match("123password123"))
+	assert.True(t, m.Match("pass123word"))
+	assert.False(t, m.Match("pas123sword"))
 
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -72,3 +72,29 @@ func TestNamedMatcher_Unsupported(t *testing.T) {
 	_, err := instana.NamedMatcher("custom", []string{"foo", "bar"})
 	assert.Error(t, err)
 }
+
+func TestDefaultSecretsMatcher(t *testing.T) {
+	m := instana.DefaultSecretsMatcher()
+
+	// test default matcher - match
+	assert.True(t, m.Match("key"))
+	assert.True(t, m.Match("pass"))
+	assert.True(t, m.Match("secret"))
+
+	assert.True(t, m.Match("KEY"))
+	assert.True(t, m.Match("PASS"))
+	assert.True(t, m.Match("SECRET"))
+
+	assert.True(t, m.Match("key123"))
+	assert.True(t, m.Match("pass123"))
+	assert.True(t, m.Match("secret123"))
+
+	assert.True(t, m.Match("123key"))
+	assert.True(t, m.Match("123pass"))
+	assert.True(t, m.Match("123secret"))
+
+	assert.True(t, m.Match("123key123"))
+	assert.True(t, m.Match("123pass123"))
+	assert.True(t, m.Match("123secret123"))
+
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -97,4 +97,13 @@ func TestDefaultSecretsMatcher(t *testing.T) {
 	assert.True(t, m.Match("123pass123"))
 	assert.True(t, m.Match("123secret123"))
 
+	// test default matcher - no match
+	assert.False(t, m.Match("ke"))
+	assert.False(t, m.Match("pas"))
+	assert.False(t, m.Match("secre"))
+
+	assert.False(t, m.Match("ke123y"))
+	assert.False(t, m.Match("pas123s"))
+	assert.False(t, m.Match("sec123ret"))
+
 }


### PR DESCRIPTION
This is a non-breaking change for existing users using the default secret matcher, as 'contains-ignore-case, pass' will continue to match all strings that were previously matched by 'contains-ignore-case, password'.