### PR TITLE
feat: cleanup pipeline runs for currency monitoring

### DIFF
--- a/.tekton/currency-monitoring/cleanup-pipelinerun.yaml
+++ b/.tekton/currency-monitoring/cleanup-pipelinerun.yaml
@@ -1,0 +1,59 @@
+# (c) Copyright IBM Corp. 2025
+# Ref : https://github.com/tektoncd/experimental/issues/479
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cleanup
+  namespace: currency-monitoring-pipelines
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cleanup
+  namespace: currency-monitoring-pipelines
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns"]
+    verbs: ["delete", "get", "watch", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cleanup-to-cleanup
+  namespace: currency-monitoring-pipelines
+roleRef:
+  kind: Role
+  name: cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: cleanup
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tekton-pipelinerun-cleanup
+  namespace: currency-monitoring-pipelines
+spec:
+  schedule: "0 4 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccount: cleanup
+          containers:
+            - name: kubectl
+              image: ghcr.io/ctron/kubectl:latest
+              env:
+                - name: NUM_TO_KEEP
+                  value: "2"
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  TO_DELETE="$(kubectl get pipelinerun -n currency-monitoring-pipelines -o jsonpath='{range .items[?(@.status.completionTime)]}{.status.completionTime}{" "}{.metadata.name}{"\n"}{end}' | sort | head -n -${NUM_TO_KEEP} | awk '{ print $2}' | tr '\n' ' ')"
+                  test -n "$TO_DELETE" && eval kubectl delete pipelinerun $TO_DELETE || true


### PR DESCRIPTION
This PR adds a CronJob to clean up PipelineRuns created for currency monitoring. It will retain the latest 2 artifacts. The implementation is based on the existing CronJob used for cleaning CI build artifacts.