### PR TITLE
chore: bump Go version to 1.24 for tracer reports

### DIFF
--- a/.tekton/tracer-reports/task.yaml
+++ b/.tekton/tracer-reports/task.yaml
@@ -51,7 +51,7 @@ spec:
       mountPath: /workspace
   steps:
     - name: run-tracer-reports-script
-      image: public.ecr.aws/docker/library/golang:1.23
+      image: public.ecr.aws/docker/library/golang:1.24
       imagePullPolicy: Always
       workingDir: /workspace/
       script: |


### PR DESCRIPTION
The minimum Go version for Google Pub/Sub and Storage has been updated from 1.23 to 1.24. Updated tracer reports script to use Go 1.24 as well.