### PR TITLE
fix(docker): skip unsupported blkio op types in ECS task stats

### DIFF
--- a/aws/ecs_metadata_test.go
+++ b/aws/ecs_metadata_test.go
@@ -247,6 +247,7 @@ func TestECSMetadataProvider_TaskStats(t *testing.T) {
 				{Operation: docker.BlockIOReadOp, Value: 1},
 				{Operation: docker.BlockIOWriteOp, Value: 2},
 				{Operation: docker.BlockIOReadOp, Value: 3},
+				{Operation: 0, Value: 4}, // "Sync" and other unknown ops are ignored during aggregation
 			},
 		},
 	}, stats)

--- a/aws/testdata/task_stats.json
+++ b/aws/testdata/task_stats.json
@@ -17,6 +17,10 @@
         {
           "value": 3,
           "op": "READ"
+        },
+        {
+          "value": 4,
+          "op": "Sync"
         }
       ],
       "io_serviced_recursive": [],

--- a/docker/container_stats.go
+++ b/docker/container_stats.go
@@ -4,7 +4,6 @@
 package docker
 
 import (
-	"fmt"
 	"strings"
 	"time"
 )
@@ -54,7 +53,7 @@ func (biop *blockIOOp) UnmarshalJSON(data []byte) error {
 	case `"write"`:
 		*biop = BlockIOWriteOp
 	default:
-		return fmt.Errorf("unexpected block i/o op %s", string(data))
+		// Only Read and Write are used for metrics; skip everything else.
 	}
 
 	return nil


### PR DESCRIPTION
AWS Fargate platform v1.4+ uses the ECS task metadata v4 endpoint and the containerd runtime. In some Fargate task stats responses, blkio_service_bytes_recursive may include operation types other than Read and Write, for example Sync.

The previous implementation returned an error for any blkio op type other than Read or Write, causing logs like:

```
  instana: WARN: failed to retrieve Docker container stats: malformed task stats response: unexpected block i/o op "Sync"
```
to be emitted repeatedly on affected Fargate tasks.

Only Read and Write are used for blk_read/blk_write metrics, so unsupported blkio op types are now skipped instead of failing the entire stats collection.

Fixes #1539