### PR TITLE
refactor: optimised trace header extraction by adding an early exit when both headers are found

### DIFF
--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -52,18 +52,8 @@ func (c Context) IsZero() bool {
 func Extract(headers http.Header) (Context, error) {
 	var tr Context
 
-	for k, v := range headers {
-		if len(v) == 0 {
-			continue
-		}
-
-		switch {
-		case strings.EqualFold(k, TraceParentHeader):
-			tr.RawParent = v[0]
-		case strings.EqualFold(k, TraceStateHeader):
-			tr.RawState = v[0]
-		}
-	}
+	tr.RawParent = headers.Get(TraceParentHeader)
+	tr.RawState = headers.Get(TraceStateHeader)
 
 	if tr.RawParent == "" {
 		return tr, ErrContextNotFound

--- a/w3ctrace/context.go
+++ b/w3ctrace/context.go
@@ -52,8 +52,22 @@ func (c Context) IsZero() bool {
 func Extract(headers http.Header) (Context, error) {
 	var tr Context
 
-	tr.RawParent = headers.Get(TraceParentHeader)
-	tr.RawState = headers.Get(TraceStateHeader)
+	for k, v := range headers {
+		if len(v) == 0 {
+			continue
+		}
+
+		switch {
+		case strings.EqualFold(k, TraceParentHeader):
+			tr.RawParent = v[0]
+		case strings.EqualFold(k, TraceStateHeader):
+			tr.RawState = v[0]
+		}
+		// early exit if both found
+		if tr.RawParent != "" && tr.RawState != "" {
+			break
+		}
+	}
 
 	if tr.RawParent == "" {
 		return tr, ErrContextNotFound

--- a/w3ctrace/context_test.go
+++ b/w3ctrace/context_test.go
@@ -5,7 +5,6 @@ package w3ctrace_test
 
 import (
 	"net/http"
-	"net/textproto"
 	"testing"
 
 	"github.com/instana/go-sensor/w3ctrace"
@@ -42,8 +41,8 @@ func TestExtract(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			headers := http.Header{}
 			// set raw headers to preserve header name case
-			headers[textproto.CanonicalMIMEHeaderKey(example.ParentHeader)] = []string{exampleTraceParent}
-			headers[textproto.CanonicalMIMEHeaderKey(example.StateHeader)] = []string{exampleTraceState}
+			headers[example.ParentHeader] = []string{exampleTraceParent}
+			headers[example.StateHeader] = []string{exampleTraceState}
 
 			tr, err := w3ctrace.Extract(headers)
 			require.NoError(t, err)

--- a/w3ctrace/context_test.go
+++ b/w3ctrace/context_test.go
@@ -5,6 +5,7 @@ package w3ctrace_test
 
 import (
 	"net/http"
+	"net/textproto"
 	"testing"
 
 	"github.com/instana/go-sensor/w3ctrace"
@@ -41,8 +42,8 @@ func TestExtract(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			headers := http.Header{}
 			// set raw headers to preserve header name case
-			headers[example.ParentHeader] = []string{exampleTraceParent}
-			headers[example.StateHeader] = []string{exampleTraceState}
+			headers[textproto.CanonicalMIMEHeaderKey(example.ParentHeader)] = []string{exampleTraceParent}
+			headers[textproto.CanonicalMIMEHeaderKey(example.StateHeader)] = []string{exampleTraceState}
 
 			tr, err := w3ctrace.Extract(headers)
 			require.NoError(t, err)


### PR DESCRIPTION
refactor: optimised trace header extraction by adding an early exit when both headers are found