### PR TITLE
ci: update timing to keep the pipelineruns number limited

### DIFF
--- a/.tekton/currency-monitoring/cleanup-pipelinerun.yaml
+++ b/.tekton/currency-monitoring/cleanup-pipelinerun.yaml
@@ -37,7 +37,7 @@ metadata:
   name: tekton-pipelinerun-cleanup
   namespace: currency-monitoring-pipelines
 spec:
-  schedule: "0 4 * * *"
+  schedule: "0 7 * * 1-5"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
This PR updates the timing to cleanup the pipelinerun artifacts on a daily basis. Currently the  pipelinerun cronjob executes after the cleanup job and it creates ambiguity towards the number of pipelinerun artifacts retained.